### PR TITLE
Publish 1.2.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,11 @@
 *.dll
 *.so
 *.dylib
+*.fol
+*.yaml.normalized
+*.yaml.rego
+*.raml.normalized
+report.rego
 
 # Test binary, built with `go test -c`
 *.test

--- a/go.mod
+++ b/go.mod
@@ -13,15 +13,12 @@ require (
 	github.com/klauspost/compress v1.15.6 // indirect
 	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 // indirect
-	github.com/open-policy-agent/opa v0.41.0
+	github.com/open-policy-agent/opa v0.44.0
 	github.com/peterh/liner v1.2.2 // indirect
 	github.com/piprate/json-gold v0.4.0
-	github.com/prometheus/client_golang v1.12.2 // indirect
-	github.com/prometheus/common v0.34.0 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
 	github.com/vektah/gqlparser/v2 v2.4.5 // indirect
 	golang.org/x/net v0.0.0-20220615171555-694bf12d69de // indirect
-	golang.org/x/sys v0.0.0-20220615213510-4f61da869c0c // indirect
 	golang.org/x/time v0.0.0-20220609170525-579cf78fd858 // indirect
 	google.golang.org/genproto v0.0.0-20220616135557-88e70c0c3a90 // indirect
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -88,6 +88,7 @@ github.com/Microsoft/hcsshim v0.8.21/go.mod h1:+w2gRZ5ReXQhFOrvSQeNfhrYB/dg3oDwT
 github.com/Microsoft/hcsshim v0.8.23/go.mod h1:4zegtUJth7lAvFyc6cH2gGQ5B3OFQim01nnU2M8jKDg=
 github.com/Microsoft/hcsshim v0.9.2/go.mod h1:7pLA8lDk46WKDWlVsENo92gC0XFa8rbKfyFRBqxEbCc=
 github.com/Microsoft/hcsshim v0.9.3/go.mod h1:7pLA8lDk46WKDWlVsENo92gC0XFa8rbKfyFRBqxEbCc=
+github.com/Microsoft/hcsshim v0.9.4/go.mod h1:7pLA8lDk46WKDWlVsENo92gC0XFa8rbKfyFRBqxEbCc=
 github.com/Microsoft/hcsshim/test v0.0.0-20201218223536-d3e5debf77da/go.mod h1:5hlzMzRKMLyo42nCZ9oml8AdTlq/0cvIaBv6tK1RehU=
 github.com/Microsoft/hcsshim/test v0.0.0-20210227013316-43a75bb4edd3/go.mod h1:mw7qgWloBUl75W/gVH3cQszUg1+gUITj7D6NY7ywVnY=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
@@ -244,6 +245,7 @@ github.com/containerd/containerd v1.6.4 h1:SEDZBp10mhCp+hkO3Njz/YhGrI7ah3edNcUlR
 github.com/containerd/containerd v1.6.4/go.mod h1:oWOqbuJUZmOVafhA0lj2NAXbiO1u7F0K5l1bUgdyo94=
 github.com/containerd/containerd v1.6.6 h1:xJNPhbrmz8xAMDNoVjHy9YHtWwEQNS+CDkcIRh7t8Y0=
 github.com/containerd/containerd v1.6.6/go.mod h1:ZoP1geJldzCVY3Tonoz7b1IXk8rIX0Nltt5QE4OMNk0=
+github.com/containerd/containerd v1.6.8/go.mod h1:By6p5KqPK0/7/CgO/A6t/Gz+CUYUu2zf1hUaaymVXB0=
 github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/containerd/continuity v0.0.0-20190815185530-f2a389ac0a02/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/containerd/continuity v0.0.0-20191127005431-f65d91d395eb/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
@@ -331,6 +333,7 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -443,6 +446,7 @@ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2
 github.com/go-ini/ini v1.25.4/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
 github.com/go-ini/ini v1.66.6 h1:h6k2Bb0HWS/BXXHCXj4QHjxPmlIU4NK+7MuLp9SD+4k=
 github.com/go-ini/ini v1.66.6/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
+github.com/go-ini/ini v1.67.0/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.10.0/go.mod h1:xUsJbQ/Fp4kEt7AFgCuvyX4a71u8h9jB8tj/ORgOZ7o=
@@ -830,6 +834,8 @@ github.com/open-policy-agent/opa v0.28.0 h1:y4e4oNVqCKXyz2nIhVNLVwZUa4+T/N8Spch7
 github.com/open-policy-agent/opa v0.28.0/go.mod h1:jYuhmtyoJI9HSLgVWEqUwfKecsLi/8wk0Uv76misZDU=
 github.com/open-policy-agent/opa v0.41.0 h1:XDTkP8bcUVuY8WOVbRY4e/KZW31+f+/cxisPc0TPe5E=
 github.com/open-policy-agent/opa v0.41.0/go.mod h1:+kB8/8/4meTlq6ZmYRnvrL5nNrykd2eckDx4O6rk/dA=
+github.com/open-policy-agent/opa v0.44.0 h1:sEZthsrWBqIN+ShTMJ0Hcz6a3GkYsY4FaB2S/ou2hZk=
+github.com/open-policy-agent/opa v0.44.0/go.mod h1:YpJaFIk5pq89n/k72c1lVvfvR5uopdJft2tMg1CW/yU=
 github.com/opencontainers/go-digest v0.0.0-20170106003457-a6d0ee40d420/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
@@ -917,6 +923,7 @@ github.com/prometheus/client_golang v1.12.1 h1:ZiaPsmm9uiBeaSMRznKsCDNtPCS0T3JVD
 github.com/prometheus/client_golang v1.12.1/go.mod h1:3Z9XVyYiZYEO+YQWt3RD2R3jrbd179Rt297l4aS6nDY=
 github.com/prometheus/client_golang v1.12.2 h1:51L9cDoUHVrXx4zWYlcLQIZ+d+VXHgqnYKkIuq4g/34=
 github.com/prometheus/client_golang v1.12.2/go.mod h1:3Z9XVyYiZYEO+YQWt3RD2R3jrbd179Rt297l4aS6nDY=
+github.com/prometheus/client_golang v1.13.0/go.mod h1:vTeo+zgvILHsnnj/39Ou/1fPN5nJFOEMgftOUOmlvYQ=
 github.com/prometheus/client_model v0.0.0-20171117100541-99fa1f4be8e5/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
@@ -940,6 +947,7 @@ github.com/prometheus/common v0.32.1 h1:hWIdL3N2HoUx3B8j3YN9mWor0qhY/NlEKZEaXxuI
 github.com/prometheus/common v0.32.1/go.mod h1:vu+V0TpY+O6vW9J44gczi3Ap/oXXR10b+M/gUGO4Hls=
 github.com/prometheus/common v0.34.0 h1:RBmGO9d/FVjqHT0yUGQwBJhkwKV+wPCn7KGpvfab0uE=
 github.com/prometheus/common v0.34.0/go.mod h1:gB3sOl7P0TvJabZpLY5uQMpUqRCPPCyRLCZYc7JZTNE=
+github.com/prometheus/common v0.37.0/go.mod h1:phzohg0JFMnBEFGxTDbfu3QyL5GI8gTQJFhYO5B3mfA=
 github.com/prometheus/procfs v0.0.0-20180125133057-cb4147076ac7/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
@@ -954,6 +962,7 @@ github.com/prometheus/procfs v0.2.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.7.3 h1:4jVXhlkAyzOScmCkXBTOLRLTz8EeU+eyjrwB/EPq0VU=
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
+github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0 h1:MkV+77GLUNo5oJ0jf870itWm3D0Sjh7+Za9gazKc5LQ=
@@ -989,6 +998,7 @@ github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrf
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
@@ -1010,6 +1020,7 @@ github.com/spf13/cobra v1.1.3/go.mod h1:pGADOWyqRD/YMrPZigI/zbliZ2wVD/23d+is3pSW
 github.com/spf13/cobra v1.2.1/go.mod h1:ExllRjgxM/piMAM+3tAZvg8fsklGAf3tPfi+i8t68Nk=
 github.com/spf13/cobra v1.4.0 h1:y+wJpx64xcgO1V+RcnwW0LEHxTKRi2ZDPSBjWnrg88Q=
 github.com/spf13/cobra v1.4.0/go.mod h1:Wo4iy3BUC+X2Fybo0PDqwJIv3dNRiZLHQymsfxlB84g=
+github.com/spf13/cobra v1.5.0/go.mod h1:dWXEIy2H428czQCjInthrTRUg7yKbok+2Qi/yBIJoUM=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
@@ -1031,6 +1042,7 @@ github.com/stretchr/objx v0.0.0-20180129172003-8a3f7159479f/go.mod h1:HFkY916IF+
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/testify v0.0.0-20180303142811-b89eecf5ca5d/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
@@ -1041,11 +1053,15 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
+github.com/tchap/go-patricia v2.2.6+incompatible h1:JvoDL7JSoIP2HDE8AbDH3zC8QBPxmzYe32HHy5yQ+Ck=
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
+github.com/tchap/go-patricia/v2 v2.3.1 h1:6rQp39lgIYZ+MHmdEq4xzuk1t7OdC35z/xm0BGhTkes=
+github.com/tchap/go-patricia/v2 v2.3.1/go.mod h1:VZRHKAb53DLaG+nA9EaYYiaEx6YztwDlLElMsnSHD4k=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
@@ -1438,6 +1454,7 @@ golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220615213510-4f61da869c0c h1:aFV+BgZ4svzjfabn8ERpuB4JI4N6/rdy1iusx77G3oU=
 golang.org/x/sys v0.0.0-20220615213510-4f61da869c0c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
@@ -1665,6 +1682,7 @@ google.golang.org/grpc v1.46.0/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACu
 google.golang.org/grpc v1.46.2/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
 google.golang.org/grpc v1.47.0 h1:9n77onPX5F3qfFCqjy9dhn8PbNQsIKeVU04J9G7umt8=
 google.golang.org/grpc v1.47.0/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
+google.golang.org/grpc v1.49.0/go.mod h1:ZgQEeidpAuNRZ8iRrlBKXZQP1ghovWIVhdJRyCDK+GI=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=
@@ -1680,6 +1698,7 @@ google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQ
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=
 google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,5 +2,5 @@ package config
 
 const (
 	Override = true
-	Debug    = true
+	Debug    = false
 )

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,6 @@
 package config
 
 const (
-	Override = true
+	Override = false
 	Debug    = false
 )

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,6 @@
 package config
 
-const(
-	Override = false
-	Debug = false
+const (
+	Override = true
+	Debug    = true
 )

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,6 @@
 package config
 
-const(
+const (
 	Override = false
-	Debug = false
+	Debug    = false
 )

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -144,6 +144,19 @@ search_subjects[valid_subject] {
   valid_subject = node
 }
 
+search_custom_property_subjects[valid_subject] {
+  extension = data.property_extension
+  object = data.object
+  
+  object["http://a.ml/vocabularies/core#extensionName"] = extension
+  object_id = object["@id"]
+  
+  node = input["@ids"][_]
+  
+  node[prop] = {"@id": object_id}
+  valid_subject = node
+}
+
 # collection functions
 
 # collect next set of nodes
@@ -236,6 +249,27 @@ as_string(x) = x["@id"] {
 as_string(x) = json.marshal(x) {
   is_object(x)
   not x["@id"]
+}
+
+# Finds a nested custom domain property for a given node an custom domain property name
+gen_path_extension[nodes] {
+  sourceNode := data.custom_property_data[0]
+  extensionName := data.custom_property_data[1]
+  customPropertiesTarget := object.get(sourceNode, "http://a.ml/vocabularies/document#customDomainProperties", [])
+  customProperties = nodes_array with data.nodes as customPropertiesTarget
+  extensionFound = [found |
+    annotationLink = customProperties[_]
+    annotationLinkId = annotationLink["@id"]
+    annotation = object.get(sourceNode, annotationLinkId, {})
+    annotationNode = find with data.link as annotation
+  
+    name = annotationNode["http://a.ml/vocabularies/core#extensionName"]
+    name = extensionName
+  
+    found = annotationNode
+  ]
+  
+  nodes = extensionFound
 }
 
 #creates an array from a comma separated values str

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -238,6 +238,27 @@ as_string(x) = json.marshal(x) {
   not x["@id"]
 }
 
+# Finds a nested custom domain property for a given node an custom domain property name
+gen_path_extension[nodes] {
+  sourceNode := data.custom_property_data[0]
+  extensionName := data.custom_property_data[1]
+  customPropertiesTarget := object.get(sourceNode, "http://a.ml/vocabularies/document#customDomainProperties", [])
+  customProperties = nodes_array with data.nodes as customPropertiesTarget
+  extensionFound = [found |
+    annotationLink = customProperties[_]
+    annotationLinkId = annotationLink["@id"]
+    annotation = object.get(sourceNode, annotationLinkId, {})
+    annotationNode = find with data.link as annotation
+  
+    name = annotationNode["http://a.ml/vocabularies/core#extensionName"]
+    name = extensionName
+  
+    found = annotationNode
+  ]
+  
+  nodes = extensionFound
+}
+
 #creates an array from a comma separated values str
 split_values[values] {
    values := split(data.nodes, ",")

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -144,6 +144,19 @@ search_subjects[valid_subject] {
   valid_subject = node
 }
 
+search_custom_property_subjects[valid_subject] {
+  extension = data.property_extension
+  object = data.object
+  
+  object["http://a.ml/vocabularies/core#extensionName"] = extension
+  object_id = object["@id"]
+  
+  node = input["@ids"][_]
+  
+  node[prop] = {"@id": object_id}
+  valid_subject = node
+}
+
 # collection functions
 
 # collect next set of nodes

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -23,6 +23,7 @@ func TestGenerated(t *testing.T) {
 		generated := Generate(*prof)
 		success, err := validateRegoUnit(generated)
 		if !success {
+			println(generated.Code)
 			t.Error(err)
 		}
 		if config.Override {

--- a/internal/generator/path.go
+++ b/internal/generator/path.go
@@ -199,9 +199,19 @@ func traverseAnd(and path.AndPath, t traversal, fetchNodes bool, iriExpander *mi
 	}
 }
 
+func traverseProperty(property path.Property, t traversal, fetchNodes bool, iriExpander *misc.IriExpander) []regoPathResultInternal {
+	if property.IsCustom(iriExpander) {
+		return traverseCustomProperty(property, t, fetchNodes, iriExpander)
+	} else {
+		return traverseRegularProperty(property, t, fetchNodes, iriExpander)
+	}
+}
+
 // Traverses the leaf components of the path expression, always a property.
 // TODO: We don't take into transitive paths yet.
-func traverseProperty(property path.Property, t traversal, fetchNodes bool, iriExpander *misc.IriExpander) []regoPathResultInternal {
+func traverseRegularProperty(property path.Property, t traversal, fetchNodes bool, iriExpander *misc.IriExpander) []regoPathResultInternal {
+
+	propertyIri, err := property.Expanded(iriExpander)
 
 	// We use IDX go generate a unique property for the Rego computation
 	idx := fmt.Sprintf("%d", len(t.pathVariables))
@@ -217,7 +227,7 @@ func traverseProperty(property path.Property, t traversal, fetchNodes bool, iriE
 		t.pathVariables = append(t.pathVariables, fmt.Sprintf("init_%s", binding)) // initial value
 	}
 	source := t.pathVariables[len(t.pathVariables)-1]
-	propertyIri, err := property.Expanded(iriExpander)
+
 	if err != nil {
 		panic(err)
 	}
@@ -233,6 +243,50 @@ func traverseProperty(property path.Property, t traversal, fetchNodes bool, iriE
 			t.rego = append(t.rego, fmt.Sprintf("nodes_tmp = object.get(%s,\"%s\",[])", source, propertyIri))
 			t.rego = append(t.rego, "nodes_tmp2 = nodes_array with data.nodes as nodes_tmp") // this returns and array
 			t.rego = append(t.rego, fmt.Sprintf("%s = nodes_tmp2[_]", binding))
+		}
+	}
+
+	r := regoPathResultInternal{
+		rego:          t.rego,
+		pathVariables: append(t.pathVariables, binding),
+		paths:         append(t.paths, property.Iri),
+		counter:       t.counter,
+		variable:      binding,
+	}
+
+	return []regoPathResultInternal{r}
+}
+
+func traverseCustomProperty(property path.Property, t traversal, fetchNodes bool, iriExpander *misc.IriExpander) []regoPathResultInternal {
+	customPropertyName, err := property.CustomName(iriExpander)
+	if err != nil {
+		panic(err)
+	}
+	// We use IDX go generate a unique property for the Rego computation
+	idx := fmt.Sprintf("%d", len(t.pathVariables))
+	if *t.counter > 0 {
+		idx = fmt.Sprintf("%s_%d", idx, t.counter)
+	}
+	binding := fmt.Sprintf("%s_%s", t.variable, idx)
+
+	if len(t.pathVariables) == 0 {
+		// If this is the first element in the path, we start computing the path from the previous variable passed
+		// to the path generator, usually a classTarget.
+		t.rego = append(t.rego, fmt.Sprintf("init_%s = data.sourceNode", binding)) // this is the connection to the variable past to the generator
+		t.pathVariables = append(t.pathVariables, fmt.Sprintf("init_%s", binding)) // initial value
+	}
+	source := t.pathVariables[len(t.pathVariables)-1]
+
+	if property.Inverse {
+		t.rego = append(t.rego, fmt.Sprintf("search_custom_property_subjects[%s] with data.property_extension as \"%s\" with data.object as %s", binding, customPropertyName, source))
+	} else {
+		t.rego = append(t.rego, fmt.Sprintf("tmp_%s = gen_path_extension with data.custom_property_data as [%s, \"%s\"]", binding, source, customPropertyName))
+		// fetch resulting nodes (fetching each @id reference) or simply return the array values
+		if fetchNodes {
+			t.rego = append(t.rego, fmt.Sprintf("%s = tmp_%s[_][_]", binding, binding))
+		} else {
+			t.rego = append(t.rego, fmt.Sprintf("tmp2_%s = tmp_%s[_][_]", binding, binding))
+			t.rego = append(t.rego, fmt.Sprintf("%s = object.get(tmp2_%s,\"@id\",\"\")", binding, binding))
 		}
 	}
 

--- a/internal/generator/path.go
+++ b/internal/generator/path.go
@@ -1,7 +1,6 @@
 package generator
 
 import (
-	"errors"
 	"fmt"
 	"github.com/aml-org/amf-custom-validator/internal/misc"
 	"github.com/aml-org/amf-custom-validator/internal/parser/path"
@@ -279,7 +278,7 @@ func traverseCustomProperty(property path.Property, t traversal, fetchNodes bool
 	source := t.pathVariables[len(t.pathVariables)-1]
 
 	if property.Inverse {
-		panic(errors.New("Inverse custom properties not supported yet"))
+		t.rego = append(t.rego, fmt.Sprintf("search_custom_property_subjects[%s] with data.property_extension as \"%s\" with data.object as %s", binding, customPropertyName, source))
 	} else {
 		t.rego = append(t.rego, fmt.Sprintf("tmp_%s = gen_path_extension with data.custom_property_data as [%s, \"%s\"]", binding, source, customPropertyName))
 		// fetch resulting nodes (fetching each @id reference) or simply return the array values

--- a/internal/parser/path/path_property.go
+++ b/internal/parser/path/path_property.go
@@ -1,6 +1,11 @@
 package path
 
-import "github.com/aml-org/amf-custom-validator/internal/misc"
+import (
+	"errors"
+	"github.com/aml-org/amf-custom-validator/internal/misc"
+	"github.com/aml-org/amf-custom-validator/internal/validator/contexts"
+	"strings"
+)
 
 type Property struct {
 	BasePath
@@ -28,4 +33,21 @@ func (p Property) Expanded(iriExpander *misc.IriExpander) (string, error) {
 
 func (p Property) Source() string {
 	return p.source
+}
+
+func (p Property) IsCustom(iriExpander *misc.IriExpander) bool {
+	expanded, err := iriExpander.Expand(p.Iri)
+	if err != nil {
+		return false
+	}
+	return strings.Index(expanded, contexts.ApiExtensionUri) == 0
+}
+
+func (p Property) CustomName(iriExpander *misc.IriExpander) (string, error) {
+	expanded, err := iriExpander.Expand(p.Iri)
+	if err != nil {
+		return "", errors.New("Invalid custom property")
+	}
+
+	return strings.Split(expanded, "#")[1], nil
 }

--- a/internal/validator/contexts/contexts.go
+++ b/internal/validator/contexts/contexts.go
@@ -2,6 +2,7 @@ package contexts
 
 import "github.com/aml-org/amf-custom-validator/internal/types"
 
+var ApiExtensionUri = "http://a.ml/vocabularies/api-extension#"
 var DefaultAMFContext = types.ObjectMap{
 	"data":        "http://a.ml/vocabularies/data#",
 	"shacl":       "http://www.w3.org/ns/shacl#",
@@ -16,6 +17,7 @@ var DefaultAMFContext = types.ObjectMap{
 	"rdf":         "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
 	"security":    "http://a.ml/vocabularies/security#",
 	"sourcemaps":  "http://a.ml/vocabularies/document-source-maps#",
+	"apiExt":      ApiExtensionUri,
 }
 
 var DefaultValidationContext = types.ObjectMap{

--- a/internal/validator/process_input.go
+++ b/internal/validator/process_input.go
@@ -21,17 +21,5 @@ func ProcessInput(jsonldText string, debug bool, receiver *chan e.Event) (interf
 	normalizedInput := Index(Normalize(input))
 	dispatchEvent(e.NewEvent(e.InputDataNormalizationDone), receiver)
 
-	if debug {
-		println("Input data")
-		println("-------------------------------")
-		var b bytes.Buffer
-		enc := json.NewEncoder(&b)
-		enc.SetIndent("", "  ")
-		err := enc.Encode(normalizedInput)
-		if err != nil {
-			panic(err)
-		}
-		println(b.String())
-	}
 	return normalizedInput, nil
 }

--- a/internal/validator/process_profile.go
+++ b/internal/validator/process_profile.go
@@ -31,22 +31,10 @@ func GenerateRego(profileText string, debug bool, eventChan *chan e.Event) (*gen
 		return nil, err
 	}
 
-	if debug {
-		println("Logic translation")
-		println("-------------------------------")
-		println(parsed.String())
-	}
-
 	// Generate Rego code
 	dispatchEvent(e.NewEvent(e.RegoGenerationStart), eventChan)
 	module := generator.Generate(*parsed)
 	dispatchEvent(e.NewEvent(e.RegoGenerationDone), eventChan)
-
-	if debug {
-		println("Generated profile")
-		println("-------------------------------")
-		println(module.Code)
-	}
 
 	return &module, err
 }

--- a/internal/validator/test_utils.go
+++ b/internal/validator/test_utils.go
@@ -74,6 +74,12 @@ func validateAndCompare(profile, data, expected string, t *testing.T) {
 		write(actualText, expected)
 	} else {
 		if !compare(actualText, expected) {
+			println("Expected")
+			println("==================")
+			println(expected)
+			println("\n\n\nActual")
+			println("==================")
+			println(actualText)
 			t.Errorf("Failed %s. Actual did not match expexted", data)
 		}
 	}

--- a/internal/validator/validate_production_test.go
+++ b/internal/validator/validate_production_test.go
@@ -1,36 +1,81 @@
 package validator
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"github.com/aml-org/amf-custom-validator/internal/config"
+	"github.com/aml-org/amf-custom-validator/internal/parser"
 	"github.com/aml-org/amf-custom-validator/test"
 	"strings"
 	"testing"
 )
 
 func TestProduction(t *testing.T) {
-	filter := "datagraph"
+	filter := ""
 	for _, fixture := range test.ProductionFixtures("../../test/data/production", &filter) {
 		profile := fixture.Profile()
 		for _, example := range fixture.Examples() {
-			filter := "15" // put the number of the text to filter here
+			filter := "" // put the number of the text to filter here
 			if strings.Index(example.File, filter) > -1 {
 				report, err := Validate(profile, example.Text, config.Debug, nil)
+				if config.Debug {
+					generateDebugOutput(profile, example)
+				}
 				if err != nil {
 					t.Errorf("Validation failed %v", err)
 				}
 
-				if config.Override {
-					test.ForceWrite(example.Reportfile(), report)
+				if report == "" {
+					t.Error("Empty report")
 				} else {
-					expected := example.ReadReport()
-					actual := report
-					if expected != actual {
-						t.Errorf(fmt.Sprintf("failed report for %s", example.File))
+					conformant := isReportConformant(report)
+					if conformant == example.Positive {
+						if config.Override {
+							test.ForceWrite(example.Reportfile(), report)
+						} else {
+							expected := example.ReadReport()
+							actual := report
+							if expected != actual {
+								t.Errorf(fmt.Sprintf("Not matching report for %s", example.File))
+							}
+						}
+					} else {
+						t.Errorf("Generated report (positive==%v) not matching report (conformat==%v) for example %s", example.Positive, conformant, example.File)
 					}
 				}
-
 			}
 		}
 	}
+}
+
+func generateDebugOutput(profile string, example test.ProductionExample) {
+	parsedProfile, err := parser.Parse(profile)
+	if err == nil {
+		test.ForceWrite(example.Folfile(), parsedProfile.String())
+	}
+	compiledRego, err := GenerateRego(profile, config.Debug, nil)
+	if err == nil {
+		test.ForceWrite(example.Regofile(), compiledRego.Code)
+	}
+
+	normalizedInput, err := ProcessInput(example.Text, config.Debug, nil)
+	if err == nil {
+		var b bytes.Buffer
+		enc := json.NewEncoder(&b)
+		enc.SetIndent("", "  ")
+		err := enc.Encode(normalizedInput)
+		if err == nil {
+			test.ForceWrite(example.Normalizedinputfile(), b.String())
+		}
+	}
+}
+
+func isReportConformant(report string) bool {
+	var output []interface{}
+	json.Unmarshal([]byte(report), &output)
+	doc := output[0].(map[string]interface{})
+	encoded := doc["doc:encodes"].([]interface{})
+	encodedDoc := encoded[0].(map[string]interface{})
+	return encodedDoc["conforms"].(bool)
 }

--- a/internal/validator/validate_production_test.go
+++ b/internal/validator/validate_production_test.go
@@ -1,8 +1,11 @@
 package validator
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"github.com/aml-org/amf-custom-validator/internal/config"
+	"github.com/aml-org/amf-custom-validator/internal/parser"
 	"github.com/aml-org/amf-custom-validator/test"
 	"strings"
 	"testing"
@@ -16,21 +19,63 @@ func TestProduction(t *testing.T) {
 			filter := "" // put the number of the text to filter here
 			if strings.Index(example.File, filter) > -1 {
 				report, err := Validate(profile, example.Text, config.Debug, nil)
+				if config.Debug {
+					generateDebugOutput(profile, example)
+				}
 				if err != nil {
 					t.Errorf("Validation failed %v", err)
 				}
 
-				if config.Override {
-					test.ForceWrite(example.Reportfile(), report)
+				if report == "" {
+					t.Error("Empty report")
 				} else {
-					expected := example.ReadReport()
-					actual := report
-					if expected != actual {
-						t.Errorf(fmt.Sprintf("failed report for %s", example.File))
+					conformant := isReportConformant(report)
+					if conformant == example.Positive {
+						if config.Override {
+							test.ForceWrite(example.Reportfile(), report)
+						} else {
+							expected := example.ReadReport()
+							actual := report
+							if expected != actual {
+								t.Errorf(fmt.Sprintf("Not matching report for %s", example.File))
+							}
+						}
+					} else {
+						t.Errorf("Generated report (positive==%v) not matching report (conformat==%v) for example %s", example.Positive, conformant, example.File)
 					}
 				}
-
 			}
 		}
 	}
+}
+
+func generateDebugOutput(profile string, example test.ProductionExample) {
+	parsedProfile, err := parser.Parse(profile)
+	if err == nil {
+		test.ForceWrite(example.Folfile(), parsedProfile.String())
+	}
+	compiledRego, err := GenerateRego(profile, config.Debug, nil)
+	if err == nil {
+		test.ForceWrite(example.Regofile(), compiledRego.Code)
+	}
+
+	normalizedInput, err := ProcessInput(example.Text, config.Debug, nil)
+	if err == nil {
+		var b bytes.Buffer
+		enc := json.NewEncoder(&b)
+		enc.SetIndent("", "  ")
+		err := enc.Encode(normalizedInput)
+		if err == nil {
+			test.ForceWrite(example.Normalizedinputfile(), b.String())
+		}
+	}
+}
+
+func isReportConformant(report string) bool {
+	var output []interface{}
+	json.Unmarshal([]byte(report), &output)
+	doc := output[0].(map[string]interface{})
+	encoded := doc["doc:encodes"].([]interface{})
+	encodedDoc := encoded[0].(map[string]interface{})
+	return encodedDoc["conforms"].(bool)
 }

--- a/internal/validator/validate_production_test.go
+++ b/internal/validator/validate_production_test.go
@@ -9,11 +9,11 @@ import (
 )
 
 func TestProduction(t *testing.T) {
-	filter := ""
+	filter := "datagraph"
 	for _, fixture := range test.ProductionFixtures("../../test/data/production", &filter) {
 		profile := fixture.Profile()
 		for _, example := range fixture.Examples() {
-			filter := "" // put the number of the text to filter here
+			filter := "15" // put the number of the text to filter here
 			if strings.Index(example.File, filter) > -1 {
 				report, err := Validate(profile, example.Text, config.Debug, nil)
 				if err != nil {

--- a/internal/validator/validate_semex_test.go
+++ b/internal/validator/validate_semex_test.go
@@ -11,6 +11,7 @@ func testSemexCase(subDirectory relativePath, dataFileName string, t *testing.T)
 	profile := fmt.Sprintf("%s/%s/profile.yaml", semexPath, subDirectory)
 	dataPath := fmt.Sprintf("%s/%s/%s", semexPath, subDirectory, dataFileName)
 	expectedPath := fmt.Sprintf("%s/%s/%s.report.jsonld", semexPath, subDirectory, dataFileName)
+	fmt.Printf("Validation profile %s over %s", profile, dataPath)
 	validateAndCompare(profile, dataPath, expectedPath, t)
 }
 

--- a/internal/validator/validate_semex_test.go
+++ b/internal/validator/validate_semex_test.go
@@ -11,6 +11,7 @@ func testSemexCase(subDirectory relativePath, dataFileName string, t *testing.T)
 	profile := fmt.Sprintf("%s/%s/profile.yaml", semexPath, subDirectory)
 	dataPath := fmt.Sprintf("%s/%s/%s", semexPath, subDirectory, dataFileName)
 	expectedPath := fmt.Sprintf("%s/%s/%s.report.jsonld", semexPath, subDirectory, dataFileName)
+	fmt.Printf("Validation profile %s over %s", profile, dataPath)
 	validateAndCompare(profile, dataPath, expectedPath, t)
 }
 
@@ -22,6 +23,9 @@ func TestPaginationOas20(t *testing.T) {
 }
 func TestPaginationOas30(t *testing.T) {
 	testSemexCase("semantic-extension-pagination", "api.oas30.yaml.jsonld", t)
+}
+func TestCaixaOas30(t *testing.T) {
+	testSemexCase("caixa", "api.oas30.yaml.jsonld", t)
 }
 func TestPaginationRaml10(t *testing.T) {
 	testSemexCase("semantic-extension-pagination", "api.raml.jsonld", t)

--- a/internal/validator/validate_semex_test.go
+++ b/internal/validator/validate_semex_test.go
@@ -24,9 +24,6 @@ func TestPaginationOas20(t *testing.T) {
 func TestPaginationOas30(t *testing.T) {
 	testSemexCase("semantic-extension-pagination", "api.oas30.yaml.jsonld", t)
 }
-func TestCaixaOas30(t *testing.T) {
-	testSemexCase("caixa", "api.oas30.yaml.jsonld", t)
-}
 func TestPaginationRaml10(t *testing.T) {
 	testSemexCase("semantic-extension-pagination", "api.raml.jsonld", t)
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "amf-custom-validator",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {}
+}

--- a/scripts/test-gen/gen_production_examples.sh
+++ b/scripts/test-gen/gen_production_examples.sh
@@ -6,7 +6,7 @@ parse () {
 }
 
 
-for subdir in ./test/data/production/*
+for subdir in ./test/data/production/asyncapi
 do
   oas_30_files=$(grep -rw "$subdir" -e 'openapi: .*$' | cut -d ":" -f1 | grep .yaml | sed 's/.\/\///' | sed 's/$.\///')
   for file in $oas_30_files

--- a/scripts/test-gen/gen_production_examples.sh
+++ b/scripts/test-gen/gen_production_examples.sh
@@ -6,7 +6,7 @@ parse () {
 }
 
 
-for subdir in ./test/data/production/asyncapi
+for subdir in ./test/data/production
 do
   oas_30_files=$(grep -rw "$subdir" -e 'openapi: .*$' | cut -d ":" -f1 | grep .yaml | sed 's/.\/\///' | sed 's/$.\///')
   for file in $oas_30_files

--- a/scripts/test-gen/gen_production_examples.sh
+++ b/scripts/test-gen/gen_production_examples.sh
@@ -6,7 +6,7 @@ parse () {
 }
 
 
-for subdir in ./test/data/production/*
+for subdir in ./test/data/production
 do
   oas_30_files=$(grep -rw "$subdir" -e 'openapi: .*$' | cut -d ":" -f1 | grep .yaml | sed 's/.\/\///' | sed 's/$.\///')
   for file in $oas_30_files

--- a/test/data/basic/profile1.rego
+++ b/test/data/basic/profile1.rego
@@ -46,6 +46,19 @@ search_subjects[valid_subject] {
   valid_subject = node
 }
 
+search_custom_property_subjects[valid_subject] {
+  extension = data.property_extension
+  object = data.object
+  
+  object["http://a.ml/vocabularies/core#extensionName"] = extension
+  object_id = object["@id"]
+  
+  node = input["@ids"][_]
+  
+  node[prop] = {"@id": object_id}
+  valid_subject = node
+}
+
 # collection functions
 
 # collect next set of nodes
@@ -138,6 +151,27 @@ as_string(x) = x["@id"] {
 as_string(x) = json.marshal(x) {
   is_object(x)
   not x["@id"]
+}
+
+# Finds a nested custom domain property for a given node an custom domain property name
+gen_path_extension[nodes] {
+  sourceNode := data.custom_property_data[0]
+  extensionName := data.custom_property_data[1]
+  customPropertiesTarget := object.get(sourceNode, "http://a.ml/vocabularies/document#customDomainProperties", [])
+  customProperties = nodes_array with data.nodes as customPropertiesTarget
+  extensionFound = [found |
+    annotationLink = customProperties[_]
+    annotationLinkId = annotationLink["@id"]
+    annotation = object.get(sourceNode, annotationLinkId, {})
+    annotationNode = find with data.link as annotation
+  
+    name = annotationNode["http://a.ml/vocabularies/core#extensionName"]
+    name = extensionName
+  
+    found = annotationNode
+  ]
+  
+  nodes = extensionFound
 }
 
 #creates an array from a comma separated values str

--- a/test/data/basic/profile1.rego
+++ b/test/data/basic/profile1.rego
@@ -46,6 +46,19 @@ search_subjects[valid_subject] {
   valid_subject = node
 }
 
+search_custom_property_subjects[valid_subject] {
+  extension = data.property_extension
+  object = data.object
+  
+  object["http://a.ml/vocabularies/core#extensionName"] = extension
+  object_id = object["@id"]
+  
+  node = input["@ids"][_]
+  
+  node[prop] = {"@id": object_id}
+  valid_subject = node
+}
+
 # collection functions
 
 # collect next set of nodes

--- a/test/data/basic/profile10.rego
+++ b/test/data/basic/profile10.rego
@@ -46,6 +46,19 @@ search_subjects[valid_subject] {
   valid_subject = node
 }
 
+search_custom_property_subjects[valid_subject] {
+  extension = data.property_extension
+  object = data.object
+  
+  object["http://a.ml/vocabularies/core#extensionName"] = extension
+  object_id = object["@id"]
+  
+  node = input["@ids"][_]
+  
+  node[prop] = {"@id": object_id}
+  valid_subject = node
+}
+
 # collection functions
 
 # collect next set of nodes
@@ -138,6 +151,27 @@ as_string(x) = x["@id"] {
 as_string(x) = json.marshal(x) {
   is_object(x)
   not x["@id"]
+}
+
+# Finds a nested custom domain property for a given node an custom domain property name
+gen_path_extension[nodes] {
+  sourceNode := data.custom_property_data[0]
+  extensionName := data.custom_property_data[1]
+  customPropertiesTarget := object.get(sourceNode, "http://a.ml/vocabularies/document#customDomainProperties", [])
+  customProperties = nodes_array with data.nodes as customPropertiesTarget
+  extensionFound = [found |
+    annotationLink = customProperties[_]
+    annotationLinkId = annotationLink["@id"]
+    annotation = object.get(sourceNode, annotationLinkId, {})
+    annotationNode = find with data.link as annotation
+  
+    name = annotationNode["http://a.ml/vocabularies/core#extensionName"]
+    name = extensionName
+  
+    found = annotationNode
+  ]
+  
+  nodes = extensionFound
 }
 
 #creates an array from a comma separated values str

--- a/test/data/basic/profile10.rego
+++ b/test/data/basic/profile10.rego
@@ -46,6 +46,19 @@ search_subjects[valid_subject] {
   valid_subject = node
 }
 
+search_custom_property_subjects[valid_subject] {
+  extension = data.property_extension
+  object = data.object
+  
+  object["http://a.ml/vocabularies/core#extensionName"] = extension
+  object_id = object["@id"]
+  
+  node = input["@ids"][_]
+  
+  node[prop] = {"@id": object_id}
+  valid_subject = node
+}
+
 # collection functions
 
 # collect next set of nodes

--- a/test/data/basic/profile10.rego
+++ b/test/data/basic/profile10.rego
@@ -140,6 +140,27 @@ as_string(x) = json.marshal(x) {
   not x["@id"]
 }
 
+# Finds a nested custom domain property for a given node an custom domain property name
+gen_path_extension[nodes] {
+  sourceNode := data.custom_property_data[0]
+  extensionName := data.custom_property_data[1]
+  customPropertiesTarget := object.get(sourceNode, "http://a.ml/vocabularies/document#customDomainProperties", [])
+  customProperties = nodes_array with data.nodes as customPropertiesTarget
+  extensionFound = [found |
+    annotationLink = customProperties[_]
+    annotationLinkId = annotationLink["@id"]
+    annotation = object.get(sourceNode, annotationLinkId, {})
+    annotationNode = find with data.link as annotation
+  
+    name = annotationNode["http://a.ml/vocabularies/core#extensionName"]
+    name = extensionName
+  
+    found = annotationNode
+  ]
+  
+  nodes = extensionFound
+}
+
 #creates an array from a comma separated values str
 split_values[values] {
    values := split(data.nodes, ",")

--- a/test/data/basic/profile11.rego
+++ b/test/data/basic/profile11.rego
@@ -46,6 +46,19 @@ search_subjects[valid_subject] {
   valid_subject = node
 }
 
+search_custom_property_subjects[valid_subject] {
+  extension = data.property_extension
+  object = data.object
+  
+  object["http://a.ml/vocabularies/core#extensionName"] = extension
+  object_id = object["@id"]
+  
+  node = input["@ids"][_]
+  
+  node[prop] = {"@id": object_id}
+  valid_subject = node
+}
+
 # collection functions
 
 # collect next set of nodes
@@ -138,6 +151,27 @@ as_string(x) = x["@id"] {
 as_string(x) = json.marshal(x) {
   is_object(x)
   not x["@id"]
+}
+
+# Finds a nested custom domain property for a given node an custom domain property name
+gen_path_extension[nodes] {
+  sourceNode := data.custom_property_data[0]
+  extensionName := data.custom_property_data[1]
+  customPropertiesTarget := object.get(sourceNode, "http://a.ml/vocabularies/document#customDomainProperties", [])
+  customProperties = nodes_array with data.nodes as customPropertiesTarget
+  extensionFound = [found |
+    annotationLink = customProperties[_]
+    annotationLinkId = annotationLink["@id"]
+    annotation = object.get(sourceNode, annotationLinkId, {})
+    annotationNode = find with data.link as annotation
+  
+    name = annotationNode["http://a.ml/vocabularies/core#extensionName"]
+    name = extensionName
+  
+    found = annotationNode
+  ]
+  
+  nodes = extensionFound
 }
 
 #creates an array from a comma separated values str

--- a/test/data/basic/profile11.rego
+++ b/test/data/basic/profile11.rego
@@ -46,6 +46,19 @@ search_subjects[valid_subject] {
   valid_subject = node
 }
 
+search_custom_property_subjects[valid_subject] {
+  extension = data.property_extension
+  object = data.object
+  
+  object["http://a.ml/vocabularies/core#extensionName"] = extension
+  object_id = object["@id"]
+  
+  node = input["@ids"][_]
+  
+  node[prop] = {"@id": object_id}
+  valid_subject = node
+}
+
 # collection functions
 
 # collect next set of nodes

--- a/test/data/basic/profile11.rego
+++ b/test/data/basic/profile11.rego
@@ -140,6 +140,27 @@ as_string(x) = json.marshal(x) {
   not x["@id"]
 }
 
+# Finds a nested custom domain property for a given node an custom domain property name
+gen_path_extension[nodes] {
+  sourceNode := data.custom_property_data[0]
+  extensionName := data.custom_property_data[1]
+  customPropertiesTarget := object.get(sourceNode, "http://a.ml/vocabularies/document#customDomainProperties", [])
+  customProperties = nodes_array with data.nodes as customPropertiesTarget
+  extensionFound = [found |
+    annotationLink = customProperties[_]
+    annotationLinkId = annotationLink["@id"]
+    annotation = object.get(sourceNode, annotationLinkId, {})
+    annotationNode = find with data.link as annotation
+  
+    name = annotationNode["http://a.ml/vocabularies/core#extensionName"]
+    name = extensionName
+  
+    found = annotationNode
+  ]
+  
+  nodes = extensionFound
+}
+
 #creates an array from a comma separated values str
 split_values[values] {
    values := split(data.nodes, ",")

--- a/test/data/basic/profile12.rego
+++ b/test/data/basic/profile12.rego
@@ -46,6 +46,19 @@ search_subjects[valid_subject] {
   valid_subject = node
 }
 
+search_custom_property_subjects[valid_subject] {
+  extension = data.property_extension
+  object = data.object
+  
+  object["http://a.ml/vocabularies/core#extensionName"] = extension
+  object_id = object["@id"]
+  
+  node = input["@ids"][_]
+  
+  node[prop] = {"@id": object_id}
+  valid_subject = node
+}
+
 # collection functions
 
 # collect next set of nodes

--- a/test/data/basic/profile12.rego
+++ b/test/data/basic/profile12.rego
@@ -140,6 +140,27 @@ as_string(x) = json.marshal(x) {
   not x["@id"]
 }
 
+# Finds a nested custom domain property for a given node an custom domain property name
+gen_path_extension[nodes] {
+  sourceNode := data.custom_property_data[0]
+  extensionName := data.custom_property_data[1]
+  customPropertiesTarget := object.get(sourceNode, "http://a.ml/vocabularies/document#customDomainProperties", [])
+  customProperties = nodes_array with data.nodes as customPropertiesTarget
+  extensionFound = [found |
+    annotationLink = customProperties[_]
+    annotationLinkId = annotationLink["@id"]
+    annotation = object.get(sourceNode, annotationLinkId, {})
+    annotationNode = find with data.link as annotation
+  
+    name = annotationNode["http://a.ml/vocabularies/core#extensionName"]
+    name = extensionName
+  
+    found = annotationNode
+  ]
+  
+  nodes = extensionFound
+}
+
 #creates an array from a comma separated values str
 split_values[values] {
    values := split(data.nodes, ",")

--- a/test/data/basic/profile13.rego
+++ b/test/data/basic/profile13.rego
@@ -46,6 +46,19 @@ search_subjects[valid_subject] {
   valid_subject = node
 }
 
+search_custom_property_subjects[valid_subject] {
+  extension = data.property_extension
+  object = data.object
+  
+  object["http://a.ml/vocabularies/core#extensionName"] = extension
+  object_id = object["@id"]
+  
+  node = input["@ids"][_]
+  
+  node[prop] = {"@id": object_id}
+  valid_subject = node
+}
+
 # collection functions
 
 # collect next set of nodes
@@ -138,6 +151,27 @@ as_string(x) = x["@id"] {
 as_string(x) = json.marshal(x) {
   is_object(x)
   not x["@id"]
+}
+
+# Finds a nested custom domain property for a given node an custom domain property name
+gen_path_extension[nodes] {
+  sourceNode := data.custom_property_data[0]
+  extensionName := data.custom_property_data[1]
+  customPropertiesTarget := object.get(sourceNode, "http://a.ml/vocabularies/document#customDomainProperties", [])
+  customProperties = nodes_array with data.nodes as customPropertiesTarget
+  extensionFound = [found |
+    annotationLink = customProperties[_]
+    annotationLinkId = annotationLink["@id"]
+    annotation = object.get(sourceNode, annotationLinkId, {})
+    annotationNode = find with data.link as annotation
+  
+    name = annotationNode["http://a.ml/vocabularies/core#extensionName"]
+    name = extensionName
+  
+    found = annotationNode
+  ]
+  
+  nodes = extensionFound
 }
 
 #creates an array from a comma separated values str

--- a/test/data/basic/profile13.rego
+++ b/test/data/basic/profile13.rego
@@ -46,6 +46,19 @@ search_subjects[valid_subject] {
   valid_subject = node
 }
 
+search_custom_property_subjects[valid_subject] {
+  extension = data.property_extension
+  object = data.object
+  
+  object["http://a.ml/vocabularies/core#extensionName"] = extension
+  object_id = object["@id"]
+  
+  node = input["@ids"][_]
+  
+  node[prop] = {"@id": object_id}
+  valid_subject = node
+}
+
 # collection functions
 
 # collect next set of nodes

--- a/test/data/basic/profile13.rego
+++ b/test/data/basic/profile13.rego
@@ -140,6 +140,27 @@ as_string(x) = json.marshal(x) {
   not x["@id"]
 }
 
+# Finds a nested custom domain property for a given node an custom domain property name
+gen_path_extension[nodes] {
+  sourceNode := data.custom_property_data[0]
+  extensionName := data.custom_property_data[1]
+  customPropertiesTarget := object.get(sourceNode, "http://a.ml/vocabularies/document#customDomainProperties", [])
+  customProperties = nodes_array with data.nodes as customPropertiesTarget
+  extensionFound = [found |
+    annotationLink = customProperties[_]
+    annotationLinkId = annotationLink["@id"]
+    annotation = object.get(sourceNode, annotationLinkId, {})
+    annotationNode = find with data.link as annotation
+  
+    name = annotationNode["http://a.ml/vocabularies/core#extensionName"]
+    name = extensionName
+  
+    found = annotationNode
+  ]
+  
+  nodes = extensionFound
+}
+
 #creates an array from a comma separated values str
 split_values[values] {
    values := split(data.nodes, ",")

--- a/test/data/basic/profile14.rego
+++ b/test/data/basic/profile14.rego
@@ -46,6 +46,19 @@ search_subjects[valid_subject] {
   valid_subject = node
 }
 
+search_custom_property_subjects[valid_subject] {
+  extension = data.property_extension
+  object = data.object
+  
+  object["http://a.ml/vocabularies/core#extensionName"] = extension
+  object_id = object["@id"]
+  
+  node = input["@ids"][_]
+  
+  node[prop] = {"@id": object_id}
+  valid_subject = node
+}
+
 # collection functions
 
 # collect next set of nodes
@@ -138,6 +151,27 @@ as_string(x) = x["@id"] {
 as_string(x) = json.marshal(x) {
   is_object(x)
   not x["@id"]
+}
+
+# Finds a nested custom domain property for a given node an custom domain property name
+gen_path_extension[nodes] {
+  sourceNode := data.custom_property_data[0]
+  extensionName := data.custom_property_data[1]
+  customPropertiesTarget := object.get(sourceNode, "http://a.ml/vocabularies/document#customDomainProperties", [])
+  customProperties = nodes_array with data.nodes as customPropertiesTarget
+  extensionFound = [found |
+    annotationLink = customProperties[_]
+    annotationLinkId = annotationLink["@id"]
+    annotation = object.get(sourceNode, annotationLinkId, {})
+    annotationNode = find with data.link as annotation
+  
+    name = annotationNode["http://a.ml/vocabularies/core#extensionName"]
+    name = extensionName
+  
+    found = annotationNode
+  ]
+  
+  nodes = extensionFound
 }
 
 #creates an array from a comma separated values str

--- a/test/data/basic/profile14.rego
+++ b/test/data/basic/profile14.rego
@@ -46,6 +46,19 @@ search_subjects[valid_subject] {
   valid_subject = node
 }
 
+search_custom_property_subjects[valid_subject] {
+  extension = data.property_extension
+  object = data.object
+  
+  object["http://a.ml/vocabularies/core#extensionName"] = extension
+  object_id = object["@id"]
+  
+  node = input["@ids"][_]
+  
+  node[prop] = {"@id": object_id}
+  valid_subject = node
+}
+
 # collection functions
 
 # collect next set of nodes

--- a/test/data/basic/profile14.rego
+++ b/test/data/basic/profile14.rego
@@ -140,6 +140,27 @@ as_string(x) = json.marshal(x) {
   not x["@id"]
 }
 
+# Finds a nested custom domain property for a given node an custom domain property name
+gen_path_extension[nodes] {
+  sourceNode := data.custom_property_data[0]
+  extensionName := data.custom_property_data[1]
+  customPropertiesTarget := object.get(sourceNode, "http://a.ml/vocabularies/document#customDomainProperties", [])
+  customProperties = nodes_array with data.nodes as customPropertiesTarget
+  extensionFound = [found |
+    annotationLink = customProperties[_]
+    annotationLinkId = annotationLink["@id"]
+    annotation = object.get(sourceNode, annotationLinkId, {})
+    annotationNode = find with data.link as annotation
+  
+    name = annotationNode["http://a.ml/vocabularies/core#extensionName"]
+    name = extensionName
+  
+    found = annotationNode
+  ]
+  
+  nodes = extensionFound
+}
+
 #creates an array from a comma separated values str
 split_values[values] {
    values := split(data.nodes, ",")

--- a/test/data/basic/profile15.rego
+++ b/test/data/basic/profile15.rego
@@ -46,6 +46,19 @@ search_subjects[valid_subject] {
   valid_subject = node
 }
 
+search_custom_property_subjects[valid_subject] {
+  extension = data.property_extension
+  object = data.object
+  
+  object["http://a.ml/vocabularies/core#extensionName"] = extension
+  object_id = object["@id"]
+  
+  node = input["@ids"][_]
+  
+  node[prop] = {"@id": object_id}
+  valid_subject = node
+}
+
 # collection functions
 
 # collect next set of nodes
@@ -138,6 +151,27 @@ as_string(x) = x["@id"] {
 as_string(x) = json.marshal(x) {
   is_object(x)
   not x["@id"]
+}
+
+# Finds a nested custom domain property for a given node an custom domain property name
+gen_path_extension[nodes] {
+  sourceNode := data.custom_property_data[0]
+  extensionName := data.custom_property_data[1]
+  customPropertiesTarget := object.get(sourceNode, "http://a.ml/vocabularies/document#customDomainProperties", [])
+  customProperties = nodes_array with data.nodes as customPropertiesTarget
+  extensionFound = [found |
+    annotationLink = customProperties[_]
+    annotationLinkId = annotationLink["@id"]
+    annotation = object.get(sourceNode, annotationLinkId, {})
+    annotationNode = find with data.link as annotation
+  
+    name = annotationNode["http://a.ml/vocabularies/core#extensionName"]
+    name = extensionName
+  
+    found = annotationNode
+  ]
+  
+  nodes = extensionFound
 }
 
 #creates an array from a comma separated values str

--- a/test/data/basic/profile15.rego
+++ b/test/data/basic/profile15.rego
@@ -46,6 +46,19 @@ search_subjects[valid_subject] {
   valid_subject = node
 }
 
+search_custom_property_subjects[valid_subject] {
+  extension = data.property_extension
+  object = data.object
+  
+  object["http://a.ml/vocabularies/core#extensionName"] = extension
+  object_id = object["@id"]
+  
+  node = input["@ids"][_]
+  
+  node[prop] = {"@id": object_id}
+  valid_subject = node
+}
+
 # collection functions
 
 # collect next set of nodes

--- a/test/data/basic/profile15.rego
+++ b/test/data/basic/profile15.rego
@@ -140,6 +140,27 @@ as_string(x) = json.marshal(x) {
   not x["@id"]
 }
 
+# Finds a nested custom domain property for a given node an custom domain property name
+gen_path_extension[nodes] {
+  sourceNode := data.custom_property_data[0]
+  extensionName := data.custom_property_data[1]
+  customPropertiesTarget := object.get(sourceNode, "http://a.ml/vocabularies/document#customDomainProperties", [])
+  customProperties = nodes_array with data.nodes as customPropertiesTarget
+  extensionFound = [found |
+    annotationLink = customProperties[_]
+    annotationLinkId = annotationLink["@id"]
+    annotation = object.get(sourceNode, annotationLinkId, {})
+    annotationNode = find with data.link as annotation
+  
+    name = annotationNode["http://a.ml/vocabularies/core#extensionName"]
+    name = extensionName
+  
+    found = annotationNode
+  ]
+  
+  nodes = extensionFound
+}
+
 #creates an array from a comma separated values str
 split_values[values] {
    values := split(data.nodes, ",")

--- a/test/data/basic/profile2.rego
+++ b/test/data/basic/profile2.rego
@@ -46,6 +46,19 @@ search_subjects[valid_subject] {
   valid_subject = node
 }
 
+search_custom_property_subjects[valid_subject] {
+  extension = data.property_extension
+  object = data.object
+  
+  object["http://a.ml/vocabularies/core#extensionName"] = extension
+  object_id = object["@id"]
+  
+  node = input["@ids"][_]
+  
+  node[prop] = {"@id": object_id}
+  valid_subject = node
+}
+
 # collection functions
 
 # collect next set of nodes
@@ -138,6 +151,27 @@ as_string(x) = x["@id"] {
 as_string(x) = json.marshal(x) {
   is_object(x)
   not x["@id"]
+}
+
+# Finds a nested custom domain property for a given node an custom domain property name
+gen_path_extension[nodes] {
+  sourceNode := data.custom_property_data[0]
+  extensionName := data.custom_property_data[1]
+  customPropertiesTarget := object.get(sourceNode, "http://a.ml/vocabularies/document#customDomainProperties", [])
+  customProperties = nodes_array with data.nodes as customPropertiesTarget
+  extensionFound = [found |
+    annotationLink = customProperties[_]
+    annotationLinkId = annotationLink["@id"]
+    annotation = object.get(sourceNode, annotationLinkId, {})
+    annotationNode = find with data.link as annotation
+  
+    name = annotationNode["http://a.ml/vocabularies/core#extensionName"]
+    name = extensionName
+  
+    found = annotationNode
+  ]
+  
+  nodes = extensionFound
 }
 
 #creates an array from a comma separated values str

--- a/test/data/basic/profile2.rego
+++ b/test/data/basic/profile2.rego
@@ -46,6 +46,19 @@ search_subjects[valid_subject] {
   valid_subject = node
 }
 
+search_custom_property_subjects[valid_subject] {
+  extension = data.property_extension
+  object = data.object
+  
+  object["http://a.ml/vocabularies/core#extensionName"] = extension
+  object_id = object["@id"]
+  
+  node = input["@ids"][_]
+  
+  node[prop] = {"@id": object_id}
+  valid_subject = node
+}
+
 # collection functions
 
 # collect next set of nodes

--- a/test/data/basic/profile2.rego
+++ b/test/data/basic/profile2.rego
@@ -140,6 +140,27 @@ as_string(x) = json.marshal(x) {
   not x["@id"]
 }
 
+# Finds a nested custom domain property for a given node an custom domain property name
+gen_path_extension[nodes] {
+  sourceNode := data.custom_property_data[0]
+  extensionName := data.custom_property_data[1]
+  customPropertiesTarget := object.get(sourceNode, "http://a.ml/vocabularies/document#customDomainProperties", [])
+  customProperties = nodes_array with data.nodes as customPropertiesTarget
+  extensionFound = [found |
+    annotationLink = customProperties[_]
+    annotationLinkId = annotationLink["@id"]
+    annotation = object.get(sourceNode, annotationLinkId, {})
+    annotationNode = find with data.link as annotation
+  
+    name = annotationNode["http://a.ml/vocabularies/core#extensionName"]
+    name = extensionName
+  
+    found = annotationNode
+  ]
+  
+  nodes = extensionFound
+}
+
 #creates an array from a comma separated values str
 split_values[values] {
    values := split(data.nodes, ",")

--- a/test/data/basic/profile3.rego
+++ b/test/data/basic/profile3.rego
@@ -46,6 +46,19 @@ search_subjects[valid_subject] {
   valid_subject = node
 }
 
+search_custom_property_subjects[valid_subject] {
+  extension = data.property_extension
+  object = data.object
+  
+  object["http://a.ml/vocabularies/core#extensionName"] = extension
+  object_id = object["@id"]
+  
+  node = input["@ids"][_]
+  
+  node[prop] = {"@id": object_id}
+  valid_subject = node
+}
+
 # collection functions
 
 # collect next set of nodes
@@ -138,6 +151,27 @@ as_string(x) = x["@id"] {
 as_string(x) = json.marshal(x) {
   is_object(x)
   not x["@id"]
+}
+
+# Finds a nested custom domain property for a given node an custom domain property name
+gen_path_extension[nodes] {
+  sourceNode := data.custom_property_data[0]
+  extensionName := data.custom_property_data[1]
+  customPropertiesTarget := object.get(sourceNode, "http://a.ml/vocabularies/document#customDomainProperties", [])
+  customProperties = nodes_array with data.nodes as customPropertiesTarget
+  extensionFound = [found |
+    annotationLink = customProperties[_]
+    annotationLinkId = annotationLink["@id"]
+    annotation = object.get(sourceNode, annotationLinkId, {})
+    annotationNode = find with data.link as annotation
+  
+    name = annotationNode["http://a.ml/vocabularies/core#extensionName"]
+    name = extensionName
+  
+    found = annotationNode
+  ]
+  
+  nodes = extensionFound
 }
 
 #creates an array from a comma separated values str

--- a/test/data/basic/profile3.rego
+++ b/test/data/basic/profile3.rego
@@ -46,6 +46,19 @@ search_subjects[valid_subject] {
   valid_subject = node
 }
 
+search_custom_property_subjects[valid_subject] {
+  extension = data.property_extension
+  object = data.object
+  
+  object["http://a.ml/vocabularies/core#extensionName"] = extension
+  object_id = object["@id"]
+  
+  node = input["@ids"][_]
+  
+  node[prop] = {"@id": object_id}
+  valid_subject = node
+}
+
 # collection functions
 
 # collect next set of nodes

--- a/test/data/basic/profile3.rego
+++ b/test/data/basic/profile3.rego
@@ -140,6 +140,27 @@ as_string(x) = json.marshal(x) {
   not x["@id"]
 }
 
+# Finds a nested custom domain property for a given node an custom domain property name
+gen_path_extension[nodes] {
+  sourceNode := data.custom_property_data[0]
+  extensionName := data.custom_property_data[1]
+  customPropertiesTarget := object.get(sourceNode, "http://a.ml/vocabularies/document#customDomainProperties", [])
+  customProperties = nodes_array with data.nodes as customPropertiesTarget
+  extensionFound = [found |
+    annotationLink = customProperties[_]
+    annotationLinkId = annotationLink["@id"]
+    annotation = object.get(sourceNode, annotationLinkId, {})
+    annotationNode = find with data.link as annotation
+  
+    name = annotationNode["http://a.ml/vocabularies/core#extensionName"]
+    name = extensionName
+  
+    found = annotationNode
+  ]
+  
+  nodes = extensionFound
+}
+
 #creates an array from a comma separated values str
 split_values[values] {
    values := split(data.nodes, ",")

--- a/test/data/basic/profile4.rego
+++ b/test/data/basic/profile4.rego
@@ -46,6 +46,19 @@ search_subjects[valid_subject] {
   valid_subject = node
 }
 
+search_custom_property_subjects[valid_subject] {
+  extension = data.property_extension
+  object = data.object
+  
+  object["http://a.ml/vocabularies/core#extensionName"] = extension
+  object_id = object["@id"]
+  
+  node = input["@ids"][_]
+  
+  node[prop] = {"@id": object_id}
+  valid_subject = node
+}
+
 # collection functions
 
 # collect next set of nodes
@@ -138,6 +151,27 @@ as_string(x) = x["@id"] {
 as_string(x) = json.marshal(x) {
   is_object(x)
   not x["@id"]
+}
+
+# Finds a nested custom domain property for a given node an custom domain property name
+gen_path_extension[nodes] {
+  sourceNode := data.custom_property_data[0]
+  extensionName := data.custom_property_data[1]
+  customPropertiesTarget := object.get(sourceNode, "http://a.ml/vocabularies/document#customDomainProperties", [])
+  customProperties = nodes_array with data.nodes as customPropertiesTarget
+  extensionFound = [found |
+    annotationLink = customProperties[_]
+    annotationLinkId = annotationLink["@id"]
+    annotation = object.get(sourceNode, annotationLinkId, {})
+    annotationNode = find with data.link as annotation
+  
+    name = annotationNode["http://a.ml/vocabularies/core#extensionName"]
+    name = extensionName
+  
+    found = annotationNode
+  ]
+  
+  nodes = extensionFound
 }
 
 #creates an array from a comma separated values str

--- a/test/data/basic/profile4.rego
+++ b/test/data/basic/profile4.rego
@@ -46,6 +46,19 @@ search_subjects[valid_subject] {
   valid_subject = node
 }
 
+search_custom_property_subjects[valid_subject] {
+  extension = data.property_extension
+  object = data.object
+  
+  object["http://a.ml/vocabularies/core#extensionName"] = extension
+  object_id = object["@id"]
+  
+  node = input["@ids"][_]
+  
+  node[prop] = {"@id": object_id}
+  valid_subject = node
+}
+
 # collection functions
 
 # collect next set of nodes

--- a/test/data/basic/profile4.rego
+++ b/test/data/basic/profile4.rego
@@ -140,6 +140,27 @@ as_string(x) = json.marshal(x) {
   not x["@id"]
 }
 
+# Finds a nested custom domain property for a given node an custom domain property name
+gen_path_extension[nodes] {
+  sourceNode := data.custom_property_data[0]
+  extensionName := data.custom_property_data[1]
+  customPropertiesTarget := object.get(sourceNode, "http://a.ml/vocabularies/document#customDomainProperties", [])
+  customProperties = nodes_array with data.nodes as customPropertiesTarget
+  extensionFound = [found |
+    annotationLink = customProperties[_]
+    annotationLinkId = annotationLink["@id"]
+    annotation = object.get(sourceNode, annotationLinkId, {})
+    annotationNode = find with data.link as annotation
+  
+    name = annotationNode["http://a.ml/vocabularies/core#extensionName"]
+    name = extensionName
+  
+    found = annotationNode
+  ]
+  
+  nodes = extensionFound
+}
+
 #creates an array from a comma separated values str
 split_values[values] {
    values := split(data.nodes, ",")

--- a/test/data/basic/profile5.rego
+++ b/test/data/basic/profile5.rego
@@ -46,6 +46,19 @@ search_subjects[valid_subject] {
   valid_subject = node
 }
 
+search_custom_property_subjects[valid_subject] {
+  extension = data.property_extension
+  object = data.object
+  
+  object["http://a.ml/vocabularies/core#extensionName"] = extension
+  object_id = object["@id"]
+  
+  node = input["@ids"][_]
+  
+  node[prop] = {"@id": object_id}
+  valid_subject = node
+}
+
 # collection functions
 
 # collect next set of nodes
@@ -138,6 +151,27 @@ as_string(x) = x["@id"] {
 as_string(x) = json.marshal(x) {
   is_object(x)
   not x["@id"]
+}
+
+# Finds a nested custom domain property for a given node an custom domain property name
+gen_path_extension[nodes] {
+  sourceNode := data.custom_property_data[0]
+  extensionName := data.custom_property_data[1]
+  customPropertiesTarget := object.get(sourceNode, "http://a.ml/vocabularies/document#customDomainProperties", [])
+  customProperties = nodes_array with data.nodes as customPropertiesTarget
+  extensionFound = [found |
+    annotationLink = customProperties[_]
+    annotationLinkId = annotationLink["@id"]
+    annotation = object.get(sourceNode, annotationLinkId, {})
+    annotationNode = find with data.link as annotation
+  
+    name = annotationNode["http://a.ml/vocabularies/core#extensionName"]
+    name = extensionName
+  
+    found = annotationNode
+  ]
+  
+  nodes = extensionFound
 }
 
 #creates an array from a comma separated values str

--- a/test/data/basic/profile5.rego
+++ b/test/data/basic/profile5.rego
@@ -46,6 +46,19 @@ search_subjects[valid_subject] {
   valid_subject = node
 }
 
+search_custom_property_subjects[valid_subject] {
+  extension = data.property_extension
+  object = data.object
+  
+  object["http://a.ml/vocabularies/core#extensionName"] = extension
+  object_id = object["@id"]
+  
+  node = input["@ids"][_]
+  
+  node[prop] = {"@id": object_id}
+  valid_subject = node
+}
+
 # collection functions
 
 # collect next set of nodes

--- a/test/data/basic/profile5.rego
+++ b/test/data/basic/profile5.rego
@@ -140,6 +140,27 @@ as_string(x) = json.marshal(x) {
   not x["@id"]
 }
 
+# Finds a nested custom domain property for a given node an custom domain property name
+gen_path_extension[nodes] {
+  sourceNode := data.custom_property_data[0]
+  extensionName := data.custom_property_data[1]
+  customPropertiesTarget := object.get(sourceNode, "http://a.ml/vocabularies/document#customDomainProperties", [])
+  customProperties = nodes_array with data.nodes as customPropertiesTarget
+  extensionFound = [found |
+    annotationLink = customProperties[_]
+    annotationLinkId = annotationLink["@id"]
+    annotation = object.get(sourceNode, annotationLinkId, {})
+    annotationNode = find with data.link as annotation
+  
+    name = annotationNode["http://a.ml/vocabularies/core#extensionName"]
+    name = extensionName
+  
+    found = annotationNode
+  ]
+  
+  nodes = extensionFound
+}
+
 #creates an array from a comma separated values str
 split_values[values] {
    values := split(data.nodes, ",")

--- a/test/data/basic/profile6.rego
+++ b/test/data/basic/profile6.rego
@@ -46,6 +46,19 @@ search_subjects[valid_subject] {
   valid_subject = node
 }
 
+search_custom_property_subjects[valid_subject] {
+  extension = data.property_extension
+  object = data.object
+  
+  object["http://a.ml/vocabularies/core#extensionName"] = extension
+  object_id = object["@id"]
+  
+  node = input["@ids"][_]
+  
+  node[prop] = {"@id": object_id}
+  valid_subject = node
+}
+
 # collection functions
 
 # collect next set of nodes
@@ -138,6 +151,27 @@ as_string(x) = x["@id"] {
 as_string(x) = json.marshal(x) {
   is_object(x)
   not x["@id"]
+}
+
+# Finds a nested custom domain property for a given node an custom domain property name
+gen_path_extension[nodes] {
+  sourceNode := data.custom_property_data[0]
+  extensionName := data.custom_property_data[1]
+  customPropertiesTarget := object.get(sourceNode, "http://a.ml/vocabularies/document#customDomainProperties", [])
+  customProperties = nodes_array with data.nodes as customPropertiesTarget
+  extensionFound = [found |
+    annotationLink = customProperties[_]
+    annotationLinkId = annotationLink["@id"]
+    annotation = object.get(sourceNode, annotationLinkId, {})
+    annotationNode = find with data.link as annotation
+  
+    name = annotationNode["http://a.ml/vocabularies/core#extensionName"]
+    name = extensionName
+  
+    found = annotationNode
+  ]
+  
+  nodes = extensionFound
 }
 
 #creates an array from a comma separated values str

--- a/test/data/basic/profile6.rego
+++ b/test/data/basic/profile6.rego
@@ -46,6 +46,19 @@ search_subjects[valid_subject] {
   valid_subject = node
 }
 
+search_custom_property_subjects[valid_subject] {
+  extension = data.property_extension
+  object = data.object
+  
+  object["http://a.ml/vocabularies/core#extensionName"] = extension
+  object_id = object["@id"]
+  
+  node = input["@ids"][_]
+  
+  node[prop] = {"@id": object_id}
+  valid_subject = node
+}
+
 # collection functions
 
 # collect next set of nodes

--- a/test/data/basic/profile6.rego
+++ b/test/data/basic/profile6.rego
@@ -140,6 +140,27 @@ as_string(x) = json.marshal(x) {
   not x["@id"]
 }
 
+# Finds a nested custom domain property for a given node an custom domain property name
+gen_path_extension[nodes] {
+  sourceNode := data.custom_property_data[0]
+  extensionName := data.custom_property_data[1]
+  customPropertiesTarget := object.get(sourceNode, "http://a.ml/vocabularies/document#customDomainProperties", [])
+  customProperties = nodes_array with data.nodes as customPropertiesTarget
+  extensionFound = [found |
+    annotationLink = customProperties[_]
+    annotationLinkId = annotationLink["@id"]
+    annotation = object.get(sourceNode, annotationLinkId, {})
+    annotationNode = find with data.link as annotation
+  
+    name = annotationNode["http://a.ml/vocabularies/core#extensionName"]
+    name = extensionName
+  
+    found = annotationNode
+  ]
+  
+  nodes = extensionFound
+}
+
 #creates an array from a comma separated values str
 split_values[values] {
    values := split(data.nodes, ",")

--- a/test/data/basic/profile6b.parsed
+++ b/test/data/basic/profile6b.parsed
@@ -1,0 +1,6 @@
+test-min-length[violation] :=  ∀x[Class(raml-shapes.ScalarShape)] : 
+  (
+    (Property(x,'apiContract.endpoint / apiExt.wadus') < Property(x,'shacl.maxLength'))
+  ∧
+    (Property(x,'apiExt.wadus') < Property(x,'shacl.maxLength'))
+  )

--- a/test/data/basic/profile6b.rego
+++ b/test/data/basic/profile6b.rego
@@ -1,6 +1,6 @@
-package profile_test_1
+package profile_test6
 
-report["profile"] = "Test 1"
+report["profile"] = "Test6"
 
 # Finds a node in the graph, following a link in the flatten JSON-LD node
 find = node {
@@ -279,33 +279,35 @@ default warning = []
 default info = []
 # Path rules
 
+gen_path_set_rule_1[nodes] {
+  init_x_0 = data.sourceNode
+  tmp_x_0 = nested_nodes with data.nodes as init_x_0["http://a.ml/vocabularies/apiContract#endpoint"]
+  x_0 = tmp_x_0[_][_]
+  tmp_x_2 = gen_path_extension with data.custom_property_data as [x_0, "wadus"]
+  tmp2_x_2 = tmp_x_2[_][_]
+  x_2 = object.get(tmp2_x_2,"@id","")
+  nodes = x_2
+}
+
+gen_path_set_rule_2[nodes] {
+  init_x_0 = data.sourceNode
+  nodes_tmp = object.get(init_x_0,"http://www.w3.org/ns/shacl#maxLength",[])
+  nodes_tmp2 = nodes_array with data.nodes as nodes_tmp
+  x_0 = nodes_tmp2[_]
+  nodes = x_0
+}
+
 gen_path_set_rule_3[nodes] {
   init_x_0 = data.sourceNode
-  nodes_tmp = object.get(init_x_0,"http://a.ml/vocabularies/apiContract#method",[])
-  nodes_tmp2 = nodes_array with data.nodes as nodes_tmp
-  x_0 = nodes_tmp2[_]
+  tmp_x_0 = gen_path_extension with data.custom_property_data as [init_x_0, "wadus"]
+  tmp2_x_0 = tmp_x_0[_][_]
+  x_0 = object.get(tmp2_x_0,"@id","")
   nodes = x_0
 }
 
-gen_path_set_rule_5[nodes] {
+gen_path_set_rule_4[nodes] {
   init_x_0 = data.sourceNode
-  nodes_tmp = object.get(init_x_0,"http://www.w3.org/ns/shacl#name",[])
-  nodes_tmp2 = nodes_array with data.nodes as nodes_tmp
-  x_0 = nodes_tmp2[_]
-  nodes = x_0
-}
-
-gen_path_set_rule_7[nodes] {
-  init_x_0 = data.sourceNode
-  nodes_tmp = object.get(init_x_0,"http://a.ml/vocabularies/apiContract#method",[])
-  nodes_tmp2 = nodes_array with data.nodes as nodes_tmp
-  x_0 = nodes_tmp2[_]
-  nodes = x_0
-}
-
-gen_path_set_rule_8[nodes] {
-  init_x_0 = data.sourceNode
-  nodes_tmp = object.get(init_x_0,"http://www.w3.org/ns/shacl#name",[])
+  nodes_tmp = object.get(init_x_0,"http://www.w3.org/ns/shacl#maxLength",[])
   nodes_tmp2 = nodes_array with data.nodes as nodes_tmp
   x_0 = nodes_tmp2[_]
   nodes = x_0
@@ -314,41 +316,27 @@ gen_path_set_rule_8[nodes] {
 # Constraint rules
 
 violation[matches] {
-  target_class[x] with data.class as "http://a.ml/vocabularies/apiContract#Operation"
-  #  querying path: apiContract.method
-  gen_x_check_2_array = gen_path_set_rule_3 with data.sourceNode as x
-  gen_x_check_2_scalar = gen_x_check_2_array[_]
-  gen_x_check_2 = as_string(gen_x_check_2_scalar)
-  gen_inValues_1 = { "publish","subscribe","1","2"}
-  not gen_inValues_1[gen_x_check_2]
-  _result_0 := trace("in","http://a.ml/vocabularies/apiContract#method",x,{"@type": ["reportSchema:TraceValueNode", "validation:TraceValue"], "negated":false,"actual": gen_x_check_2,"expected": "[\"publish\",\"subscribe\",\"1\",\"2\"]"})
-  matches := error("validation1",x,"This is the message",[_result_0])
+  target_class[x] with data.class as "http://a.ml/vocabularies/shapes#ScalarShape"
+  #  querying path: apiContract.endpoint / apiExt.wadus
+  gen_path_set_rule_1As = gen_path_set_rule_1 with data.sourceNode as x
+  #  querying path: shacl.maxLength
+  gen_path_set_rule_2Bs = gen_path_set_rule_2 with data.sourceNode as x
+  gen_path_set_rule_1A = gen_path_set_rule_1As[_]
+  gen_path_set_rule_2B = gen_path_set_rule_2Bs[_]
+  not gen_path_set_rule_1A < gen_path_set_rule_2B
+  _result_0 := trace("lessThan","http://a.ml/vocabularies/apiContract#endpoint / http://a.ml/vocabularies/api-extension#wadus",x,{"@type": ["reportSchema:TraceValueNode", "validation:TraceValue"], "negated":false, "condition":"<","expected":gen_path_set_rule_1A, "actual":gen_path_set_rule_2B})
+  matches := error("test-min-length",x,"Min length must be less than max length must match in scalar",[_result_0])
 }
 
 violation[matches] {
-  target_class[x] with data.class as "http://a.ml/vocabularies/apiContract#Operation"
-  #  querying path: shacl.name
-  gen_propValues_4 = gen_path_set_rule_5 with data.sourceNode as x
-  not count(gen_propValues_4) <= 1
-  _result_0 := trace("maxCount","http://www.w3.org/ns/shacl#name",x,{"@type": ["reportSchema:TraceValueNode", "validation:TraceValue"], "negated":false,"condition":"<=","actual": count(gen_propValues_4),"expected": 1})
-  matches := error("validation1",x,"This is the message",[_result_0])
-}
-
-violation[matches] {
-  target_class[x] with data.class as "http://a.ml/vocabularies/apiContract#Operation"
-  #  querying path: apiContract.method
-  gen_propValues_6 = gen_path_set_rule_7 with data.sourceNode as x
-  not count(gen_propValues_6) >= 1
-  _result_0 := trace("minCount","http://a.ml/vocabularies/apiContract#method",x,{"@type": ["reportSchema:TraceValueNode", "validation:TraceValue"], "negated":false,"condition":">=","actual": count(gen_propValues_6),"expected": 1})
-  matches := error("validation1",x,"This is the message",[_result_0])
-}
-
-violation[matches] {
-  target_class[x] with data.class as "http://a.ml/vocabularies/apiContract#Operation"
-  #  querying path: shacl.name
-  gen_gen_path_set_rule_8_node_9_array = gen_path_set_rule_8 with data.sourceNode as x
-  gen_gen_path_set_rule_8_node_9 = gen_gen_path_set_rule_8_node_9_array[_]
-  not regex.match(`^put|post$`,gen_gen_path_set_rule_8_node_9)
-  _result_0 := trace("pattern","http://www.w3.org/ns/shacl#name",x,{"@type": ["reportSchema:TraceValueNode", "validation:TraceValue"], "negated":false,"argument": gen_gen_path_set_rule_8_node_9})
-  matches := error("validation1",x,"This is the message",[_result_0])
+  target_class[x] with data.class as "http://a.ml/vocabularies/shapes#ScalarShape"
+  #  querying path: apiExt.wadus
+  gen_path_set_rule_3As = gen_path_set_rule_3 with data.sourceNode as x
+  #  querying path: shacl.maxLength
+  gen_path_set_rule_4Bs = gen_path_set_rule_4 with data.sourceNode as x
+  gen_path_set_rule_3A = gen_path_set_rule_3As[_]
+  gen_path_set_rule_4B = gen_path_set_rule_4Bs[_]
+  not gen_path_set_rule_3A < gen_path_set_rule_4B
+  _result_0 := trace("lessThan","http://a.ml/vocabularies/api-extension#wadus",x,{"@type": ["reportSchema:TraceValueNode", "validation:TraceValue"], "negated":false, "condition":"<","expected":gen_path_set_rule_3A, "actual":gen_path_set_rule_4B})
+  matches := error("test-min-length",x,"Min length must be less than max length must match in scalar",[_result_0])
 }

--- a/test/data/basic/profile6b.rego
+++ b/test/data/basic/profile6b.rego
@@ -1,6 +1,6 @@
-package profile_test13
+package profile_test6
 
-report["profile"] = "Test13"
+report["profile"] = "Test6"
 
 # Finds a node in the graph, following a link in the flatten JSON-LD node
 find = node {
@@ -294,83 +294,62 @@ default info = []
 
 gen_path_set_rule_1[nodes] {
   init_x_0 = data.sourceNode
-  tmp_x_0 = nested_nodes with data.nodes as init_x_0["http://a.ml/vocabularies/apiContract#returns"]
+  tmp_x_0 = nested_nodes with data.nodes as init_x_0["http://a.ml/vocabularies/apiContract#endpoint"]
   x_0 = tmp_x_0[_][_]
+  tmp_x_2 = gen_path_extension with data.custom_property_data as [x_0, "wadus"]
+  tmp2_x_2 = tmp_x_2[_][_]
+  x_2 = object.get(tmp2_x_2,"@id","")
+  nodes = x_2
+}
+
+gen_path_set_rule_2[nodes] {
+  init_x_0 = data.sourceNode
+  nodes_tmp = object.get(init_x_0,"http://www.w3.org/ns/shacl#maxLength",[])
+  nodes_tmp2 = nodes_array with data.nodes as nodes_tmp
+  x_0 = nodes_tmp2[_]
+  nodes = x_0
+}
+
+gen_path_set_rule_3[nodes] {
+  init_x_0 = data.sourceNode
+  tmp_x_0 = gen_path_extension with data.custom_property_data as [init_x_0, "wadus"]
+  tmp2_x_0 = tmp_x_0[_][_]
+  x_0 = object.get(tmp2_x_0,"@id","")
   nodes = x_0
 }
 
 gen_path_set_rule_4[nodes] {
-  init_y_0 = data.sourceNode
-  nodes_tmp = object.get(init_y_0,"http://a.ml/vocabularies/apiContract#statusCode",[])
-  nodes_tmp2 = nodes_array with data.nodes as nodes_tmp
-  y_0 = nodes_tmp2[_]
-  nodes = y_0
-}
-
-gen_path_set_rule_5[nodes] {
   init_x_0 = data.sourceNode
-  tmp_x_0 = nested_nodes with data.nodes as init_x_0["http://a.ml/vocabularies/apiContract#returns"]
-  x_0 = tmp_x_0[_][_]
-  nodes = x_0
-}
-
-gen_path_set_rule_8[nodes] {
-  init_z_0 = data.sourceNode
-  nodes_tmp = object.get(init_z_0,"http://a.ml/vocabularies/apiContract#statusCode",[])
+  nodes_tmp = object.get(init_x_0,"http://www.w3.org/ns/shacl#maxLength",[])
   nodes_tmp2 = nodes_array with data.nodes as nodes_tmp
-  z_0 = nodes_tmp2[_]
-  nodes = z_0
+  x_0 = nodes_tmp2[_]
+  nodes = x_0
 }
 
 # Constraint rules
 
 violation[matches] {
-  target_class[x] with data.class as "http://a.ml/vocabularies/apiContract#Operation"
-  #  querying path: apiContract.returns
-  ys = gen_path_set_rule_1 with data.sourceNode as x
-  y_errorAcc0 = []
-  ys_br_0 = [ ys_br_0_error|
-    y = ys[_]
-    #  querying path: apiContract.statusCode
-    gen_y_check_3_array = gen_path_set_rule_4 with data.sourceNode as y
-    gen_y_check_3_scalar = gen_y_check_3_array[_]
-    gen_y_check_3 = as_string(gen_y_check_3_scalar)
-    gen_inValues_2 = { "200"}
-    not gen_inValues_2[gen_y_check_3]
-    _result_0 := trace("in","http://a.ml/vocabularies/apiContract#statusCode",y,{"@type": ["reportSchema:TraceValueNode", "validation:TraceValue"], "negated":false,"actual": gen_y_check_3,"expected": "[\"200\"]"})
-    ys_br_0_inner_error := error("nested",y,"error in nested nodes under http://a.ml/vocabularies/apiContract#returns",[_result_0])
-    ys_br_0_error = [y["@id"],ys_br_0_inner_error]
-  ]
-  ys_br_0_errors = { nodeId | n = ys_br_0[_]; nodeId = n[0] }
-  ys_br_0_errors_errors = [ node | n = ys_br_0[_]; node = n[1] ]
-  y_errorAcc1 = array.concat(y_errorAcc0,ys_br_0_errors_errors)
-  y_errorAcc = y_errorAcc1
-  # let's accumulate results
-  ys_error_node_variables_agg = ys_br_0_errors
-  not count(ys) - count(ys_error_node_variables_agg) >= 1
-  _result_0 := trace("atLeast","http://a.ml/vocabularies/apiContract#returns",x,{"@type": ["reportSchema:TraceValueNode", "validation:TraceValue"], "negated":false, "failedNodes":count(ys_error_node_variables_agg), "successfulNodes":(count(ys)-count(ys_error_node_variables_agg)), "cardinality":1, "subResult": y_errorAcc})
-  #  querying path: apiContract.returns
-  zs = gen_path_set_rule_5 with data.sourceNode as x
-  z_errorAcc0 = []
-  zs_br_0 = [ zs_br_0_error|
-    z = zs[_]
-    #  querying path: apiContract.statusCode
-    gen_z_check_7_array = gen_path_set_rule_8 with data.sourceNode as z
-    gen_z_check_7_scalar = gen_z_check_7_array[_]
-    gen_z_check_7 = as_string(gen_z_check_7_scalar)
-    gen_inValues_6 = { "429"}
-    not gen_inValues_6[gen_z_check_7]
-    _result_0 := trace("in","http://a.ml/vocabularies/apiContract#statusCode",z,{"@type": ["reportSchema:TraceValueNode", "validation:TraceValue"], "negated":false,"actual": gen_z_check_7,"expected": "[\"429\"]"})
-    zs_br_0_inner_error := error("nested",z,"error in nested nodes under http://a.ml/vocabularies/apiContract#returns",[_result_0])
-    zs_br_0_error = [z["@id"],zs_br_0_inner_error]
-  ]
-  zs_br_0_errors = { nodeId | n = zs_br_0[_]; nodeId = n[0] }
-  zs_br_0_errors_errors = [ node | n = zs_br_0[_]; node = n[1] ]
-  z_errorAcc1 = array.concat(z_errorAcc0,zs_br_0_errors_errors)
-  z_errorAcc = z_errorAcc1
-  # let's accumulate results
-  zs_error_node_variables_agg = zs_br_0_errors
-  not count(zs) - count(zs_error_node_variables_agg) >= 1
-  _result_1 := trace("atLeast","http://a.ml/vocabularies/apiContract#returns",x,{"@type": ["reportSchema:TraceValueNode", "validation:TraceValue"], "negated":false, "failedNodes":count(zs_error_node_variables_agg), "successfulNodes":(count(zs)-count(zs_error_node_variables_agg)), "cardinality":1, "subResult": z_errorAcc})
-  matches := error("lack-of-resources-and-rate-limiting-too-many-requests",x,"Notify the client when the limit is exceeded by providing the limit number and the time at which the limit will\nbe reset.\n",[_result_0,_result_1])
+  target_class[x] with data.class as "http://a.ml/vocabularies/shapes#ScalarShape"
+  #  querying path: apiContract.endpoint / apiExt.wadus
+  gen_path_set_rule_1As = gen_path_set_rule_1 with data.sourceNode as x
+  #  querying path: shacl.maxLength
+  gen_path_set_rule_2Bs = gen_path_set_rule_2 with data.sourceNode as x
+  gen_path_set_rule_1A = gen_path_set_rule_1As[_]
+  gen_path_set_rule_2B = gen_path_set_rule_2Bs[_]
+  not gen_path_set_rule_1A < gen_path_set_rule_2B
+  _result_0 := trace("lessThan","http://a.ml/vocabularies/apiContract#endpoint / http://a.ml/vocabularies/api-extension#wadus",x,{"@type": ["reportSchema:TraceValueNode", "validation:TraceValue"], "negated":false, "condition":"<","expected":gen_path_set_rule_1A, "actual":gen_path_set_rule_2B})
+  matches := error("test-min-length",x,"Min length must be less than max length must match in scalar",[_result_0])
+}
+
+violation[matches] {
+  target_class[x] with data.class as "http://a.ml/vocabularies/shapes#ScalarShape"
+  #  querying path: apiExt.wadus
+  gen_path_set_rule_3As = gen_path_set_rule_3 with data.sourceNode as x
+  #  querying path: shacl.maxLength
+  gen_path_set_rule_4Bs = gen_path_set_rule_4 with data.sourceNode as x
+  gen_path_set_rule_3A = gen_path_set_rule_3As[_]
+  gen_path_set_rule_4B = gen_path_set_rule_4Bs[_]
+  not gen_path_set_rule_3A < gen_path_set_rule_4B
+  _result_0 := trace("lessThan","http://a.ml/vocabularies/api-extension#wadus",x,{"@type": ["reportSchema:TraceValueNode", "validation:TraceValue"], "negated":false, "condition":"<","expected":gen_path_set_rule_3A, "actual":gen_path_set_rule_4B})
+  matches := error("test-min-length",x,"Min length must be less than max length must match in scalar",[_result_0])
 }

--- a/test/data/basic/profile6b.rego
+++ b/test/data/basic/profile6b.rego
@@ -46,6 +46,19 @@ search_subjects[valid_subject] {
   valid_subject = node
 }
 
+search_custom_property_subjects[valid_subject] {
+  extension = data.property_extension
+  object = data.object
+  
+  object["http://a.ml/vocabularies/core#extensionName"] = extension
+  object_id = object["@id"]
+  
+  node = input["@ids"][_]
+  
+  node[prop] = {"@id": object_id}
+  valid_subject = node
+}
+
 # collection functions
 
 # collect next set of nodes

--- a/test/data/basic/profile6b.yaml
+++ b/test/data/basic/profile6b.yaml
@@ -1,0 +1,16 @@
+#%Validation Profile 1.0
+
+profile: Test6
+
+violation:
+  - test-min-length
+
+validations:
+  test-min-length:
+    targetClass: raml-shapes.ScalarShape
+    message: Min length must be less than max length must match in scalar
+    propertyConstraints:
+      apiExt.wadus:
+        lessThanProperty: shacl.maxLength
+      apiContract.endpoint / apiExt.wadus :
+        lessThanProperty: shacl.maxLength

--- a/test/data/basic/profile7.rego
+++ b/test/data/basic/profile7.rego
@@ -46,6 +46,19 @@ search_subjects[valid_subject] {
   valid_subject = node
 }
 
+search_custom_property_subjects[valid_subject] {
+  extension = data.property_extension
+  object = data.object
+  
+  object["http://a.ml/vocabularies/core#extensionName"] = extension
+  object_id = object["@id"]
+  
+  node = input["@ids"][_]
+  
+  node[prop] = {"@id": object_id}
+  valid_subject = node
+}
+
 # collection functions
 
 # collect next set of nodes
@@ -138,6 +151,27 @@ as_string(x) = x["@id"] {
 as_string(x) = json.marshal(x) {
   is_object(x)
   not x["@id"]
+}
+
+# Finds a nested custom domain property for a given node an custom domain property name
+gen_path_extension[nodes] {
+  sourceNode := data.custom_property_data[0]
+  extensionName := data.custom_property_data[1]
+  customPropertiesTarget := object.get(sourceNode, "http://a.ml/vocabularies/document#customDomainProperties", [])
+  customProperties = nodes_array with data.nodes as customPropertiesTarget
+  extensionFound = [found |
+    annotationLink = customProperties[_]
+    annotationLinkId = annotationLink["@id"]
+    annotation = object.get(sourceNode, annotationLinkId, {})
+    annotationNode = find with data.link as annotation
+  
+    name = annotationNode["http://a.ml/vocabularies/core#extensionName"]
+    name = extensionName
+  
+    found = annotationNode
+  ]
+  
+  nodes = extensionFound
 }
 
 #creates an array from a comma separated values str

--- a/test/data/basic/profile7.rego
+++ b/test/data/basic/profile7.rego
@@ -46,6 +46,19 @@ search_subjects[valid_subject] {
   valid_subject = node
 }
 
+search_custom_property_subjects[valid_subject] {
+  extension = data.property_extension
+  object = data.object
+  
+  object["http://a.ml/vocabularies/core#extensionName"] = extension
+  object_id = object["@id"]
+  
+  node = input["@ids"][_]
+  
+  node[prop] = {"@id": object_id}
+  valid_subject = node
+}
+
 # collection functions
 
 # collect next set of nodes

--- a/test/data/basic/profile7.rego
+++ b/test/data/basic/profile7.rego
@@ -140,6 +140,27 @@ as_string(x) = json.marshal(x) {
   not x["@id"]
 }
 
+# Finds a nested custom domain property for a given node an custom domain property name
+gen_path_extension[nodes] {
+  sourceNode := data.custom_property_data[0]
+  extensionName := data.custom_property_data[1]
+  customPropertiesTarget := object.get(sourceNode, "http://a.ml/vocabularies/document#customDomainProperties", [])
+  customProperties = nodes_array with data.nodes as customPropertiesTarget
+  extensionFound = [found |
+    annotationLink = customProperties[_]
+    annotationLinkId = annotationLink["@id"]
+    annotation = object.get(sourceNode, annotationLinkId, {})
+    annotationNode = find with data.link as annotation
+  
+    name = annotationNode["http://a.ml/vocabularies/core#extensionName"]
+    name = extensionName
+  
+    found = annotationNode
+  ]
+  
+  nodes = extensionFound
+}
+
 #creates an array from a comma separated values str
 split_values[values] {
    values := split(data.nodes, ",")

--- a/test/data/basic/profile8.rego
+++ b/test/data/basic/profile8.rego
@@ -46,6 +46,19 @@ search_subjects[valid_subject] {
   valid_subject = node
 }
 
+search_custom_property_subjects[valid_subject] {
+  extension = data.property_extension
+  object = data.object
+  
+  object["http://a.ml/vocabularies/core#extensionName"] = extension
+  object_id = object["@id"]
+  
+  node = input["@ids"][_]
+  
+  node[prop] = {"@id": object_id}
+  valid_subject = node
+}
+
 # collection functions
 
 # collect next set of nodes
@@ -138,6 +151,27 @@ as_string(x) = x["@id"] {
 as_string(x) = json.marshal(x) {
   is_object(x)
   not x["@id"]
+}
+
+# Finds a nested custom domain property for a given node an custom domain property name
+gen_path_extension[nodes] {
+  sourceNode := data.custom_property_data[0]
+  extensionName := data.custom_property_data[1]
+  customPropertiesTarget := object.get(sourceNode, "http://a.ml/vocabularies/document#customDomainProperties", [])
+  customProperties = nodes_array with data.nodes as customPropertiesTarget
+  extensionFound = [found |
+    annotationLink = customProperties[_]
+    annotationLinkId = annotationLink["@id"]
+    annotation = object.get(sourceNode, annotationLinkId, {})
+    annotationNode = find with data.link as annotation
+  
+    name = annotationNode["http://a.ml/vocabularies/core#extensionName"]
+    name = extensionName
+  
+    found = annotationNode
+  ]
+  
+  nodes = extensionFound
 }
 
 #creates an array from a comma separated values str

--- a/test/data/basic/profile8.rego
+++ b/test/data/basic/profile8.rego
@@ -46,6 +46,19 @@ search_subjects[valid_subject] {
   valid_subject = node
 }
 
+search_custom_property_subjects[valid_subject] {
+  extension = data.property_extension
+  object = data.object
+  
+  object["http://a.ml/vocabularies/core#extensionName"] = extension
+  object_id = object["@id"]
+  
+  node = input["@ids"][_]
+  
+  node[prop] = {"@id": object_id}
+  valid_subject = node
+}
+
 # collection functions
 
 # collect next set of nodes

--- a/test/data/basic/profile8.rego
+++ b/test/data/basic/profile8.rego
@@ -140,6 +140,27 @@ as_string(x) = json.marshal(x) {
   not x["@id"]
 }
 
+# Finds a nested custom domain property for a given node an custom domain property name
+gen_path_extension[nodes] {
+  sourceNode := data.custom_property_data[0]
+  extensionName := data.custom_property_data[1]
+  customPropertiesTarget := object.get(sourceNode, "http://a.ml/vocabularies/document#customDomainProperties", [])
+  customProperties = nodes_array with data.nodes as customPropertiesTarget
+  extensionFound = [found |
+    annotationLink = customProperties[_]
+    annotationLinkId = annotationLink["@id"]
+    annotation = object.get(sourceNode, annotationLinkId, {})
+    annotationNode = find with data.link as annotation
+  
+    name = annotationNode["http://a.ml/vocabularies/core#extensionName"]
+    name = extensionName
+  
+    found = annotationNode
+  ]
+  
+  nodes = extensionFound
+}
+
 #creates an array from a comma separated values str
 split_values[values] {
    values := split(data.nodes, ",")

--- a/test/data/basic/profile9.rego
+++ b/test/data/basic/profile9.rego
@@ -46,6 +46,19 @@ search_subjects[valid_subject] {
   valid_subject = node
 }
 
+search_custom_property_subjects[valid_subject] {
+  extension = data.property_extension
+  object = data.object
+  
+  object["http://a.ml/vocabularies/core#extensionName"] = extension
+  object_id = object["@id"]
+  
+  node = input["@ids"][_]
+  
+  node[prop] = {"@id": object_id}
+  valid_subject = node
+}
+
 # collection functions
 
 # collect next set of nodes
@@ -138,6 +151,27 @@ as_string(x) = x["@id"] {
 as_string(x) = json.marshal(x) {
   is_object(x)
   not x["@id"]
+}
+
+# Finds a nested custom domain property for a given node an custom domain property name
+gen_path_extension[nodes] {
+  sourceNode := data.custom_property_data[0]
+  extensionName := data.custom_property_data[1]
+  customPropertiesTarget := object.get(sourceNode, "http://a.ml/vocabularies/document#customDomainProperties", [])
+  customProperties = nodes_array with data.nodes as customPropertiesTarget
+  extensionFound = [found |
+    annotationLink = customProperties[_]
+    annotationLinkId = annotationLink["@id"]
+    annotation = object.get(sourceNode, annotationLinkId, {})
+    annotationNode = find with data.link as annotation
+  
+    name = annotationNode["http://a.ml/vocabularies/core#extensionName"]
+    name = extensionName
+  
+    found = annotationNode
+  ]
+  
+  nodes = extensionFound
 }
 
 #creates an array from a comma separated values str

--- a/test/data/basic/profile9.rego
+++ b/test/data/basic/profile9.rego
@@ -46,6 +46,19 @@ search_subjects[valid_subject] {
   valid_subject = node
 }
 
+search_custom_property_subjects[valid_subject] {
+  extension = data.property_extension
+  object = data.object
+  
+  object["http://a.ml/vocabularies/core#extensionName"] = extension
+  object_id = object["@id"]
+  
+  node = input["@ids"][_]
+  
+  node[prop] = {"@id": object_id}
+  valid_subject = node
+}
+
 # collection functions
 
 # collect next set of nodes

--- a/test/data/basic/profile9.rego
+++ b/test/data/basic/profile9.rego
@@ -140,6 +140,27 @@ as_string(x) = json.marshal(x) {
   not x["@id"]
 }
 
+# Finds a nested custom domain property for a given node an custom domain property name
+gen_path_extension[nodes] {
+  sourceNode := data.custom_property_data[0]
+  extensionName := data.custom_property_data[1]
+  customPropertiesTarget := object.get(sourceNode, "http://a.ml/vocabularies/document#customDomainProperties", [])
+  customProperties = nodes_array with data.nodes as customPropertiesTarget
+  extensionFound = [found |
+    annotationLink = customProperties[_]
+    annotationLinkId = annotationLink["@id"]
+    annotation = object.get(sourceNode, annotationLinkId, {})
+    annotationNode = find with data.link as annotation
+  
+    name = annotationNode["http://a.ml/vocabularies/core#extensionName"]
+    name = extensionName
+  
+    found = annotationNode
+  ]
+  
+  nodes = extensionFound
+}
+
 #creates an array from a comma separated values str
 split_values[values] {
    values := split(data.nodes, ",")

--- a/test/data/integration/profile18/negative.data.jsonld
+++ b/test/data/integration/profile18/negative.data.jsonld
@@ -1,0 +1,87 @@
+{
+  "@context": {
+    "@base": "amf://id#",
+    "data": "http://a.ml/vocabularies/data#",
+    "shacl": "http://www.w3.org/ns/shacl#",
+    "shapes": "http://a.ml/vocabularies/shapes#",
+    "doc": "http://a.ml/vocabularies/document#",
+    "meta": "http://a.ml/vocabularies/meta#",
+    "apiContract": "http://a.ml/vocabularies/apiContract#",
+    "core": "http://a.ml/vocabularies/core#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "security": "http://a.ml/vocabularies/security#",
+    "sourcemaps": "http://a.ml/vocabularies/document-source-maps#"
+  },
+  "@graph": [
+    {
+      "@id": "./",
+      "@type": [
+        "doc:Document",
+        "doc:Fragment",
+        "doc:Module",
+        "doc:Unit"
+      ],
+      "doc:declares": {
+        "@id": "#1",
+        "@type": [
+          "doc:DomainProperty",
+          "rdf:Property",
+          "doc:DomainElement"
+        ],
+        "core:name": "wadus2",
+        "shapes:schema": {
+          "@id": "#2",
+          "@type": [
+            "shapes:ScalarShape",
+            "shapes:AnyShape",
+            "shacl:Shape",
+            "shapes:Shape",
+            "doc:DomainElement"
+          ],
+          "shacl:datatype": {
+            "@id": "xsd:boolean"
+          },
+          "shacl:name": "schema"
+        }
+      },
+      "doc:encodes": {
+        "@id": "#4",
+        "@type": [
+          "apiContract:WebAPI",
+          "apiContract:API",
+          "doc:RootDomainElement",
+          "doc:DomainElement"
+        ],
+        "amf://id#1": {
+          "@id": "#6",
+          "@type": [
+            "data:Scalar",
+            "data:Node",
+            "doc:DomainElement"
+          ],
+          "core:extensionName": "wadus2",
+          "core:name": "scalar_1",
+          "data:value": "true",
+          "shacl:datatype": {
+            "@id": "xsd:boolean"
+          }
+        },
+        "core:name": "example api",
+        "core:version": "1.0.0",
+        "doc:customDomainProperties": {
+          "@id": "#1"
+        }
+      },
+      "doc:processingData": {
+        "@id": "#3",
+        "@type": "doc:APIContractProcessingData",
+        "apiContract:modelVersion": "3.6.0",
+        "doc:sourceSpec": "RAML 1.0",
+        "doc:transformed": true
+      },
+      "doc:root": true
+    }
+  ]
+}

--- a/test/data/integration/profile18/negative.data.yaml
+++ b/test/data/integration/profile18/negative.data.yaml
@@ -1,0 +1,9 @@
+#%RAML 1.0
+title: example api
+version: 1.0.0
+
+annotationTypes:
+  wadus2:
+    type: boolean
+
+(wadus2): true

--- a/test/data/integration/profile18/negative.report.jsonld
+++ b/test/data/integration/profile18/negative.report.jsonld
@@ -1,0 +1,148 @@
+[
+  {
+    "@context": {
+      "actual": {
+        "@id": "http://a.ml/vocabularies/validation#actual"
+      },
+      "argument": {
+        "@id": "http://a.ml/vocabularies/validation#argument"
+      },
+      "column": {
+        "@id": "http://a.ml/vocabularies/lexical#column"
+      },
+      "component": {
+        "@id": "http://a.ml/vocabularies/validation#component"
+      },
+      "condition": {
+        "@id": "http://a.ml/vocabularies/validation#condition"
+      },
+      "conforms": {
+        "@id": "http://www.w3.org/ns/shacl#conforms"
+      },
+      "doc": "http://a.ml/vocabularies/document#",
+      "end": {
+        "@id": "http://a.ml/vocabularies/lexical#end"
+      },
+      "expected": {
+        "@id": "http://a.ml/vocabularies/validation#expected"
+      },
+      "focusNode": {
+        "@id": "http://www.w3.org/ns/shacl#focusNode"
+      },
+      "lexical": "http://a.ml/vocabularies/lexical#",
+      "lexicalSchema": "file:///dialects/lexical.yaml#/declarations/",
+      "line": {
+        "@id": "http://a.ml/vocabularies/lexical#line"
+      },
+      "location": {
+        "@id": "http://a.ml/vocabularies/validation#location"
+      },
+      "meta": "http://a.ml/vocabularies/meta#",
+      "negated": {
+        "@id": "http://a.ml/vocabularies/validation#negated"
+      },
+      "profileName": {
+        "@id": "http://a.ml/vocabularies/validation#profileName"
+      },
+      "range": {
+        "@id": "http://a.ml/vocabularies/lexical#range"
+      },
+      "reportSchema": "file:///dialects/validation-report.yaml#/declarations/",
+      "result": {
+        "@id": "http://www.w3.org/ns/shacl#result"
+      },
+      "resultMessage": {
+        "@id": "http://www.w3.org/ns/shacl#resultMessage"
+      },
+      "resultPath": {
+        "@id": "http://www.w3.org/ns/shacl#resultPath"
+      },
+      "resultSeverity": {
+        "@id": "http://www.w3.org/ns/shacl#resultSeverity"
+      },
+      "shacl": "http://www.w3.org/ns/shacl#",
+      "sourceShapeName": {
+        "@id": "http://a.ml/vocabularies/validation#sourceShapeName"
+      },
+      "start": {
+        "@id": "http://a.ml/vocabularies/lexical#start"
+      },
+      "subResult": {
+        "@id": "http://a.ml/vocabularies/validation#subResult"
+      },
+      "trace": {
+        "@id": "http://a.ml/vocabularies/validation#trace"
+      },
+      "traceValue": {
+        "@id": "http://www.w3.org/ns/shacl#traceValue"
+      },
+      "uri": {
+        "@id": "http://a.ml/vocabularies/lexical#uri"
+      },
+      "validation": "http://a.ml/vocabularies/validation#"
+    },
+    "@id": "dialect-instance",
+    "@type": [
+      "meta:DialectInstance",
+      "doc:Document",
+      "doc:Fragment",
+      "doc:Module",
+      "doc:Unit"
+    ],
+    "doc:encodes": [
+      {
+        "@id": "validation-report",
+        "@type": [
+          "reportSchema:ReportNode",
+          "shacl:ValidationReport"
+        ],
+        "conforms": false,
+        "profileName": "salesforce-aips/annotations",
+        "result": [
+          {
+            "@id": "violation_0",
+            "@type": [
+              "reportSchema:ValidationResultNode",
+              "shacl:ValidationResult"
+            ],
+            "focusNode": "amf://id#4",
+            "resultMessage": "wadus is a mandatory extension",
+            "resultSeverity": "http://www.w3.org/ns/shacl#Violation",
+            "sourceShapeName": "annotations",
+            "trace": [
+              {
+                "@id": "violation_0_0",
+                "@type": [
+                  "reportSchema:TraceMessageNode",
+                  "validation:TraceMessage"
+                ],
+                "component": "minCount",
+                "resultPath": "http://a.ml/vocabularies/api-extension#wadus",
+                "traceValue": {
+                  "@id": "violation_0_0_traceValue",
+                  "@type": [
+                    "reportSchema:TraceValueNode",
+                    "validation:TraceValue"
+                  ],
+                  "actual": 0,
+                  "condition": ">=",
+                  "expected": 1,
+                  "negated": false
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "doc:processingData": [
+      {
+        "@id": "processing-data",
+        "@type": [
+          "doc:DialectInstanceProcessingData"
+        ],
+        "doc:sourceSpec": "Validation Report 1.0"
+      }
+    ]
+  }
+]

--- a/test/data/integration/profile18/positive.data.jsonld
+++ b/test/data/integration/profile18/positive.data.jsonld
@@ -1,0 +1,144 @@
+{
+  "@context": {
+    "@base": "amf://id#",
+    "data": "http://a.ml/vocabularies/data#",
+    "shacl": "http://www.w3.org/ns/shacl#",
+    "shapes": "http://a.ml/vocabularies/shapes#",
+    "doc": "http://a.ml/vocabularies/document#",
+    "meta": "http://a.ml/vocabularies/meta#",
+    "apiContract": "http://a.ml/vocabularies/apiContract#",
+    "core": "http://a.ml/vocabularies/core#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "security": "http://a.ml/vocabularies/security#",
+    "sourcemaps": "http://a.ml/vocabularies/document-source-maps#"
+  },
+  "@graph": [
+    {
+      "@id": "./",
+      "@type": [
+        "doc:Document",
+        "doc:Fragment",
+        "doc:Module",
+        "doc:Unit"
+      ],
+      "doc:encodes": {
+        "@id": "#2",
+        "@type": [
+          "apiContract:WebAPI",
+          "apiContract:API",
+          "doc:RootDomainElement",
+          "doc:DomainElement"
+        ],
+        "amf://id#10": {
+          "@id": "#4",
+          "@type": [
+            "data:Object",
+            "data:Node",
+            "doc:DomainElement"
+          ],
+          "core:extensionName": "wadus",
+          "core:name": "object_1",
+          "data:hola": {
+            "@id": "#5",
+            "@type": [
+              "data:Scalar",
+              "data:Node",
+              "doc:DomainElement"
+            ],
+            "core:name": "hola",
+            "data:value": "mundo",
+            "shacl:datatype": {
+              "@id": "xsd:string"
+            }
+          },
+          "data:things": {
+            "@id": "#6",
+            "@type": [
+              "data:Array",
+              "rdf:Seq",
+              "data:Node",
+              "doc:DomainElement"
+            ],
+            "core:name": "things",
+            "http://www.w3.org/2000/01/rdf-schema#member": [
+              {
+                "@id": "#7",
+                "@type": [
+                  "data:Scalar",
+                  "data:Node",
+                  "doc:DomainElement"
+                ],
+                "core:name": "scalar_4",
+                "data:value": "1",
+                "shacl:datatype": {
+                  "@id": "xsd:integer"
+                }
+              },
+              {
+                "@id": "#8",
+                "@type": [
+                  "data:Scalar",
+                  "data:Node",
+                  "doc:DomainElement"
+                ],
+                "core:name": "scalar_5",
+                "data:value": "2",
+                "shacl:datatype": {
+                  "@id": "xsd:integer"
+                }
+              },
+              {
+                "@id": "#9",
+                "@type": [
+                  "data:Scalar",
+                  "data:Node",
+                  "doc:DomainElement"
+                ],
+                "core:name": "scalar_6",
+                "data:value": "3",
+                "shacl:datatype": {
+                  "@id": "xsd:integer"
+                }
+              }
+            ]
+          }
+        },
+        "amf://id#13": {
+          "@id": "#12",
+          "@type": [
+            "data:Scalar",
+            "data:Node",
+            "doc:DomainElement"
+          ],
+          "core:extensionName": "scalar",
+          "core:name": "scalar_1",
+          "data:value": "true",
+          "shacl:datatype": {
+            "@id": "xsd:boolean"
+          }
+        },
+        "apiContract:endpoint": [],
+        "core:name": "example API",
+        "core:version": "1.0.0",
+        "doc:customDomainProperties": [
+          {
+            "@id": "#13"
+          },
+          {
+            "@id": "#10"
+          }
+        ]
+      },
+      "doc:processingData": {
+        "@id": "#1",
+        "@type": "doc:APIContractProcessingData",
+        "apiContract:modelVersion": "3.6.0",
+        "doc:sourceSpec": "OAS 3.0",
+        "doc:transformed": true
+      },
+      "doc:root": true
+    }
+  ]
+}

--- a/test/data/integration/profile18/positive.data.yaml
+++ b/test/data/integration/profile18/positive.data.yaml
@@ -1,0 +1,12 @@
+openapi: "3.0.0"
+info:
+  title: example API
+  version: "1.0.0"
+paths: {}
+x-wadus:
+  hola: mundo
+  things:
+    - 1
+    - 2
+    - 3
+x-scalar: true

--- a/test/data/integration/profile18/positive.report.jsonld
+++ b/test/data/integration/profile18/positive.report.jsonld
@@ -1,0 +1,41 @@
+[
+  {
+    "@context": {
+      "conforms": {
+        "@id": "http://www.w3.org/ns/shacl#conforms"
+      },
+      "doc": "http://a.ml/vocabularies/document#",
+      "meta": "http://a.ml/vocabularies/meta#",
+      "reportSchema": "file:///dialects/validation-report.yaml#/declarations/",
+      "shacl": "http://www.w3.org/ns/shacl#"
+    },
+    "@id": "dialect-instance",
+    "@type": [
+      "meta:DialectInstance",
+      "doc:Document",
+      "doc:Fragment",
+      "doc:Module",
+      "doc:Unit"
+    ],
+    "doc:encodes": [
+      {
+        "@id": "validation-report",
+        "@type": [
+          "reportSchema:ReportNode",
+          "shacl:ValidationReport"
+        ],
+        "conforms": true,
+        "profileName": "salesforce-aips/annotations"
+      }
+    ],
+    "doc:processingData": [
+      {
+        "@id": "processing-data",
+        "@type": [
+          "doc:DialectInstanceProcessingData"
+        ],
+        "doc:sourceSpec": "Validation Report 1.0"
+      }
+    ]
+  }
+]

--- a/test/data/integration/profile18/profile.yaml
+++ b/test/data/integration/profile18/profile.yaml
@@ -1,0 +1,12 @@
+#%Validation Profile 1.0
+
+profile: salesforce-aips/annotations
+violation:
+  - annotations
+validations:
+  annotations:
+    message: wadus is a mandatory extension
+    targetClass: apiContract.WebAPI
+    propertyConstraints:
+      apiExt.wadus:
+        minCount: 1

--- a/test/data/integration/profile19/negative.data.jsonld
+++ b/test/data/integration/profile19/negative.data.jsonld
@@ -1,0 +1,124 @@
+{
+  "@context": {
+    "@base": "amf://id#",
+    "data": "http://a.ml/vocabularies/data#",
+    "shacl": "http://www.w3.org/ns/shacl#",
+    "shapes": "http://a.ml/vocabularies/shapes#",
+    "doc": "http://a.ml/vocabularies/document#",
+    "meta": "http://a.ml/vocabularies/meta#",
+    "apiContract": "http://a.ml/vocabularies/apiContract#",
+    "core": "http://a.ml/vocabularies/core#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "security": "http://a.ml/vocabularies/security#",
+    "sourcemaps": "http://a.ml/vocabularies/document-source-maps#"
+  },
+  "@graph": [
+    {
+      "@id": "./",
+      "@type": [
+        "doc:Document",
+        "doc:Fragment",
+        "doc:Module",
+        "doc:Unit"
+      ],
+      "doc:encodes": {
+        "@id": "#2",
+        "@type": [
+          "apiContract:WebAPI",
+          "apiContract:API",
+          "doc:RootDomainElement",
+          "doc:DomainElement"
+        ],
+        "apiContract:endpoint": [
+          {
+            "@id": "#3",
+            "@type": [
+              "apiContract:EndPoint",
+              "doc:DomainElement"
+            ],
+            "apiContract:path": "/test",
+            "apiContract:supportedOperation": {
+              "@id": "#4",
+              "@type": [
+                "apiContract:Operation",
+                "core:Operation",
+                "doc:DomainElement"
+              ],
+              "amf://id#7": {
+                "@id": "#6",
+                "@type": [
+                  "data:Scalar",
+                  "data:Node",
+                  "doc:DomainElement"
+                ],
+                "core:extensionName": "wadus",
+                "core:name": "scalar_1",
+                "data:value": "false",
+                "shacl:datatype": {
+                  "@id": "xsd:boolean"
+                }
+              },
+              "apiContract:method": "get",
+              "apiContract:returns": {
+                "@id": "#8",
+                "@type": [
+                  "apiContract:Response",
+                  "core:Response",
+                  "apiContract:Message",
+                  "doc:DomainElement"
+                ],
+                "apiContract:statusCode": "200",
+                "core:description": "",
+                "core:name": "200"
+              },
+              "doc:customDomainProperties": {
+                "@id": "#7"
+              }
+            }
+          },
+          {
+            "@id": "#9",
+            "@type": [
+              "apiContract:EndPoint",
+              "doc:DomainElement"
+            ],
+            "apiContract:path": "/test2",
+            "apiContract:supportedOperation": {
+              "@id": "#10",
+              "@type": [
+                "apiContract:Operation",
+                "core:Operation",
+                "doc:DomainElement"
+              ],
+              "apiContract:method": "get",
+              "apiContract:returns": {
+                "@id": "#11",
+                "@type": [
+                  "apiContract:Response",
+                  "core:Response",
+                  "apiContract:Message",
+                  "doc:DomainElement"
+                ],
+                "apiContract:statusCode": "200",
+                "core:description": "",
+                "core:name": "200"
+              }
+            }
+          }
+        ],
+        "core:name": "example API",
+        "core:version": "1.0.0"
+      },
+      "doc:processingData": {
+        "@id": "#1",
+        "@type": "doc:APIContractProcessingData",
+        "apiContract:modelVersion": "3.6.0",
+        "doc:sourceSpec": "OAS 3.0",
+        "doc:transformed": true
+      },
+      "doc:root": true
+    }
+  ]
+}

--- a/test/data/integration/profile19/negative.data.yaml
+++ b/test/data/integration/profile19/negative.data.yaml
@@ -1,0 +1,18 @@
+openapi: "3.0.0"
+info:
+  title: example API
+  version: "1.0.0"
+paths:
+
+  /test:
+    get:
+      x-wadus: false
+      responses:
+        "200":
+          description: ""
+
+  /test2:
+    get:
+      responses:
+        "200":
+          description: ""

--- a/test/data/integration/profile19/negative.report.jsonld
+++ b/test/data/integration/profile19/negative.report.jsonld
@@ -1,0 +1,146 @@
+[
+  {
+    "@context": {
+      "actual": {
+        "@id": "http://a.ml/vocabularies/validation#actual"
+      },
+      "argument": {
+        "@id": "http://a.ml/vocabularies/validation#argument"
+      },
+      "column": {
+        "@id": "http://a.ml/vocabularies/lexical#column"
+      },
+      "component": {
+        "@id": "http://a.ml/vocabularies/validation#component"
+      },
+      "condition": {
+        "@id": "http://a.ml/vocabularies/validation#condition"
+      },
+      "conforms": {
+        "@id": "http://www.w3.org/ns/shacl#conforms"
+      },
+      "doc": "http://a.ml/vocabularies/document#",
+      "end": {
+        "@id": "http://a.ml/vocabularies/lexical#end"
+      },
+      "expected": {
+        "@id": "http://a.ml/vocabularies/validation#expected"
+      },
+      "focusNode": {
+        "@id": "http://www.w3.org/ns/shacl#focusNode"
+      },
+      "lexical": "http://a.ml/vocabularies/lexical#",
+      "lexicalSchema": "file:///dialects/lexical.yaml#/declarations/",
+      "line": {
+        "@id": "http://a.ml/vocabularies/lexical#line"
+      },
+      "location": {
+        "@id": "http://a.ml/vocabularies/validation#location"
+      },
+      "meta": "http://a.ml/vocabularies/meta#",
+      "negated": {
+        "@id": "http://a.ml/vocabularies/validation#negated"
+      },
+      "profileName": {
+        "@id": "http://a.ml/vocabularies/validation#profileName"
+      },
+      "range": {
+        "@id": "http://a.ml/vocabularies/lexical#range"
+      },
+      "reportSchema": "file:///dialects/validation-report.yaml#/declarations/",
+      "result": {
+        "@id": "http://www.w3.org/ns/shacl#result"
+      },
+      "resultMessage": {
+        "@id": "http://www.w3.org/ns/shacl#resultMessage"
+      },
+      "resultPath": {
+        "@id": "http://www.w3.org/ns/shacl#resultPath"
+      },
+      "resultSeverity": {
+        "@id": "http://www.w3.org/ns/shacl#resultSeverity"
+      },
+      "shacl": "http://www.w3.org/ns/shacl#",
+      "sourceShapeName": {
+        "@id": "http://a.ml/vocabularies/validation#sourceShapeName"
+      },
+      "start": {
+        "@id": "http://a.ml/vocabularies/lexical#start"
+      },
+      "subResult": {
+        "@id": "http://a.ml/vocabularies/validation#subResult"
+      },
+      "trace": {
+        "@id": "http://a.ml/vocabularies/validation#trace"
+      },
+      "traceValue": {
+        "@id": "http://www.w3.org/ns/shacl#traceValue"
+      },
+      "uri": {
+        "@id": "http://a.ml/vocabularies/lexical#uri"
+      },
+      "validation": "http://a.ml/vocabularies/validation#"
+    },
+    "@id": "dialect-instance",
+    "@type": [
+      "meta:DialectInstance",
+      "doc:Document",
+      "doc:Fragment",
+      "doc:Module",
+      "doc:Unit"
+    ],
+    "doc:encodes": [
+      {
+        "@id": "validation-report",
+        "@type": [
+          "reportSchema:ReportNode",
+          "shacl:ValidationReport"
+        ],
+        "conforms": false,
+        "profileName": "salesforce-aips/annotations",
+        "result": [
+          {
+            "@id": "violation_0",
+            "@type": [
+              "reportSchema:ValidationResultNode",
+              "shacl:ValidationResult"
+            ],
+            "focusNode": "amf://id#2",
+            "resultMessage": "wadus is a mandatory extension",
+            "resultSeverity": "http://www.w3.org/ns/shacl#Violation",
+            "sourceShapeName": "annotations",
+            "trace": [
+              {
+                "@id": "violation_0_0",
+                "@type": [
+                  "reportSchema:TraceMessageNode",
+                  "validation:TraceMessage"
+                ],
+                "component": "pattern",
+                "resultPath": "http://a.ml/vocabularies/apiContract#endpoint / http://a.ml/vocabularies/apiContract#supportedOperation / http://a.ml/vocabularies/api-extension#wadus / http://a.ml/vocabularies/data#value",
+                "traceValue": {
+                  "@id": "violation_0_0_traceValue",
+                  "@type": [
+                    "reportSchema:TraceValueNode",
+                    "validation:TraceValue"
+                  ],
+                  "argument": "false",
+                  "negated": false
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "doc:processingData": [
+      {
+        "@id": "processing-data",
+        "@type": [
+          "doc:DialectInstanceProcessingData"
+        ],
+        "doc:sourceSpec": "Validation Report 1.0"
+      }
+    ]
+  }
+]

--- a/test/data/integration/profile19/positive.data.jsonld
+++ b/test/data/integration/profile19/positive.data.jsonld
@@ -1,0 +1,141 @@
+{
+  "@context": {
+    "@base": "amf://id#",
+    "data": "http://a.ml/vocabularies/data#",
+    "shacl": "http://www.w3.org/ns/shacl#",
+    "shapes": "http://a.ml/vocabularies/shapes#",
+    "doc": "http://a.ml/vocabularies/document#",
+    "meta": "http://a.ml/vocabularies/meta#",
+    "apiContract": "http://a.ml/vocabularies/apiContract#",
+    "core": "http://a.ml/vocabularies/core#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "security": "http://a.ml/vocabularies/security#",
+    "sourcemaps": "http://a.ml/vocabularies/document-source-maps#"
+  },
+  "@graph": [
+    {
+      "@id": "./",
+      "@type": [
+        "doc:Document",
+        "doc:Fragment",
+        "doc:Module",
+        "doc:Unit"
+      ],
+      "doc:encodes": {
+        "@id": "#2",
+        "@type": [
+          "apiContract:WebAPI",
+          "apiContract:API",
+          "doc:RootDomainElement",
+          "doc:DomainElement"
+        ],
+        "apiContract:endpoint": [
+          {
+            "@id": "#3",
+            "@type": [
+              "apiContract:EndPoint",
+              "doc:DomainElement"
+            ],
+            "apiContract:path": "/test",
+            "apiContract:supportedOperation": {
+              "@id": "#4",
+              "@type": [
+                "apiContract:Operation",
+                "core:Operation",
+                "doc:DomainElement"
+              ],
+              "amf://id#7": {
+                "@id": "#6",
+                "@type": [
+                  "data:Scalar",
+                  "data:Node",
+                  "doc:DomainElement"
+                ],
+                "core:extensionName": "wadus",
+                "core:name": "scalar_1",
+                "data:value": "true",
+                "shacl:datatype": {
+                  "@id": "xsd:boolean"
+                }
+              },
+              "apiContract:method": "get",
+              "apiContract:returns": {
+                "@id": "#8",
+                "@type": [
+                  "apiContract:Response",
+                  "core:Response",
+                  "apiContract:Message",
+                  "doc:DomainElement"
+                ],
+                "apiContract:statusCode": "200",
+                "core:description": "",
+                "core:name": "200"
+              },
+              "doc:customDomainProperties": {
+                "@id": "#7"
+              }
+            }
+          },
+          {
+            "@id": "#9",
+            "@type": [
+              "apiContract:EndPoint",
+              "doc:DomainElement"
+            ],
+            "apiContract:path": "/test2",
+            "apiContract:supportedOperation": {
+              "@id": "#10",
+              "@type": [
+                "apiContract:Operation",
+                "core:Operation",
+                "doc:DomainElement"
+              ],
+              "amf://id#13": {
+                "@id": "#12",
+                "@type": [
+                  "data:Scalar",
+                  "data:Node",
+                  "doc:DomainElement"
+                ],
+                "core:extensionName": "wadus",
+                "core:name": "scalar_1",
+                "data:value": "true",
+                "shacl:datatype": {
+                  "@id": "xsd:boolean"
+                }
+              },
+              "apiContract:method": "get",
+              "apiContract:returns": {
+                "@id": "#14",
+                "@type": [
+                  "apiContract:Response",
+                  "core:Response",
+                  "apiContract:Message",
+                  "doc:DomainElement"
+                ],
+                "apiContract:statusCode": "200",
+                "core:description": "",
+                "core:name": "200"
+              },
+              "doc:customDomainProperties": {
+                "@id": "#13"
+              }
+            }
+          }
+        ],
+        "core:name": "example API",
+        "core:version": "1.0.0"
+      },
+      "doc:processingData": {
+        "@id": "#1",
+        "@type": "doc:APIContractProcessingData",
+        "apiContract:modelVersion": "3.6.0",
+        "doc:sourceSpec": "OAS 3.0",
+        "doc:transformed": true
+      },
+      "doc:root": true
+    }
+  ]
+}

--- a/test/data/integration/profile19/positive.data.yaml
+++ b/test/data/integration/profile19/positive.data.yaml
@@ -1,0 +1,19 @@
+openapi: "3.0.0"
+info:
+  title: example API
+  version: "1.0.0"
+paths:
+
+  /test:
+    get:
+      x-wadus: true
+      responses:
+        "200":
+          description: ""
+
+  /test2:
+    get:
+      x-wadus: true
+      responses:
+        "200":
+          description: ""

--- a/test/data/integration/profile19/positive.report.jsonld
+++ b/test/data/integration/profile19/positive.report.jsonld
@@ -1,0 +1,41 @@
+[
+  {
+    "@context": {
+      "conforms": {
+        "@id": "http://www.w3.org/ns/shacl#conforms"
+      },
+      "doc": "http://a.ml/vocabularies/document#",
+      "meta": "http://a.ml/vocabularies/meta#",
+      "reportSchema": "file:///dialects/validation-report.yaml#/declarations/",
+      "shacl": "http://www.w3.org/ns/shacl#"
+    },
+    "@id": "dialect-instance",
+    "@type": [
+      "meta:DialectInstance",
+      "doc:Document",
+      "doc:Fragment",
+      "doc:Module",
+      "doc:Unit"
+    ],
+    "doc:encodes": [
+      {
+        "@id": "validation-report",
+        "@type": [
+          "reportSchema:ReportNode",
+          "shacl:ValidationReport"
+        ],
+        "conforms": true,
+        "profileName": "salesforce-aips/annotations"
+      }
+    ],
+    "doc:processingData": [
+      {
+        "@id": "processing-data",
+        "@type": [
+          "doc:DialectInstanceProcessingData"
+        ],
+        "doc:sourceSpec": "Validation Report 1.0"
+      }
+    ]
+  }
+]

--- a/test/data/integration/profile19/profile.yaml
+++ b/test/data/integration/profile19/profile.yaml
@@ -1,0 +1,13 @@
+#%Validation Profile 1.0
+
+profile: salesforce-aips/annotations
+violation:
+  - annotations
+validations:
+  annotations:
+    message: wadus is a mandatory extension
+    targetClass: apiContract.WebAPI
+    propertyConstraints:
+      apiContract.endpoint / apiContract.supportedOperation / apiExt.wadus / data.value:
+        minCount: 1
+        pattern: "true"

--- a/test/data/integration/profile20/negative.data.jsonld
+++ b/test/data/integration/profile20/negative.data.jsonld
@@ -1,0 +1,141 @@
+{
+  "@context": {
+    "@base": "amf://id#",
+    "data": "http://a.ml/vocabularies/data#",
+    "shacl": "http://www.w3.org/ns/shacl#",
+    "shapes": "http://a.ml/vocabularies/shapes#",
+    "doc": "http://a.ml/vocabularies/document#",
+    "meta": "http://a.ml/vocabularies/meta#",
+    "apiContract": "http://a.ml/vocabularies/apiContract#",
+    "core": "http://a.ml/vocabularies/core#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "security": "http://a.ml/vocabularies/security#",
+    "sourcemaps": "http://a.ml/vocabularies/document-source-maps#"
+  },
+  "@graph": [
+    {
+      "@id": "./",
+      "@type": [
+        "doc:Document",
+        "doc:Fragment",
+        "doc:Module",
+        "doc:Unit"
+      ],
+      "doc:encodes": {
+        "@id": "#2",
+        "@type": [
+          "apiContract:WebAPI",
+          "apiContract:API",
+          "doc:RootDomainElement",
+          "doc:DomainElement"
+        ],
+        "apiContract:endpoint": [
+          {
+            "@id": "#3",
+            "@type": [
+              "apiContract:EndPoint",
+              "doc:DomainElement"
+            ],
+            "apiContract:path": "/test",
+            "apiContract:supportedOperation": {
+              "@id": "#4",
+              "@type": [
+                "apiContract:Operation",
+                "core:Operation",
+                "doc:DomainElement"
+              ],
+              "amf://id#7": {
+                "@id": "#6",
+                "@type": [
+                  "data:Scalar",
+                  "data:Node",
+                  "doc:DomainElement"
+                ],
+                "core:extensionName": "wadus",
+                "core:name": "scalar_1",
+                "data:value": "true",
+                "shacl:datatype": {
+                  "@id": "xsd:boolean"
+                }
+              },
+              "apiContract:method": "get",
+              "apiContract:returns": {
+                "@id": "#8",
+                "@type": [
+                  "apiContract:Response",
+                  "core:Response",
+                  "apiContract:Message",
+                  "doc:DomainElement"
+                ],
+                "apiContract:statusCode": "200",
+                "core:description": "",
+                "core:name": "200"
+              },
+              "doc:customDomainProperties": {
+                "@id": "#7"
+              }
+            }
+          },
+          {
+            "@id": "#9",
+            "@type": [
+              "apiContract:EndPoint",
+              "doc:DomainElement"
+            ],
+            "amf://id#12": {
+              "@id": "#11",
+              "@type": [
+                "data:Scalar",
+                "data:Node",
+                "doc:DomainElement"
+              ],
+              "core:extensionName": "wadus",
+              "core:name": "scalar_1",
+              "data:value": "true",
+              "shacl:datatype": {
+                "@id": "xsd:boolean"
+              }
+            },
+            "apiContract:path": "/test2",
+            "apiContract:supportedOperation": {
+              "@id": "#13",
+              "@type": [
+                "apiContract:Operation",
+                "core:Operation",
+                "doc:DomainElement"
+              ],
+              "apiContract:method": "get",
+              "apiContract:returns": {
+                "@id": "#14",
+                "@type": [
+                  "apiContract:Response",
+                  "core:Response",
+                  "apiContract:Message",
+                  "doc:DomainElement"
+                ],
+                "apiContract:statusCode": "200",
+                "core:description": "",
+                "core:name": "200"
+              }
+            },
+            "doc:customDomainProperties": {
+              "@id": "#12"
+            }
+          }
+        ],
+        "core:name": "example API",
+        "core:version": "1.0.0"
+      },
+      "doc:processingData": {
+        "@id": "#1",
+        "@type": "doc:APIContractProcessingData",
+        "apiContract:modelVersion": "3.6.0",
+        "doc:sourceSpec": "OAS 3.0",
+        "doc:transformed": true
+      },
+      "doc:root": true
+    }
+  ]
+}

--- a/test/data/integration/profile20/negative.data.yaml
+++ b/test/data/integration/profile20/negative.data.yaml
@@ -1,0 +1,19 @@
+openapi: "3.0.0"
+info:
+  title: example API
+  version: "1.0.0"
+paths:
+
+  /test:
+    get:
+      x-wadus: true
+      responses:
+        "200":
+          description:
+
+  /test2:
+    x-wadus: true
+    get:
+      responses:
+        "200":
+          description:

--- a/test/data/integration/profile20/negative.report.jsonld
+++ b/test/data/integration/profile20/negative.report.jsonld
@@ -1,0 +1,148 @@
+[
+  {
+    "@context": {
+      "actual": {
+        "@id": "http://a.ml/vocabularies/validation#actual"
+      },
+      "argument": {
+        "@id": "http://a.ml/vocabularies/validation#argument"
+      },
+      "column": {
+        "@id": "http://a.ml/vocabularies/lexical#column"
+      },
+      "component": {
+        "@id": "http://a.ml/vocabularies/validation#component"
+      },
+      "condition": {
+        "@id": "http://a.ml/vocabularies/validation#condition"
+      },
+      "conforms": {
+        "@id": "http://www.w3.org/ns/shacl#conforms"
+      },
+      "doc": "http://a.ml/vocabularies/document#",
+      "end": {
+        "@id": "http://a.ml/vocabularies/lexical#end"
+      },
+      "expected": {
+        "@id": "http://a.ml/vocabularies/validation#expected"
+      },
+      "focusNode": {
+        "@id": "http://www.w3.org/ns/shacl#focusNode"
+      },
+      "lexical": "http://a.ml/vocabularies/lexical#",
+      "lexicalSchema": "file:///dialects/lexical.yaml#/declarations/",
+      "line": {
+        "@id": "http://a.ml/vocabularies/lexical#line"
+      },
+      "location": {
+        "@id": "http://a.ml/vocabularies/validation#location"
+      },
+      "meta": "http://a.ml/vocabularies/meta#",
+      "negated": {
+        "@id": "http://a.ml/vocabularies/validation#negated"
+      },
+      "profileName": {
+        "@id": "http://a.ml/vocabularies/validation#profileName"
+      },
+      "range": {
+        "@id": "http://a.ml/vocabularies/lexical#range"
+      },
+      "reportSchema": "file:///dialects/validation-report.yaml#/declarations/",
+      "result": {
+        "@id": "http://www.w3.org/ns/shacl#result"
+      },
+      "resultMessage": {
+        "@id": "http://www.w3.org/ns/shacl#resultMessage"
+      },
+      "resultPath": {
+        "@id": "http://www.w3.org/ns/shacl#resultPath"
+      },
+      "resultSeverity": {
+        "@id": "http://www.w3.org/ns/shacl#resultSeverity"
+      },
+      "shacl": "http://www.w3.org/ns/shacl#",
+      "sourceShapeName": {
+        "@id": "http://a.ml/vocabularies/validation#sourceShapeName"
+      },
+      "start": {
+        "@id": "http://a.ml/vocabularies/lexical#start"
+      },
+      "subResult": {
+        "@id": "http://a.ml/vocabularies/validation#subResult"
+      },
+      "trace": {
+        "@id": "http://a.ml/vocabularies/validation#trace"
+      },
+      "traceValue": {
+        "@id": "http://www.w3.org/ns/shacl#traceValue"
+      },
+      "uri": {
+        "@id": "http://a.ml/vocabularies/lexical#uri"
+      },
+      "validation": "http://a.ml/vocabularies/validation#"
+    },
+    "@id": "dialect-instance",
+    "@type": [
+      "meta:DialectInstance",
+      "doc:Document",
+      "doc:Fragment",
+      "doc:Module",
+      "doc:Unit"
+    ],
+    "doc:encodes": [
+      {
+        "@id": "validation-report",
+        "@type": [
+          "reportSchema:ReportNode",
+          "shacl:ValidationReport"
+        ],
+        "conforms": false,
+        "profileName": "salesforce-aips/annotations",
+        "result": [
+          {
+            "@id": "violation_0",
+            "@type": [
+              "reportSchema:ValidationResultNode",
+              "shacl:ValidationResult"
+            ],
+            "focusNode": "amf://id#11",
+            "resultMessage": "wadus is a mandatory extension",
+            "resultSeverity": "http://www.w3.org/ns/shacl#Violation",
+            "sourceShapeName": "annotations",
+            "trace": [
+              {
+                "@id": "violation_0_0",
+                "@type": [
+                  "reportSchema:TraceMessageNode",
+                  "validation:TraceMessage"
+                ],
+                "component": "minCount",
+                "resultPath": "http://a.ml/vocabularies/api-extension#wadus^ / http://a.ml/vocabularies/apiContract#method",
+                "traceValue": {
+                  "@id": "violation_0_0_traceValue",
+                  "@type": [
+                    "reportSchema:TraceValueNode",
+                    "validation:TraceValue"
+                  ],
+                  "actual": 0,
+                  "condition": ">=",
+                  "expected": 1,
+                  "negated": false
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "doc:processingData": [
+      {
+        "@id": "processing-data",
+        "@type": [
+          "doc:DialectInstanceProcessingData"
+        ],
+        "doc:sourceSpec": "Validation Report 1.0"
+      }
+    ]
+  }
+]

--- a/test/data/integration/profile20/positive.data.jsonld
+++ b/test/data/integration/profile20/positive.data.jsonld
@@ -1,0 +1,141 @@
+{
+  "@context": {
+    "@base": "amf://id#",
+    "data": "http://a.ml/vocabularies/data#",
+    "shacl": "http://www.w3.org/ns/shacl#",
+    "shapes": "http://a.ml/vocabularies/shapes#",
+    "doc": "http://a.ml/vocabularies/document#",
+    "meta": "http://a.ml/vocabularies/meta#",
+    "apiContract": "http://a.ml/vocabularies/apiContract#",
+    "core": "http://a.ml/vocabularies/core#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "security": "http://a.ml/vocabularies/security#",
+    "sourcemaps": "http://a.ml/vocabularies/document-source-maps#"
+  },
+  "@graph": [
+    {
+      "@id": "./",
+      "@type": [
+        "doc:Document",
+        "doc:Fragment",
+        "doc:Module",
+        "doc:Unit"
+      ],
+      "doc:encodes": {
+        "@id": "#2",
+        "@type": [
+          "apiContract:WebAPI",
+          "apiContract:API",
+          "doc:RootDomainElement",
+          "doc:DomainElement"
+        ],
+        "apiContract:endpoint": [
+          {
+            "@id": "#3",
+            "@type": [
+              "apiContract:EndPoint",
+              "doc:DomainElement"
+            ],
+            "apiContract:path": "/test",
+            "apiContract:supportedOperation": {
+              "@id": "#4",
+              "@type": [
+                "apiContract:Operation",
+                "core:Operation",
+                "doc:DomainElement"
+              ],
+              "amf://id#7": {
+                "@id": "#6",
+                "@type": [
+                  "data:Scalar",
+                  "data:Node",
+                  "doc:DomainElement"
+                ],
+                "core:extensionName": "wadus",
+                "core:name": "scalar_1",
+                "data:value": "true",
+                "shacl:datatype": {
+                  "@id": "xsd:boolean"
+                }
+              },
+              "apiContract:method": "get",
+              "apiContract:returns": {
+                "@id": "#8",
+                "@type": [
+                  "apiContract:Response",
+                  "core:Response",
+                  "apiContract:Message",
+                  "doc:DomainElement"
+                ],
+                "apiContract:statusCode": "200",
+                "core:description": "",
+                "core:name": "200"
+              },
+              "doc:customDomainProperties": {
+                "@id": "#7"
+              }
+            }
+          },
+          {
+            "@id": "#9",
+            "@type": [
+              "apiContract:EndPoint",
+              "doc:DomainElement"
+            ],
+            "apiContract:path": "/test2",
+            "apiContract:supportedOperation": {
+              "@id": "#10",
+              "@type": [
+                "apiContract:Operation",
+                "core:Operation",
+                "doc:DomainElement"
+              ],
+              "amf://id#13": {
+                "@id": "#12",
+                "@type": [
+                  "data:Scalar",
+                  "data:Node",
+                  "doc:DomainElement"
+                ],
+                "core:extensionName": "wadus",
+                "core:name": "scalar_1",
+                "data:value": "true",
+                "shacl:datatype": {
+                  "@id": "xsd:boolean"
+                }
+              },
+              "apiContract:method": "get",
+              "apiContract:returns": {
+                "@id": "#14",
+                "@type": [
+                  "apiContract:Response",
+                  "core:Response",
+                  "apiContract:Message",
+                  "doc:DomainElement"
+                ],
+                "apiContract:statusCode": "200",
+                "core:description": "",
+                "core:name": "200"
+              },
+              "doc:customDomainProperties": {
+                "@id": "#13"
+              }
+            }
+          }
+        ],
+        "core:name": "example API",
+        "core:version": "1.0.0"
+      },
+      "doc:processingData": {
+        "@id": "#1",
+        "@type": "doc:APIContractProcessingData",
+        "apiContract:modelVersion": "3.6.0",
+        "doc:sourceSpec": "OAS 3.0",
+        "doc:transformed": true
+      },
+      "doc:root": true
+    }
+  ]
+}

--- a/test/data/integration/profile20/positive.data.yaml
+++ b/test/data/integration/profile20/positive.data.yaml
@@ -1,0 +1,19 @@
+openapi: "3.0.0"
+info:
+  title: example API
+  version: "1.0.0"
+paths:
+
+  /test:
+    get:
+      x-wadus: true
+      responses:
+        "200":
+          description: ""
+
+  /test2:
+    get:
+      x-wadus: true
+      responses:
+        "200":
+          description: ""

--- a/test/data/integration/profile20/positive.report.jsonld
+++ b/test/data/integration/profile20/positive.report.jsonld
@@ -1,0 +1,41 @@
+[
+  {
+    "@context": {
+      "conforms": {
+        "@id": "http://www.w3.org/ns/shacl#conforms"
+      },
+      "doc": "http://a.ml/vocabularies/document#",
+      "meta": "http://a.ml/vocabularies/meta#",
+      "reportSchema": "file:///dialects/validation-report.yaml#/declarations/",
+      "shacl": "http://www.w3.org/ns/shacl#"
+    },
+    "@id": "dialect-instance",
+    "@type": [
+      "meta:DialectInstance",
+      "doc:Document",
+      "doc:Fragment",
+      "doc:Module",
+      "doc:Unit"
+    ],
+    "doc:encodes": [
+      {
+        "@id": "validation-report",
+        "@type": [
+          "reportSchema:ReportNode",
+          "shacl:ValidationReport"
+        ],
+        "conforms": true,
+        "profileName": "salesforce-aips/annotations"
+      }
+    ],
+    "doc:processingData": [
+      {
+        "@id": "processing-data",
+        "@type": [
+          "doc:DialectInstanceProcessingData"
+        ],
+        "doc:sourceSpec": "Validation Report 1.0"
+      }
+    ]
+  }
+]

--- a/test/data/integration/profile20/profile.yaml
+++ b/test/data/integration/profile20/profile.yaml
@@ -1,0 +1,13 @@
+#%Validation Profile 1.0
+
+profile: salesforce-aips/annotations
+violation:
+  - annotations
+validations:
+  annotations:
+    message: wadus is a mandatory extension
+    targetClass: data.Scalar
+    propertyConstraints:
+      apiExt.wadus^ / apiContract.method :
+        minCount: 1
+        pattern: "get"

--- a/test/data/integration/profile21/negative.data.jsonld
+++ b/test/data/integration/profile21/negative.data.jsonld
@@ -1,0 +1,119 @@
+{
+  "@graph": [
+    {
+      "@id": "amf://id#1",
+      "@type": [
+        "http://a.ml/vocabularies/document#APIContractProcessingData"
+      ],
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.3.0",
+      "http://a.ml/vocabularies/document#transformed": true,
+      "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
+    },
+    {
+      "@id": "amf://id#2",
+      "@type": [
+        "http://a.ml/vocabularies/apiContract#WebAPI",
+        "http://a.ml/vocabularies/apiContract#API",
+        "http://a.ml/vocabularies/document#RootDomainElement",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/core#name": "example API",
+      "http://a.ml/vocabularies/core#version": "1.0.0",
+      "http://a.ml/vocabularies/apiContract#endpoint": [
+        {
+          "@id": "amf://id#3"
+        }
+      ]
+    },
+    {
+      "@id": "amf://id#3",
+      "@type": [
+        "http://a.ml/vocabularies/apiContract#EndPoint",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/apiContract#path": "/test",
+      "http://a.ml/vocabularies/apiContract#supportedOperation": [
+        {
+          "@id": "amf://id#4"
+        }
+      ]
+    },
+    {
+      "@id": "amf://id#4",
+      "@type": [
+        "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/apiContract#method": "get",
+      "http://a.ml/vocabularies/apiContract#returns": [
+        {
+          "@id": "amf://id#9"
+        }
+      ],
+      "amf://id#8": {
+        "@id": "amf://id#6"
+      },
+      "http://a.ml/vocabularies/document#customDomainProperties": [
+        {
+          "@id": "amf://id#8"
+        }
+      ]
+    },
+    {
+      "@id": "amf://id#9",
+      "@type": [
+        "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/apiContract#Message",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/apiContract#statusCode": "200",
+      "http://a.ml/vocabularies/core#name": "200",
+      "http://a.ml/vocabularies/core#description": ""
+    },
+    {
+      "http://a.ml/vocabularies/core#extensionName": "wadus",
+      "@id": "amf://id#6",
+      "@type": [
+        "http://a.ml/vocabularies/data#Object",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#name": {
+        "@id": "amf://id#7"
+      },
+      "http://a.ml/vocabularies/core#name": "object_1"
+    },
+    {
+      "@id": "amf://id#7",
+      "@type": [
+        "http://a.ml/vocabularies/data#Scalar",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#value": "asdf",
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "http://a.ml/vocabularies/core#name": "name"
+    },
+    {
+      "@id": "amf://id",
+      "@type": [
+        "http://a.ml/vocabularies/document#Document",
+        "http://a.ml/vocabularies/document#Fragment",
+        "http://a.ml/vocabularies/document#Module",
+        "http://a.ml/vocabularies/document#Unit"
+      ],
+      "http://a.ml/vocabularies/document#encodes": {
+        "@id": "amf://id#2"
+      },
+      "http://a.ml/vocabularies/document#root": true,
+      "http://a.ml/vocabularies/document#processingData": {
+        "@id": "amf://id#1"
+      }
+    }
+  ]
+}
+

--- a/test/data/integration/profile21/negative.data.yaml
+++ b/test/data/integration/profile21/negative.data.yaml
@@ -1,0 +1,13 @@
+openapi: "3.0.0"
+info:
+  title: example API
+  version: "1.0.0"
+paths:
+
+  /test:
+    get:
+      x-wadus:
+        name: asdf
+      responses:
+        "200":
+          description:

--- a/test/data/integration/profile21/negative.report.jsonld
+++ b/test/data/integration/profile21/negative.report.jsonld
@@ -1,0 +1,146 @@
+[
+  {
+    "@context": {
+      "actual": {
+        "@id": "http://a.ml/vocabularies/validation#actual"
+      },
+      "argument": {
+        "@id": "http://a.ml/vocabularies/validation#argument"
+      },
+      "column": {
+        "@id": "http://a.ml/vocabularies/lexical#column"
+      },
+      "component": {
+        "@id": "http://a.ml/vocabularies/validation#component"
+      },
+      "condition": {
+        "@id": "http://a.ml/vocabularies/validation#condition"
+      },
+      "conforms": {
+        "@id": "http://www.w3.org/ns/shacl#conforms"
+      },
+      "doc": "http://a.ml/vocabularies/document#",
+      "end": {
+        "@id": "http://a.ml/vocabularies/lexical#end"
+      },
+      "expected": {
+        "@id": "http://a.ml/vocabularies/validation#expected"
+      },
+      "focusNode": {
+        "@id": "http://www.w3.org/ns/shacl#focusNode"
+      },
+      "lexical": "http://a.ml/vocabularies/lexical#",
+      "lexicalSchema": "file:///dialects/lexical.yaml#/declarations/",
+      "line": {
+        "@id": "http://a.ml/vocabularies/lexical#line"
+      },
+      "location": {
+        "@id": "http://a.ml/vocabularies/validation#location"
+      },
+      "meta": "http://a.ml/vocabularies/meta#",
+      "negated": {
+        "@id": "http://a.ml/vocabularies/validation#negated"
+      },
+      "profileName": {
+        "@id": "http://a.ml/vocabularies/validation#profileName"
+      },
+      "range": {
+        "@id": "http://a.ml/vocabularies/lexical#range"
+      },
+      "reportSchema": "file:///dialects/validation-report.yaml#/declarations/",
+      "result": {
+        "@id": "http://www.w3.org/ns/shacl#result"
+      },
+      "resultMessage": {
+        "@id": "http://www.w3.org/ns/shacl#resultMessage"
+      },
+      "resultPath": {
+        "@id": "http://www.w3.org/ns/shacl#resultPath"
+      },
+      "resultSeverity": {
+        "@id": "http://www.w3.org/ns/shacl#resultSeverity"
+      },
+      "shacl": "http://www.w3.org/ns/shacl#",
+      "sourceShapeName": {
+        "@id": "http://a.ml/vocabularies/validation#sourceShapeName"
+      },
+      "start": {
+        "@id": "http://a.ml/vocabularies/lexical#start"
+      },
+      "subResult": {
+        "@id": "http://a.ml/vocabularies/validation#subResult"
+      },
+      "trace": {
+        "@id": "http://a.ml/vocabularies/validation#trace"
+      },
+      "traceValue": {
+        "@id": "http://www.w3.org/ns/shacl#traceValue"
+      },
+      "uri": {
+        "@id": "http://a.ml/vocabularies/lexical#uri"
+      },
+      "validation": "http://a.ml/vocabularies/validation#"
+    },
+    "@id": "dialect-instance",
+    "@type": [
+      "meta:DialectInstance",
+      "doc:Document",
+      "doc:Fragment",
+      "doc:Module",
+      "doc:Unit"
+    ],
+    "doc:encodes": [
+      {
+        "@id": "validation-report",
+        "@type": [
+          "reportSchema:ReportNode",
+          "shacl:ValidationReport"
+        ],
+        "conforms": false,
+        "profileName": "salesforce-aips/annotations",
+        "result": [
+          {
+            "@id": "violation_0",
+            "@type": [
+              "reportSchema:ValidationResultNode",
+              "shacl:ValidationResult"
+            ],
+            "focusNode": "amf://id#4",
+            "resultMessage": "wadus name should be 'valid'",
+            "resultSeverity": "http://www.w3.org/ns/shacl#Violation",
+            "sourceShapeName": "annotations",
+            "trace": [
+              {
+                "@id": "violation_0_0",
+                "@type": [
+                  "reportSchema:TraceMessageNode",
+                  "validation:TraceMessage"
+                ],
+                "component": "pattern",
+                "resultPath": "http://a.ml/vocabularies/api-extension#wadus / http://a.ml/vocabularies/data#name / http://a.ml/vocabularies/data#value",
+                "traceValue": {
+                  "@id": "violation_0_0_traceValue",
+                  "@type": [
+                    "reportSchema:TraceValueNode",
+                    "validation:TraceValue"
+                  ],
+                  "argument": "asdf",
+                  "negated": false
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "doc:processingData": [
+      {
+        "@id": "processing-data",
+        "@type": [
+          "doc:DialectInstanceProcessingData"
+        ],
+        "doc:sourceSpec": "Validation Report 1.0"
+      }
+    ]
+  }
+]

--- a/test/data/integration/profile21/positive.data.jsonld
+++ b/test/data/integration/profile21/positive.data.jsonld
@@ -1,0 +1,119 @@
+{
+  "@graph": [
+    {
+      "@id": "amf://id#1",
+      "@type": [
+        "http://a.ml/vocabularies/document#APIContractProcessingData"
+      ],
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.3.0",
+      "http://a.ml/vocabularies/document#transformed": true,
+      "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
+    },
+    {
+      "@id": "amf://id#2",
+      "@type": [
+        "http://a.ml/vocabularies/apiContract#WebAPI",
+        "http://a.ml/vocabularies/apiContract#API",
+        "http://a.ml/vocabularies/document#RootDomainElement",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/core#name": "example API",
+      "http://a.ml/vocabularies/core#version": "1.0.0",
+      "http://a.ml/vocabularies/apiContract#endpoint": [
+        {
+          "@id": "amf://id#3"
+        }
+      ]
+    },
+    {
+      "@id": "amf://id#3",
+      "@type": [
+        "http://a.ml/vocabularies/apiContract#EndPoint",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/apiContract#path": "/test",
+      "http://a.ml/vocabularies/apiContract#supportedOperation": [
+        {
+          "@id": "amf://id#4"
+        }
+      ]
+    },
+    {
+      "@id": "amf://id#4",
+      "@type": [
+        "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/apiContract#method": "get",
+      "http://a.ml/vocabularies/apiContract#returns": [
+        {
+          "@id": "amf://id#9"
+        }
+      ],
+      "amf://id#8": {
+        "@id": "amf://id#6"
+      },
+      "http://a.ml/vocabularies/document#customDomainProperties": [
+        {
+          "@id": "amf://id#8"
+        }
+      ]
+    },
+    {
+      "@id": "amf://id#9",
+      "@type": [
+        "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/apiContract#Message",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/apiContract#statusCode": "200",
+      "http://a.ml/vocabularies/core#name": "200",
+      "http://a.ml/vocabularies/core#description": ""
+    },
+    {
+      "http://a.ml/vocabularies/core#extensionName": "wadus",
+      "@id": "amf://id#6",
+      "@type": [
+        "http://a.ml/vocabularies/data#Object",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#name": {
+        "@id": "amf://id#7"
+      },
+      "http://a.ml/vocabularies/core#name": "object_1"
+    },
+    {
+      "@id": "amf://id#7",
+      "@type": [
+        "http://a.ml/vocabularies/data#Scalar",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#value": "valid",
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "http://a.ml/vocabularies/core#name": "name"
+    },
+    {
+      "@id": "amf://id",
+      "@type": [
+        "http://a.ml/vocabularies/document#Document",
+        "http://a.ml/vocabularies/document#Fragment",
+        "http://a.ml/vocabularies/document#Module",
+        "http://a.ml/vocabularies/document#Unit"
+      ],
+      "http://a.ml/vocabularies/document#encodes": {
+        "@id": "amf://id#2"
+      },
+      "http://a.ml/vocabularies/document#root": true,
+      "http://a.ml/vocabularies/document#processingData": {
+        "@id": "amf://id#1"
+      }
+    }
+  ]
+}
+

--- a/test/data/integration/profile21/positive.data.yaml
+++ b/test/data/integration/profile21/positive.data.yaml
@@ -1,0 +1,13 @@
+openapi: "3.0.0"
+info:
+  title: example API
+  version: "1.0.0"
+paths:
+
+  /test:
+    get:
+      x-wadus:
+        name: valid
+      responses:
+        "200":
+          description: ""

--- a/test/data/integration/profile21/positive.report.jsonld
+++ b/test/data/integration/profile21/positive.report.jsonld
@@ -1,0 +1,41 @@
+[
+  {
+    "@context": {
+      "conforms": {
+        "@id": "http://www.w3.org/ns/shacl#conforms"
+      },
+      "doc": "http://a.ml/vocabularies/document#",
+      "meta": "http://a.ml/vocabularies/meta#",
+      "reportSchema": "file:///dialects/validation-report.yaml#/declarations/",
+      "shacl": "http://www.w3.org/ns/shacl#"
+    },
+    "@id": "dialect-instance",
+    "@type": [
+      "meta:DialectInstance",
+      "doc:Document",
+      "doc:Fragment",
+      "doc:Module",
+      "doc:Unit"
+    ],
+    "doc:encodes": [
+      {
+        "@id": "validation-report",
+        "@type": [
+          "reportSchema:ReportNode",
+          "shacl:ValidationReport"
+        ],
+        "conforms": true,
+        "profileName": "salesforce-aips/annotations"
+      }
+    ],
+    "doc:processingData": [
+      {
+        "@id": "processing-data",
+        "@type": [
+          "doc:DialectInstanceProcessingData"
+        ],
+        "doc:sourceSpec": "Validation Report 1.0"
+      }
+    ]
+  }
+]

--- a/test/data/integration/profile21/profile.yaml
+++ b/test/data/integration/profile21/profile.yaml
@@ -1,0 +1,13 @@
+#%Validation Profile 1.0
+
+profile: salesforce-aips/annotations
+violation:
+  - annotations
+validations:
+  annotations:
+    message: wadus name should be 'valid'
+    targetClass: apiContract.Operation
+    propertyConstraints:
+      apiExt.wadus / data.name / data.value:
+        minCount: 1
+        pattern: "valid"

--- a/test/data/production/best-practices/negative1.raml.jsonld
+++ b/test/data/production/best-practices/negative1.raml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
@@ -196,7 +196,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/test/data/production/best-practices/negative1.raml.report.jsonld
+++ b/test/data/production/best-practices/negative1.raml.report.jsonld
@@ -105,7 +105,7 @@
               "reportSchema:ValidationResultNode",
               "shacl:ValidationResult"
             ],
-            "focusNode": "amf://id#3",
+            "focusNode": "amf://id#2",
             "location": {
               "@id": "violation_0_location",
               "@type": [
@@ -133,15 +133,15 @@
                     "lexicalSchema:PositionNode",
                     "lexical:Position"
                   ],
-                  "column": 6,
-                  "line": 7
+                  "column": 2,
+                  "line": 4
                 }
               },
               "uri": "file://./test/data/production/best-practices/lib.raml"
             },
-            "resultMessage": "Use camelCase for all the names (fields), preferably don’t use underscores.",
+            "resultMessage": "Provide description for data shapes",
             "resultSeverity": "http://www.w3.org/ns/shacl#Violation",
-            "sourceShapeName": "camel-case-fields",
+            "sourceShapeName": "payload-shapes-must-have-descriptions",
             "trace": [
               {
                 "@id": "violation_0_0",
@@ -149,7 +149,7 @@
                   "reportSchema:TraceMessageNode",
                   "validation:TraceMessage"
                 ],
-                "component": "pattern",
+                "component": "minCount",
                 "location": {
                   "@id": "violation_0_0_location",
                   "@type": [
@@ -177,6 +177,105 @@
                         "lexicalSchema:PositionNode",
                         "lexical:Position"
                       ],
+                      "column": 2,
+                      "line": 4
+                    }
+                  },
+                  "uri": "file://./test/data/production/best-practices/lib.raml"
+                },
+                "resultPath": "http://a.ml/vocabularies/core#description",
+                "traceValue": {
+                  "@id": "violation_0_0_traceValue",
+                  "@type": [
+                    "reportSchema:TraceValueNode",
+                    "validation:TraceValue"
+                  ],
+                  "actual": 0,
+                  "condition": ">=",
+                  "expected": 1,
+                  "negated": false
+                }
+              }
+            ]
+          },
+          {
+            "@id": "violation_1",
+            "@type": [
+              "reportSchema:ValidationResultNode",
+              "shacl:ValidationResult"
+            ],
+            "focusNode": "amf://id#3",
+            "location": {
+              "@id": "violation_1_location",
+              "@type": [
+                "lexicalSchema:LocationNode",
+                "lexical:Location"
+              ],
+              "range": {
+                "@id": "violation_1_location_range",
+                "@type": [
+                  "lexicalSchema:RangeNode",
+                  "lexical:Range"
+                ],
+                "end": {
+                  "@id": "violation_1_location_range_end",
+                  "@type": [
+                    "lexicalSchema:PositionNode",
+                    "lexical:Position"
+                  ],
+                  "column": 27,
+                  "line": 7
+                },
+                "start": {
+                  "@id": "violation_1_location_range_start",
+                  "@type": [
+                    "lexicalSchema:PositionNode",
+                    "lexical:Position"
+                  ],
+                  "column": 6,
+                  "line": 7
+                }
+              },
+              "uri": "file://./test/data/production/best-practices/lib.raml"
+            },
+            "resultMessage": "Use camelCase for all the names (fields), preferably don’t use underscores.",
+            "resultSeverity": "http://www.w3.org/ns/shacl#Violation",
+            "sourceShapeName": "camel-case-fields",
+            "trace": [
+              {
+                "@id": "violation_1_0",
+                "@type": [
+                  "reportSchema:TraceMessageNode",
+                  "validation:TraceMessage"
+                ],
+                "component": "pattern",
+                "location": {
+                  "@id": "violation_1_0_location",
+                  "@type": [
+                    "lexicalSchema:LocationNode",
+                    "lexical:Location"
+                  ],
+                  "range": {
+                    "@id": "violation_1_0_location_range",
+                    "@type": [
+                      "lexicalSchema:RangeNode",
+                      "lexical:Range"
+                    ],
+                    "end": {
+                      "@id": "violation_1_0_location_range_end",
+                      "@type": [
+                        "lexicalSchema:PositionNode",
+                        "lexical:Position"
+                      ],
+                      "column": 27,
+                      "line": 7
+                    },
+                    "start": {
+                      "@id": "violation_1_0_location_range_start",
+                      "@type": [
+                        "lexicalSchema:PositionNode",
+                        "lexical:Position"
+                      ],
                       "column": 6,
                       "line": 7
                     }
@@ -185,7 +284,7 @@
                 },
                 "resultPath": "http://www.w3.org/ns/shacl#name",
                 "traceValue": {
-                  "@id": "violation_0_0_traceValue",
+                  "@id": "violation_1_0_traceValue",
                   "@type": [
                     "reportSchema:TraceValueNode",
                     "validation:TraceValue"
@@ -197,125 +296,26 @@
             ]
           },
           {
-            "@id": "warning_0",
-            "@type": [
-              "reportSchema:ValidationResultNode",
-              "shacl:ValidationResult"
-            ],
-            "focusNode": "amf://id#2",
-            "location": {
-              "@id": "warning_0_location",
-              "@type": [
-                "lexicalSchema:LocationNode",
-                "lexical:Location"
-              ],
-              "range": {
-                "@id": "warning_0_location_range",
-                "@type": [
-                  "lexicalSchema:RangeNode",
-                  "lexical:Range"
-                ],
-                "end": {
-                  "@id": "warning_0_location_range_end",
-                  "@type": [
-                    "lexicalSchema:PositionNode",
-                    "lexical:Position"
-                  ],
-                  "column": 27,
-                  "line": 7
-                },
-                "start": {
-                  "@id": "warning_0_location_range_start",
-                  "@type": [
-                    "lexicalSchema:PositionNode",
-                    "lexical:Position"
-                  ],
-                  "column": 2,
-                  "line": 4
-                }
-              },
-              "uri": "file://./test/data/production/best-practices/lib.raml"
-            },
-            "resultMessage": "Provide description for data shapes",
-            "resultSeverity": "http://www.w3.org/ns/shacl#Warning",
-            "sourceShapeName": "payload-shapes-must-have-descriptions",
-            "trace": [
-              {
-                "@id": "warning_0_0",
-                "@type": [
-                  "reportSchema:TraceMessageNode",
-                  "validation:TraceMessage"
-                ],
-                "component": "minCount",
-                "location": {
-                  "@id": "warning_0_0_location",
-                  "@type": [
-                    "lexicalSchema:LocationNode",
-                    "lexical:Location"
-                  ],
-                  "range": {
-                    "@id": "warning_0_0_location_range",
-                    "@type": [
-                      "lexicalSchema:RangeNode",
-                      "lexical:Range"
-                    ],
-                    "end": {
-                      "@id": "warning_0_0_location_range_end",
-                      "@type": [
-                        "lexicalSchema:PositionNode",
-                        "lexical:Position"
-                      ],
-                      "column": 27,
-                      "line": 7
-                    },
-                    "start": {
-                      "@id": "warning_0_0_location_range_start",
-                      "@type": [
-                        "lexicalSchema:PositionNode",
-                        "lexical:Position"
-                      ],
-                      "column": 2,
-                      "line": 4
-                    }
-                  },
-                  "uri": "file://./test/data/production/best-practices/lib.raml"
-                },
-                "resultPath": "http://a.ml/vocabularies/core#description",
-                "traceValue": {
-                  "@id": "warning_0_0_traceValue",
-                  "@type": [
-                    "reportSchema:TraceValueNode",
-                    "validation:TraceValue"
-                  ],
-                  "actual": 0,
-                  "condition": ">=",
-                  "expected": 1,
-                  "negated": false
-                }
-              }
-            ]
-          },
-          {
-            "@id": "warning_1",
+            "@id": "violation_2",
             "@type": [
               "reportSchema:ValidationResultNode",
               "shacl:ValidationResult"
             ],
             "focusNode": "amf://id#6",
             "location": {
-              "@id": "warning_1_location",
+              "@id": "violation_2_location",
               "@type": [
                 "lexicalSchema:LocationNode",
                 "lexical:Location"
               ],
               "range": {
-                "@id": "warning_1_location_range",
+                "@id": "violation_2_location_range",
                 "@type": [
                   "lexicalSchema:RangeNode",
                   "lexical:Range"
                 ],
                 "end": {
-                  "@id": "warning_1_location_range_end",
+                  "@id": "violation_2_location_range_end",
                   "@type": [
                     "lexicalSchema:PositionNode",
                     "lexical:Position"
@@ -324,7 +324,7 @@
                   "line": 7
                 },
                 "start": {
-                  "@id": "warning_1_location_range_start",
+                  "@id": "violation_2_location_range_start",
                   "@type": [
                     "lexicalSchema:PositionNode",
                     "lexical:Position"
@@ -336,30 +336,30 @@
               "uri": "file://./test/data/production/best-practices/lib.raml"
             },
             "resultMessage": "Provide description for data shapes",
-            "resultSeverity": "http://www.w3.org/ns/shacl#Warning",
+            "resultSeverity": "http://www.w3.org/ns/shacl#Violation",
             "sourceShapeName": "payload-shapes-must-have-descriptions",
             "trace": [
               {
-                "@id": "warning_1_0",
+                "@id": "violation_2_0",
                 "@type": [
                   "reportSchema:TraceMessageNode",
                   "validation:TraceMessage"
                 ],
                 "component": "minCount",
                 "location": {
-                  "@id": "warning_1_0_location",
+                  "@id": "violation_2_0_location",
                   "@type": [
                     "lexicalSchema:LocationNode",
                     "lexical:Location"
                   ],
                   "range": {
-                    "@id": "warning_1_0_location_range",
+                    "@id": "violation_2_0_location_range",
                     "@type": [
                       "lexicalSchema:RangeNode",
                       "lexical:Range"
                     ],
                     "end": {
-                      "@id": "warning_1_0_location_range_end",
+                      "@id": "violation_2_0_location_range_end",
                       "@type": [
                         "lexicalSchema:PositionNode",
                         "lexical:Position"
@@ -368,7 +368,7 @@
                       "line": 7
                     },
                     "start": {
-                      "@id": "warning_1_0_location_range_start",
+                      "@id": "violation_2_0_location_range_start",
                       "@type": [
                         "lexicalSchema:PositionNode",
                         "lexical:Position"
@@ -381,7 +381,7 @@
                 },
                 "resultPath": "http://a.ml/vocabularies/core#description",
                 "traceValue": {
-                  "@id": "warning_1_0_traceValue",
+                  "@id": "violation_2_0_traceValue",
                   "@type": [
                     "reportSchema:TraceValueNode",
                     "validation:TraceValue"
@@ -395,26 +395,26 @@
             ]
           },
           {
-            "@id": "warning_2",
+            "@id": "violation_3",
             "@type": [
               "reportSchema:ValidationResultNode",
               "shacl:ValidationResult"
             ],
             "focusNode": "amf://id#8",
             "location": {
-              "@id": "warning_2_location",
+              "@id": "violation_3_location",
               "@type": [
                 "lexicalSchema:LocationNode",
                 "lexical:Location"
               ],
               "range": {
-                "@id": "warning_2_location_range",
+                "@id": "violation_3_location_range",
                 "@type": [
                   "lexicalSchema:RangeNode",
                   "lexical:Range"
                 ],
                 "end": {
-                  "@id": "warning_2_location_range_end",
+                  "@id": "violation_3_location_range_end",
                   "@type": [
                     "lexicalSchema:PositionNode",
                     "lexical:Position"
@@ -423,7 +423,7 @@
                   "line": 7
                 },
                 "start": {
-                  "@id": "warning_2_location_range_start",
+                  "@id": "violation_3_location_range_start",
                   "@type": [
                     "lexicalSchema:PositionNode",
                     "lexical:Position"
@@ -435,30 +435,30 @@
               "uri": "file://./test/data/production/best-practices/negative1.raml"
             },
             "resultMessage": "Provide the description for the API",
-            "resultSeverity": "http://www.w3.org/ns/shacl#Warning",
+            "resultSeverity": "http://www.w3.org/ns/shacl#Violation",
             "sourceShapeName": "api-must-have-description",
             "trace": [
               {
-                "@id": "warning_2_0",
+                "@id": "violation_3_0",
                 "@type": [
                   "reportSchema:TraceMessageNode",
                   "validation:TraceMessage"
                 ],
                 "component": "minCount",
                 "location": {
-                  "@id": "warning_2_0_location",
+                  "@id": "violation_3_0_location",
                   "@type": [
                     "lexicalSchema:LocationNode",
                     "lexical:Location"
                   ],
                   "range": {
-                    "@id": "warning_2_0_location_range",
+                    "@id": "violation_3_0_location_range",
                     "@type": [
                       "lexicalSchema:RangeNode",
                       "lexical:Range"
                     ],
                     "end": {
-                      "@id": "warning_2_0_location_range_end",
+                      "@id": "violation_3_0_location_range_end",
                       "@type": [
                         "lexicalSchema:PositionNode",
                         "lexical:Position"
@@ -467,7 +467,7 @@
                       "line": 7
                     },
                     "start": {
-                      "@id": "warning_2_0_location_range_start",
+                      "@id": "violation_3_0_location_range_start",
                       "@type": [
                         "lexicalSchema:PositionNode",
                         "lexical:Position"
@@ -480,7 +480,7 @@
                 },
                 "resultPath": "http://a.ml/vocabularies/core#description",
                 "traceValue": {
-                  "@id": "warning_2_0_traceValue",
+                  "@id": "violation_3_0_traceValue",
                   "@type": [
                     "reportSchema:TraceValueNode",
                     "validation:TraceValue"
@@ -494,26 +494,26 @@
             ]
           },
           {
-            "@id": "warning_3",
+            "@id": "violation_4",
             "@type": [
               "reportSchema:ValidationResultNode",
               "shacl:ValidationResult"
             ],
             "focusNode": "amf://id#8",
             "location": {
-              "@id": "warning_3_location",
+              "@id": "violation_4_location",
               "@type": [
                 "lexicalSchema:LocationNode",
                 "lexical:Location"
               ],
               "range": {
-                "@id": "warning_3_location_range",
+                "@id": "violation_4_location_range",
                 "@type": [
                   "lexicalSchema:RangeNode",
                   "lexical:Range"
                 ],
                 "end": {
-                  "@id": "warning_3_location_range_end",
+                  "@id": "violation_4_location_range_end",
                   "@type": [
                     "lexicalSchema:PositionNode",
                     "lexical:Position"
@@ -522,7 +522,7 @@
                   "line": 7
                 },
                 "start": {
-                  "@id": "warning_3_location_range_start",
+                  "@id": "violation_4_location_range_start",
                   "@type": [
                     "lexicalSchema:PositionNode",
                     "lexical:Position"
@@ -534,30 +534,30 @@
               "uri": "file://./test/data/production/best-practices/negative1.raml"
             },
             "resultMessage": "Provide the documentation for the API",
-            "resultSeverity": "http://www.w3.org/ns/shacl#Warning",
+            "resultSeverity": "http://www.w3.org/ns/shacl#Violation",
             "sourceShapeName": "api-must-have-documentation",
             "trace": [
               {
-                "@id": "warning_3_0",
+                "@id": "violation_4_0",
                 "@type": [
                   "reportSchema:TraceMessageNode",
                   "validation:TraceMessage"
                 ],
                 "component": "minCount",
                 "location": {
-                  "@id": "warning_3_0_location",
+                  "@id": "violation_4_0_location",
                   "@type": [
                     "lexicalSchema:LocationNode",
                     "lexical:Location"
                   ],
                   "range": {
-                    "@id": "warning_3_0_location_range",
+                    "@id": "violation_4_0_location_range",
                     "@type": [
                       "lexicalSchema:RangeNode",
                       "lexical:Range"
                     ],
                     "end": {
-                      "@id": "warning_3_0_location_range_end",
+                      "@id": "violation_4_0_location_range_end",
                       "@type": [
                         "lexicalSchema:PositionNode",
                         "lexical:Position"
@@ -566,7 +566,7 @@
                       "line": 7
                     },
                     "start": {
-                      "@id": "warning_3_0_location_range_start",
+                      "@id": "violation_4_0_location_range_start",
                       "@type": [
                         "lexicalSchema:PositionNode",
                         "lexical:Position"
@@ -579,7 +579,7 @@
                 },
                 "resultPath": "http://a.ml/vocabularies/core#documentation",
                 "traceValue": {
-                  "@id": "warning_3_0_traceValue",
+                  "@id": "violation_4_0_traceValue",
                   "@type": [
                     "reportSchema:TraceValueNode",
                     "validation:TraceValue"

--- a/test/data/production/best-practices/negative1.yaml.jsonld
+++ b/test/data/production/best-practices/negative1.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -167,6 +167,7 @@
       "@id": "amf://id#16",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -274,6 +275,7 @@
       "@id": "amf://id#21",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -287,6 +289,7 @@
       "@id": "amf://id#18",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -357,6 +360,7 @@
       "@id": "amf://id#22",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -379,6 +383,7 @@
       "@id": "amf://id#9",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -395,6 +400,7 @@
       "@id": "amf://id#19",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "content-type",

--- a/test/data/production/best-practices/negative10.raml.jsonld
+++ b/test/data/production/best-practices/negative10.raml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
@@ -293,6 +293,7 @@
       "@id": "amf://id#39",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "put",
@@ -331,6 +332,7 @@
       "@id": "amf://id#50",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -416,6 +418,7 @@
       "@id": "amf://id#41",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -483,6 +486,7 @@
       "@id": "amf://id#51",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -567,6 +571,7 @@
       "@id": "amf://id#44",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/shapes#schema": {
@@ -582,6 +587,7 @@
       "@id": "amf://id#42",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "content-type",
@@ -663,6 +669,7 @@
       "@id": "amf://id#54",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/shapes#schema": {
@@ -678,6 +685,7 @@
       "@id": "amf://id#52",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "content-type",
@@ -3271,7 +3279,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/test/data/production/best-practices/negative11.raml.jsonld
+++ b/test/data/production/best-practices/negative11.raml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
@@ -45,7 +45,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#BaseUnitSourceInformation"
       ],
-      "http://a.ml/vocabularies/document#rootLocation": "file:///Users/abettati/mulesoft/amf-custom-validator/test/data/production/best-practices/positive2.raml",
+      "http://a.ml/vocabularies/document#rootLocation": "file://./test/data/production/best-practices/positive2.raml",
       "http://a.ml/vocabularies/document#additionalLocations": [
         {
           "@id": "amf://id/BaseUnitSourceInformation/location_0"
@@ -126,7 +126,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#LocationInformation"
       ],
-      "http://a.ml/vocabularies/document#location": "file:///Users/abettati/mulesoft/amf-custom-validator/test/data/production/best-practices/negative11.raml",
+      "http://a.ml/vocabularies/document#location": "file://./test/data/production/best-practices/negative11.raml",
       "http://a.ml/vocabularies/document#elements": [
         {
           "@id": "amf://id#10"
@@ -176,6 +176,7 @@
       "@id": "amf://id#14",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -268,6 +269,7 @@
       "@id": "amf://id#15",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -294,6 +296,7 @@
       "@id": "amf://id#22",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -355,6 +358,7 @@
       "@id": "amf://id#16",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "filter",
@@ -375,6 +379,7 @@
       "@id": "amf://id#18",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "order",
@@ -395,6 +400,7 @@
       "@id": "amf://id#20",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "callerId",
@@ -429,6 +435,7 @@
       "@id": "amf://id#25",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -445,6 +452,7 @@
       "@id": "amf://id#23",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "content-type",
@@ -1188,7 +1196,7 @@
         }
       ],
       "http://www.w3.org/ns/shacl#name": "IncorrectType",
-      "http://a.ml/vocabularies/core#description": "some description",
+      "http://a.ml/vocabularies/core#description": "type with incorrect camel-case property",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
           "@id": "amf://id#8/source-map"

--- a/test/data/production/best-practices/negative11.raml.report.jsonld
+++ b/test/data/production/best-practices/negative11.raml.report.jsonld
@@ -137,7 +137,7 @@
                   "line": 9
                 }
               },
-              "uri": "file:///Users/abettati/mulesoft/amf-custom-validator/test/data/production/best-practices/negative11.raml"
+              "uri": "file://./test/data/production/best-practices/negative11.raml"
             },
             "resultMessage": "Use camelCase for all the names (fields), preferably don’t use underscores.",
             "resultSeverity": "http://www.w3.org/ns/shacl#Violation",
@@ -181,7 +181,7 @@
                       "line": 9
                     }
                   },
-                  "uri": "file:///Users/abettati/mulesoft/amf-custom-validator/test/data/production/best-practices/negative11.raml"
+                  "uri": "file://./test/data/production/best-practices/negative11.raml"
                 },
                 "resultPath": "http://www.w3.org/ns/shacl#name",
                 "traceValue": {

--- a/test/data/production/best-practices/negative2.yaml.jsonld
+++ b/test/data/production/best-practices/negative2.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -193,6 +193,7 @@
       "@id": "amf://id#21",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -240,6 +241,7 @@
       "@id": "amf://id#32",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -347,6 +349,7 @@
       "@id": "amf://id#26",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -365,6 +368,7 @@
       "@id": "amf://id#23",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -435,6 +439,7 @@
       "@id": "amf://id#35",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -453,6 +458,7 @@
       "@id": "amf://id#34",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -518,6 +524,7 @@
       "@id": "amf://id#29",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -540,6 +547,7 @@
       "@id": "amf://id#27",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "accept",
@@ -562,6 +570,7 @@
       "@id": "amf://id#9",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -578,6 +587,7 @@
       "@id": "amf://id#24",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "content-type",
@@ -662,6 +672,7 @@
       "@id": "amf://id#38",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -684,6 +695,7 @@
       "@id": "amf://id#36",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "accept",
@@ -706,6 +718,7 @@
       "@id": "amf://id#13",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/best-practices/negative3.yaml.jsonld
+++ b/test/data/production/best-practices/negative3.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -193,6 +193,7 @@
       "@id": "amf://id#21",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -240,6 +241,7 @@
       "@id": "amf://id#32",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -347,6 +349,7 @@
       "@id": "amf://id#26",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -365,6 +368,7 @@
       "@id": "amf://id#23",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -435,6 +439,7 @@
       "@id": "amf://id#37",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -453,6 +458,7 @@
       "@id": "amf://id#34",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -523,6 +529,7 @@
       "@id": "amf://id#29",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -545,6 +552,7 @@
       "@id": "amf://id#27",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "accept",
@@ -567,6 +575,7 @@
       "@id": "amf://id#9",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -583,6 +592,7 @@
       "@id": "amf://id#24",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "content-type",
@@ -667,6 +677,7 @@
       "@id": "amf://id#40",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -689,6 +700,7 @@
       "@id": "amf://id#38",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "accept",
@@ -711,6 +723,7 @@
       "@id": "amf://id#13",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -727,6 +740,7 @@
       "@id": "amf://id#35",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "content-type",

--- a/test/data/production/best-practices/negative4.yaml.jsonld
+++ b/test/data/production/best-practices/negative4.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -193,6 +193,7 @@
       "@id": "amf://id#27",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -240,6 +241,7 @@
       "@id": "amf://id#38",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -347,6 +349,7 @@
       "@id": "amf://id#32",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -365,6 +368,7 @@
       "@id": "amf://id#29",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -435,6 +439,7 @@
       "@id": "amf://id#43",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -453,6 +458,7 @@
       "@id": "amf://id#40",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -523,6 +529,7 @@
       "@id": "amf://id#35",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -545,6 +552,7 @@
       "@id": "amf://id#33",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "accept",
@@ -567,6 +575,7 @@
       "@id": "amf://id#15",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -583,6 +592,7 @@
       "@id": "amf://id#30",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "content-type",
@@ -667,6 +677,7 @@
       "@id": "amf://id#46",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -689,6 +700,7 @@
       "@id": "amf://id#44",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "accept",
@@ -711,6 +723,7 @@
       "@id": "amf://id#19",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -727,6 +740,7 @@
       "@id": "amf://id#41",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "content-type",

--- a/test/data/production/best-practices/negative5.yaml.jsonld
+++ b/test/data/production/best-practices/negative5.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -193,6 +193,7 @@
       "@id": "amf://id#31",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -240,6 +241,7 @@
       "@id": "amf://id#42",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -347,6 +349,7 @@
       "@id": "amf://id#36",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -365,6 +368,7 @@
       "@id": "amf://id#33",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -435,6 +439,7 @@
       "@id": "amf://id#47",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -453,6 +458,7 @@
       "@id": "amf://id#44",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -523,6 +529,7 @@
       "@id": "amf://id#39",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -545,6 +552,7 @@
       "@id": "amf://id#37",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "accept",
@@ -567,6 +575,7 @@
       "@id": "amf://id#19",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -583,6 +592,7 @@
       "@id": "amf://id#34",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "content-type",
@@ -667,6 +677,7 @@
       "@id": "amf://id#50",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -689,6 +700,7 @@
       "@id": "amf://id#48",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "accept",
@@ -711,6 +723,7 @@
       "@id": "amf://id#23",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -727,6 +740,7 @@
       "@id": "amf://id#45",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "content-type",

--- a/test/data/production/best-practices/negative6.yaml.jsonld
+++ b/test/data/production/best-practices/negative6.yaml.jsonld
@@ -5,19 +5,12 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
     {
       "@id": "amf://id#22",
-      "@type": [
-        "http://a.ml/vocabularies/document#BaseUnitSourceInformation"
-      ],
-      "http://a.ml/vocabularies/document#rootLocation": "file://./test/data/production/best-practices/negative6.yaml"
-    },
-    {
-      "@id": "amf://id#23",
       "@type": [
         "http://a.ml/vocabularies/apiContract#WebAPI",
         "http://a.ml/vocabularies/apiContract#API",
@@ -28,31 +21,38 @@
       "http://a.ml/vocabularies/core#description": "the awesome API",
       "http://a.ml/vocabularies/apiContract#server": [
         {
-          "@id": "amf://id#24"
+          "@id": "amf://id#23"
         }
       ],
       "http://a.ml/vocabularies/core#version": "1.0",
       "http://a.ml/vocabularies/core#documentation": [
         {
-          "@id": "amf://id#25"
+          "@id": "amf://id#24"
         }
       ],
       "http://a.ml/vocabularies/apiContract#endpoint": [
         {
-          "@id": "amf://id#26"
+          "@id": "amf://id#25"
         },
         {
-          "@id": "amf://id#37"
+          "@id": "amf://id#36"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#23/source-map"
+          "@id": "amf://id#22/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#24",
+      "@id": "amf://id/BaseUnitSourceInformation",
+      "@type": [
+        "http://a.ml/vocabularies/document#BaseUnitSourceInformation"
+      ],
+      "http://a.ml/vocabularies/document#rootLocation": "file://./test/data/production/best-practices/negative6.yaml"
+    },
+    {
+      "@id": "amf://id#23",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Server",
         "http://a.ml/vocabularies/document#DomainElement"
@@ -61,12 +61,12 @@
       "http://a.ml/vocabularies/core#description": "production environment",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#24/source-map"
+          "@id": "amf://id#23/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#25",
+      "@id": "amf://id#24",
       "@type": [
         "http://a.ml/vocabularies/core#CreativeWork",
         "http://a.ml/vocabularies/document#DomainElement"
@@ -79,12 +79,12 @@
       "http://a.ml/vocabularies/core#description": "",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#25/source-map"
+          "@id": "amf://id#24/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#26",
+      "@id": "amf://id#25",
       "@type": [
         "http://a.ml/vocabularies/apiContract#EndPoint",
         "http://a.ml/vocabularies/document#DomainElement"
@@ -92,22 +92,22 @@
       "http://a.ml/vocabularies/apiContract#path": "/users/{id}",
       "http://a.ml/vocabularies/apiContract#supportedOperation": [
         {
-          "@id": "amf://id#27"
+          "@id": "amf://id#26"
         }
       ],
       "http://a.ml/vocabularies/apiContract#server": [
         {
-          "@id": "amf://id#24"
+          "@id": "amf://id#23"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#26/source-map"
+          "@id": "amf://id#25/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#37",
+      "@id": "amf://id#36",
       "@type": [
         "http://a.ml/vocabularies/apiContract#EndPoint",
         "http://a.ml/vocabularies/document#DomainElement"
@@ -115,17 +115,43 @@
       "http://a.ml/vocabularies/apiContract#path": "/users-list/{id}",
       "http://a.ml/vocabularies/apiContract#supportedOperation": [
         {
-          "@id": "amf://id#38"
+          "@id": "amf://id#37"
         }
       ],
       "http://a.ml/vocabularies/apiContract#server": [
         {
-          "@id": "amf://id#24"
+          "@id": "amf://id#23"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#37/source-map"
+          "@id": "amf://id#36/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "amf://id#22/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "amf://id#22/source-map/lexical/element_5"
+        },
+        {
+          "@id": "amf://id#22/source-map/lexical/element_3"
+        },
+        {
+          "@id": "amf://id#22/source-map/lexical/element_1"
+        },
+        {
+          "@id": "amf://id#22/source-map/lexical/element_0"
+        },
+        {
+          "@id": "amf://id#22/source-map/lexical/element_2"
+        },
+        {
+          "@id": "amf://id#22/source-map/lexical/element_4"
         }
       ]
     },
@@ -136,22 +162,13 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#23/source-map/lexical/element_5"
-        },
-        {
-          "@id": "amf://id#23/source-map/lexical/element_3"
-        },
-        {
-          "@id": "amf://id#23/source-map/lexical/element_1"
+          "@id": "amf://id#23/source-map/lexical/element_2"
         },
         {
           "@id": "amf://id#23/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#23/source-map/lexical/element_2"
-        },
-        {
-          "@id": "amf://id#23/source-map/lexical/element_4"
+          "@id": "amf://id#23/source-map/lexical/element_1"
         }
       ]
     },
@@ -173,26 +190,58 @@
       ]
     },
     {
+      "@id": "amf://id#26",
+      "@type": [
+        "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/apiContract#method": "get",
+      "http://a.ml/vocabularies/core#name": "opid",
+      "http://a.ml/vocabularies/core#description": "op-description",
+      "http://a.ml/vocabularies/apiContract#expects": [
+        {
+          "@id": "amf://id#31"
+        }
+      ],
+      "http://a.ml/vocabularies/apiContract#returns": [
+        {
+          "@id": "amf://id#28"
+        }
+      ],
+      "http://a.ml/vocabularies/apiContract#tag": [
+        {
+          "@id": "amf://id#27"
+        }
+      ],
+      "http://a.ml/vocabularies/apiContract#server": [
+        {
+          "@id": "amf://id#23"
+        }
+      ],
+      "http://a.ml/vocabularies/apiContract#operationId": "opid",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "amf://id#26/source-map"
+        }
+      ]
+    },
+    {
       "@id": "amf://id#25/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#25/source-map/lexical/element_2"
-        },
-        {
           "@id": "amf://id#25/source-map/lexical/element_0"
-        },
-        {
-          "@id": "amf://id#25/source-map/lexical/element_1"
         }
       ]
     },
     {
-      "@id": "amf://id#27",
+      "@id": "amf://id#37",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -200,178 +249,133 @@
       "http://a.ml/vocabularies/core#description": "op-description",
       "http://a.ml/vocabularies/apiContract#expects": [
         {
-          "@id": "amf://id#32"
+          "@id": "amf://id#42"
         }
       ],
       "http://a.ml/vocabularies/apiContract#returns": [
-        {
-          "@id": "amf://id#29"
-        }
-      ],
-      "http://a.ml/vocabularies/apiContract#tag": [
-        {
-          "@id": "amf://id#28"
-        }
-      ],
-      "http://a.ml/vocabularies/apiContract#server": [
-        {
-          "@id": "amf://id#24"
-        }
-      ],
-      "http://a.ml/vocabularies/apiContract#operationId": "opid",
-      "http://a.ml/vocabularies/document-source-maps#sources": [
-        {
-          "@id": "amf://id#27/source-map"
-        }
-      ]
-    },
-    {
-      "@id": "amf://id#26/source-map",
-      "@type": [
-        "http://a.ml/vocabularies/document-source-maps#SourceMap"
-      ],
-      "http://a.ml/vocabularies/document-source-maps#lexical": [
-        {
-          "@id": "amf://id#26/source-map/lexical/element_0"
-        }
-      ]
-    },
-    {
-      "@id": "amf://id#38",
-      "@type": [
-        "http://a.ml/vocabularies/apiContract#Operation",
-        "http://a.ml/vocabularies/document#DomainElement"
-      ],
-      "http://a.ml/vocabularies/apiContract#method": "get",
-      "http://a.ml/vocabularies/core#name": "opid",
-      "http://a.ml/vocabularies/core#description": "op-description",
-      "http://a.ml/vocabularies/apiContract#expects": [
-        {
-          "@id": "amf://id#43"
-        }
-      ],
-      "http://a.ml/vocabularies/apiContract#returns": [
-        {
-          "@id": "amf://id#40"
-        }
-      ],
-      "http://a.ml/vocabularies/apiContract#tag": [
         {
           "@id": "amf://id#39"
         }
       ],
+      "http://a.ml/vocabularies/apiContract#tag": [
+        {
+          "@id": "amf://id#38"
+        }
+      ],
       "http://a.ml/vocabularies/apiContract#server": [
         {
-          "@id": "amf://id#24"
+          "@id": "amf://id#23"
         }
       ],
       "http://a.ml/vocabularies/apiContract#operationId": "opid",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#38/source-map"
+          "@id": "amf://id#37/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#37/source-map",
+      "@id": "amf://id#36/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#37/source-map/lexical/element_0"
+          "@id": "amf://id#36/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#23/source-map/lexical/element_5",
+      "@id": "amf://id#22/source-map/lexical/element_5",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#version",
       "http://a.ml/vocabularies/document-source-maps#value": "[(4,2)-(5,0)]"
     },
     {
-      "@id": "amf://id#23/source-map/lexical/element_3",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#23",
+      "@id": "amf://id#22/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#22",
       "http://a.ml/vocabularies/document-source-maps#value": "[(1,0)-(108,28)]"
     },
     {
-      "@id": "amf://id#23/source-map/lexical/element_1",
+      "@id": "amf://id#22/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#server",
       "http://a.ml/vocabularies/document-source-maps#value": "[(6,0)-(9,0)]"
     },
     {
-      "@id": "amf://id#23/source-map/lexical/element_0",
+      "@id": "amf://id#22/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#endpoint",
       "http://a.ml/vocabularies/document-source-maps#value": "[(47,0)-(108,28)]"
     },
     {
-      "@id": "amf://id#23/source-map/lexical/element_2",
+      "@id": "amf://id#22/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(3,2)-(4,0)]"
     },
     {
-      "@id": "amf://id#23/source-map/lexical/element_4",
+      "@id": "amf://id#22/source-map/lexical/element_4",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(5,2)-(6,0)]"
     },
     {
-      "@id": "amf://id#24/source-map/lexical/element_2",
+      "@id": "amf://id#23/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#urlTemplate",
       "http://a.ml/vocabularies/document-source-maps#value": "[(7,4)-(8,0)]"
     },
     {
-      "@id": "amf://id#24/source-map/lexical/element_0",
+      "@id": "amf://id#23/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(8,4)-(9,0)]"
     },
     {
-      "@id": "amf://id#24/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#24",
+      "@id": "amf://id#23/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#23",
       "http://a.ml/vocabularies/document-source-maps#value": "[(7,4)-(9,0)]"
     },
     {
-      "@id": "amf://id#25/source-map/lexical/element_2",
+      "@id": "amf://id#24/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#url",
       "http://a.ml/vocabularies/document-source-maps#value": "[(11,2)-(14,0)]"
     },
     {
-      "@id": "amf://id#25/source-map/lexical/element_0",
+      "@id": "amf://id#24/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(10,2)-(11,0)]"
     },
     {
-      "@id": "amf://id#25/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#25",
+      "@id": "amf://id#24/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#24",
       "http://a.ml/vocabularies/document-source-maps#value": "[(10,0)-(14,0)]"
     },
     {
-      "@id": "amf://id#32",
+      "@id": "amf://id#31",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#uriParameter": [
         {
-          "@id": "amf://id#35"
+          "@id": "amf://id#34"
         }
       ],
       "http://a.ml/vocabularies/core#name": "requestBody",
       "http://a.ml/vocabularies/apiContract#payload": [],
       "http://a.ml/vocabularies/apiContract#header": [
         {
-          "@id": "amf://id#33"
+          "@id": "amf://id#32"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#32/source-map"
+          "@id": "amf://id#31/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#29",
+      "@id": "amf://id#28",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -385,22 +389,9 @@
       ],
       "http://a.ml/vocabularies/apiContract#header": [
         {
-          "@id": "amf://id#30"
+          "@id": "amf://id#29"
         }
       ],
-      "http://a.ml/vocabularies/document-source-maps#sources": [
-        {
-          "@id": "amf://id#29/source-map"
-        }
-      ]
-    },
-    {
-      "@id": "amf://id#28",
-      "@type": [
-        "http://a.ml/vocabularies/apiContract#Tag",
-        "http://a.ml/vocabularies/document#DomainElement"
-      ],
-      "http://a.ml/vocabularies/core#name": "Invoice Items",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
           "@id": "amf://id#28/source-map"
@@ -408,61 +399,73 @@
       ]
     },
     {
-      "@id": "amf://id#27/source-map",
+      "@id": "amf://id#27",
+      "@type": [
+        "http://a.ml/vocabularies/apiContract#Tag",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/core#name": "Invoice Items",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "amf://id#27/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "amf://id#26/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#27/source-map/lexical/element_6"
+          "@id": "amf://id#26/source-map/lexical/element_5"
         },
         {
-          "@id": "amf://id#27/source-map/lexical/element_4"
+          "@id": "amf://id#26/source-map/lexical/element_3"
         },
         {
-          "@id": "amf://id#27/source-map/lexical/element_2"
+          "@id": "amf://id#26/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#27/source-map/lexical/element_0"
+          "@id": "amf://id#26/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#27/source-map/lexical/element_1"
+          "@id": "amf://id#26/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#27/source-map/lexical/element_3"
-        },
-        {
-          "@id": "amf://id#27/source-map/lexical/element_5"
+          "@id": "amf://id#26/source-map/lexical/element_4"
         }
       ]
     },
     {
-      "@id": "amf://id#26/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#26",
+      "@id": "amf://id#25/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#25",
       "http://a.ml/vocabularies/document-source-maps#value": "[(48,2)-(83,0)]"
     },
     {
-      "@id": "amf://id#43",
+      "@id": "amf://id#42",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#uriParameter": [
         {
-          "@id": "amf://id#46"
+          "@id": "amf://id#45"
         }
       ],
       "http://a.ml/vocabularies/apiContract#header": [
         {
-          "@id": "amf://id#44"
+          "@id": "amf://id#43"
         }
       ]
     },
     {
-      "@id": "amf://id#40",
+      "@id": "amf://id#39",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -471,22 +474,9 @@
       "http://a.ml/vocabularies/core#description": "teapot",
       "http://a.ml/vocabularies/apiContract#header": [
         {
-          "@id": "amf://id#41"
+          "@id": "amf://id#40"
         }
       ],
-      "http://a.ml/vocabularies/document-source-maps#sources": [
-        {
-          "@id": "amf://id#40/source-map"
-        }
-      ]
-    },
-    {
-      "@id": "amf://id#39",
-      "@type": [
-        "http://a.ml/vocabularies/apiContract#Tag",
-        "http://a.ml/vocabularies/document#DomainElement"
-      ],
-      "http://a.ml/vocabularies/core#name": "Invoice Items",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
           "@id": "amf://id#39/source-map"
@@ -494,40 +484,54 @@
       ]
     },
     {
-      "@id": "amf://id#38/source-map",
+      "@id": "amf://id#38",
+      "@type": [
+        "http://a.ml/vocabularies/apiContract#Tag",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/core#name": "Invoice Items",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "amf://id#38/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "amf://id#37/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#38/source-map/lexical/element_5"
+          "@id": "amf://id#37/source-map/lexical/element_5"
         },
         {
-          "@id": "amf://id#38/source-map/lexical/element_3"
+          "@id": "amf://id#37/source-map/lexical/element_3"
         },
         {
-          "@id": "amf://id#38/source-map/lexical/element_1"
+          "@id": "amf://id#37/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#38/source-map/lexical/element_0"
+          "@id": "amf://id#37/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#38/source-map/lexical/element_2"
+          "@id": "amf://id#37/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#38/source-map/lexical/element_4"
+          "@id": "amf://id#37/source-map/lexical/element_4"
         }
       ]
     },
     {
-      "@id": "amf://id#37/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#37",
+      "@id": "amf://id#36/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#36",
       "http://a.ml/vocabularies/document-source-maps#value": "[(83,2)-(108,28)]"
     },
     {
-      "@id": "amf://id#35",
+      "@id": "amf://id#34",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -538,18 +542,19 @@
       "http://a.ml/vocabularies/apiContract#explode": false,
       "http://a.ml/vocabularies/apiContract#binding": "path",
       "http://a.ml/vocabularies/shapes#schema": {
-        "@id": "amf://id#36"
+        "@id": "amf://id#35"
       },
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#35/source-map"
+          "@id": "amf://id#34/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#33",
+      "@id": "amf://id#32",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "accept",
@@ -560,25 +565,22 @@
       "http://a.ml/vocabularies/apiContract#explode": false,
       "http://a.ml/vocabularies/apiContract#binding": "header",
       "http://a.ml/vocabularies/shapes#schema": {
-        "@id": "amf://id#34"
+        "@id": "amf://id#33"
       },
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#33/source-map"
+          "@id": "amf://id#32/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#32/source-map",
+      "@id": "amf://id#31/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#32/source-map/lexical/element_1"
-        },
-        {
-          "@id": "amf://id#32/source-map/lexical/element_0"
+          "@id": "amf://id#31/source-map/lexical/element_0"
         }
       ]
     },
@@ -586,6 +588,7 @@
       "@id": "amf://id#19",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -599,9 +602,10 @@
       ]
     },
     {
-      "@id": "amf://id#30",
+      "@id": "amf://id#29",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "content-type",
@@ -610,34 +614,11 @@
       "http://a.ml/vocabularies/apiContract#explode": false,
       "http://a.ml/vocabularies/apiContract#binding": "header",
       "http://a.ml/vocabularies/shapes#schema": {
-        "@id": "amf://id#31"
+        "@id": "amf://id#30"
       },
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#30/source-map"
-        }
-      ]
-    },
-    {
-      "@id": "amf://id#29/source-map",
-      "@type": [
-        "http://a.ml/vocabularies/document-source-maps#SourceMap"
-      ],
-      "http://a.ml/vocabularies/document-source-maps#lexical": [
-        {
-          "@id": "amf://id#29/source-map/lexical/element_4"
-        },
-        {
-          "@id": "amf://id#29/source-map/lexical/element_2"
-        },
-        {
-          "@id": "amf://id#29/source-map/lexical/element_0"
-        },
-        {
-          "@id": "amf://id#29/source-map/lexical/element_1"
-        },
-        {
-          "@id": "amf://id#29/source-map/lexical/element_3"
+          "@id": "amf://id#29/source-map"
         }
       ]
     },
@@ -648,49 +629,68 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
+          "@id": "amf://id#28/source-map/lexical/element_4"
+        },
+        {
+          "@id": "amf://id#28/source-map/lexical/element_2"
+        },
+        {
           "@id": "amf://id#28/source-map/lexical/element_0"
+        },
+        {
+          "@id": "amf://id#28/source-map/lexical/element_1"
+        },
+        {
+          "@id": "amf://id#28/source-map/lexical/element_3"
         }
       ]
     },
     {
-      "@id": "amf://id#27/source-map/lexical/element_6",
+      "@id": "amf://id#27/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "amf://id#27/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "amf://id#26/source-map/lexical/element_5",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#tag",
       "http://a.ml/vocabularies/document-source-maps#value": "[(64,6)-(66,0)]"
     },
     {
-      "@id": "amf://id#27/source-map/lexical/element_4",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(63,6)-(64,0)]"
+      "@id": "amf://id#26/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#26",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(61,4)-(83,0)]"
     },
     {
-      "@id": "amf://id#27/source-map/lexical/element_2",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(62,6)-(63,0)]"
-    },
-    {
-      "@id": "amf://id#27/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#operationId",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(63,6)-(64,0)]"
-    },
-    {
-      "@id": "amf://id#27/source-map/lexical/element_1",
+      "@id": "amf://id#26/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#returns",
       "http://a.ml/vocabularies/document-source-maps#value": "[(68,6)-(83,0)]"
     },
     {
-      "@id": "amf://id#27/source-map/lexical/element_3",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#27",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(61,4)-(83,0)]"
+      "@id": "amf://id#26/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#operationId",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(63,6)-(64,0)]"
     },
     {
-      "@id": "amf://id#27/source-map/lexical/element_5",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#expects",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(66,6)-(68,0)]"
+      "@id": "amf://id#26/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(63,6)-(64,0)]"
     },
     {
-      "@id": "amf://id#46",
+      "@id": "amf://id#26/source-map/lexical/element_4",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(62,6)-(63,0)]"
+    },
+    {
+      "@id": "amf://id#45",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -701,18 +701,19 @@
       "http://a.ml/vocabularies/apiContract#explode": false,
       "http://a.ml/vocabularies/apiContract#binding": "path",
       "http://a.ml/vocabularies/shapes#schema": {
-        "@id": "amf://id#47"
+        "@id": "amf://id#46"
       },
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#46/source-map"
+          "@id": "amf://id#45/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#44",
+      "@id": "amf://id#43",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "accept",
@@ -723,18 +724,19 @@
       "http://a.ml/vocabularies/apiContract#explode": false,
       "http://a.ml/vocabularies/apiContract#binding": "header",
       "http://a.ml/vocabularies/shapes#schema": {
-        "@id": "amf://id#45"
+        "@id": "amf://id#44"
       },
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#44/source-map"
+          "@id": "amf://id#43/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#41",
+      "@id": "amf://id#40",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "content-type",
@@ -743,31 +745,11 @@
       "http://a.ml/vocabularies/apiContract#explode": false,
       "http://a.ml/vocabularies/apiContract#binding": "header",
       "http://a.ml/vocabularies/shapes#schema": {
-        "@id": "amf://id#42"
+        "@id": "amf://id#41"
       },
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#41/source-map"
-        }
-      ]
-    },
-    {
-      "@id": "amf://id#40/source-map",
-      "@type": [
-        "http://a.ml/vocabularies/document-source-maps#SourceMap"
-      ],
-      "http://a.ml/vocabularies/document-source-maps#lexical": [
-        {
-          "@id": "amf://id#40/source-map/lexical/element_3"
-        },
-        {
-          "@id": "amf://id#40/source-map/lexical/element_1"
-        },
-        {
-          "@id": "amf://id#40/source-map/lexical/element_0"
-        },
-        {
-          "@id": "amf://id#40/source-map/lexical/element_2"
+          "@id": "amf://id#40/source-map"
         }
       ]
     },
@@ -778,42 +760,62 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
+          "@id": "amf://id#39/source-map/lexical/element_3"
+        },
+        {
+          "@id": "amf://id#39/source-map/lexical/element_1"
+        },
+        {
           "@id": "amf://id#39/source-map/lexical/element_0"
+        },
+        {
+          "@id": "amf://id#39/source-map/lexical/element_2"
         }
       ]
     },
     {
-      "@id": "amf://id#38/source-map/lexical/element_5",
+      "@id": "amf://id#38/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "amf://id#38/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "amf://id#37/source-map/lexical/element_5",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#tag",
       "http://a.ml/vocabularies/document-source-maps#value": "[(99,6)-(101,0)]"
     },
     {
-      "@id": "amf://id#38/source-map/lexical/element_3",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#38",
+      "@id": "amf://id#37/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#37",
       "http://a.ml/vocabularies/document-source-maps#value": "[(96,4)-(108,28)]"
     },
     {
-      "@id": "amf://id#38/source-map/lexical/element_1",
+      "@id": "amf://id#37/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#returns",
       "http://a.ml/vocabularies/document-source-maps#value": "[(101,6)-(108,28)]"
     },
     {
-      "@id": "amf://id#38/source-map/lexical/element_0",
+      "@id": "amf://id#37/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#operationId",
       "http://a.ml/vocabularies/document-source-maps#value": "[(98,6)-(99,0)]"
     },
     {
-      "@id": "amf://id#38/source-map/lexical/element_2",
+      "@id": "amf://id#37/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(98,6)-(99,0)]"
     },
     {
-      "@id": "amf://id#38/source-map/lexical/element_4",
+      "@id": "amf://id#37/source-map/lexical/element_4",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(97,6)-(98,0)]"
     },
     {
-      "@id": "amf://id#36",
+      "@id": "amf://id#35",
       "@type": [
         "http://a.ml/vocabularies/shapes#ScalarShape",
         "http://a.ml/vocabularies/shapes#AnyShape",
@@ -829,49 +831,49 @@
       "http://www.w3.org/ns/shacl#name": "id",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#36/source-map"
+          "@id": "amf://id#35/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#35/source-map",
+      "@id": "amf://id#34/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#35/source-map/synthesized-field/element_1"
+          "@id": "amf://id#34/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "amf://id#35/source-map/synthesized-field/element_0"
+          "@id": "amf://id#34/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#35/source-map/lexical/element_6"
+          "@id": "amf://id#34/source-map/lexical/element_6"
         },
         {
-          "@id": "amf://id#35/source-map/lexical/element_4"
+          "@id": "amf://id#34/source-map/lexical/element_4"
         },
         {
-          "@id": "amf://id#35/source-map/lexical/element_2"
+          "@id": "amf://id#34/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#35/source-map/lexical/element_0"
+          "@id": "amf://id#34/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#35/source-map/lexical/element_1"
+          "@id": "amf://id#34/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#35/source-map/lexical/element_3"
+          "@id": "amf://id#34/source-map/lexical/element_3"
         },
         {
-          "@id": "amf://id#35/source-map/lexical/element_5"
+          "@id": "amf://id#34/source-map/lexical/element_5"
         }
       ]
     },
     {
-      "@id": "amf://id#34",
+      "@id": "amf://id#33",
       "@type": [
         "http://a.ml/vocabularies/shapes#ScalarShape",
         "http://a.ml/vocabularies/shapes#AnyShape",
@@ -887,54 +889,49 @@
       "http://www.w3.org/ns/shacl#name": "accept",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#34/source-map"
+          "@id": "amf://id#33/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#33/source-map",
+      "@id": "amf://id#32/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#33/source-map/synthesized-field/element_2"
+          "@id": "amf://id#32/source-map/synthesized-field/element_2"
         },
         {
-          "@id": "amf://id#33/source-map/synthesized-field/element_0"
+          "@id": "amf://id#32/source-map/synthesized-field/element_0"
         },
         {
-          "@id": "amf://id#33/source-map/synthesized-field/element_1"
+          "@id": "amf://id#32/source-map/synthesized-field/element_1"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#33/source-map/lexical/element_5"
+          "@id": "amf://id#32/source-map/lexical/element_5"
         },
         {
-          "@id": "amf://id#33/source-map/lexical/element_3"
+          "@id": "amf://id#32/source-map/lexical/element_3"
         },
         {
-          "@id": "amf://id#33/source-map/lexical/element_1"
+          "@id": "amf://id#32/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#33/source-map/lexical/element_0"
+          "@id": "amf://id#32/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#33/source-map/lexical/element_2"
+          "@id": "amf://id#32/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#33/source-map/lexical/element_4"
+          "@id": "amf://id#32/source-map/lexical/element_4"
         }
       ]
     },
     {
-      "@id": "amf://id#32/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#32",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(66,6)-(68,0)]"
-    },
-    {
-      "@id": "amf://id#32/source-map/lexical/element_0",
+      "@id": "amf://id#31/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(66,6)-(66,17)]"
     },
@@ -997,7 +994,7 @@
       ]
     },
     {
-      "@id": "amf://id#31",
+      "@id": "amf://id#30",
       "@type": [
         "http://a.ml/vocabularies/shapes#ScalarShape",
         "http://a.ml/vocabularies/shapes#AnyShape",
@@ -1013,70 +1010,70 @@
       "http://www.w3.org/ns/shacl#name": "schema",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#31/source-map"
+          "@id": "amf://id#30/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#30/source-map",
+      "@id": "amf://id#29/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#30/source-map/synthesized-field/element_2"
+          "@id": "amf://id#29/source-map/synthesized-field/element_2"
         },
         {
-          "@id": "amf://id#30/source-map/synthesized-field/element_0"
+          "@id": "amf://id#29/source-map/synthesized-field/element_0"
         },
         {
-          "@id": "amf://id#30/source-map/synthesized-field/element_1"
+          "@id": "amf://id#29/source-map/synthesized-field/element_1"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#30/source-map/lexical/element_2"
+          "@id": "amf://id#29/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#30/source-map/lexical/element_0"
+          "@id": "amf://id#29/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#30/source-map/lexical/element_1"
+          "@id": "amf://id#29/source-map/lexical/element_1"
         }
       ]
     },
     {
-      "@id": "amf://id#29/source-map/lexical/element_4",
+      "@id": "amf://id#28/source-map/lexical/element_4",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#payload",
       "http://a.ml/vocabularies/document-source-maps#value": "[(76,10)-(83,0)]"
     },
     {
-      "@id": "amf://id#29/source-map/lexical/element_2",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#29",
+      "@id": "amf://id#28/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#28",
       "http://a.ml/vocabularies/document-source-maps#value": "[(69,8)-(83,0)]"
     },
     {
-      "@id": "amf://id#29/source-map/lexical/element_0",
+      "@id": "amf://id#28/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#header",
       "http://a.ml/vocabularies/document-source-maps#value": "[(71,10)-(76,0)]"
     },
     {
-      "@id": "amf://id#29/source-map/lexical/element_1",
+      "@id": "amf://id#28/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(70,10)-(71,0)]"
     },
     {
-      "@id": "amf://id#29/source-map/lexical/element_3",
+      "@id": "amf://id#28/source-map/lexical/element_3",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(69,8)-(69,13)]"
     },
     {
-      "@id": "amf://id#28/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#28",
+      "@id": "amf://id#27/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#27",
       "http://a.ml/vocabularies/document-source-maps#value": "[(65,10)-(65,23)]"
     },
     {
-      "@id": "amf://id#47",
+      "@id": "amf://id#46",
       "@type": [
         "http://a.ml/vocabularies/shapes#ScalarShape",
         "http://a.ml/vocabularies/shapes#AnyShape",
@@ -1092,49 +1089,49 @@
       "http://www.w3.org/ns/shacl#name": "id",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#47/source-map"
+          "@id": "amf://id#46/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#46/source-map",
+      "@id": "amf://id#45/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#46/source-map/synthesized-field/element_1"
+          "@id": "amf://id#45/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "amf://id#46/source-map/synthesized-field/element_0"
+          "@id": "amf://id#45/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#46/source-map/lexical/element_6"
+          "@id": "amf://id#45/source-map/lexical/element_6"
         },
         {
-          "@id": "amf://id#46/source-map/lexical/element_4"
+          "@id": "amf://id#45/source-map/lexical/element_4"
         },
         {
-          "@id": "amf://id#46/source-map/lexical/element_2"
+          "@id": "amf://id#45/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#46/source-map/lexical/element_0"
+          "@id": "amf://id#45/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#46/source-map/lexical/element_1"
+          "@id": "amf://id#45/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#46/source-map/lexical/element_3"
+          "@id": "amf://id#45/source-map/lexical/element_3"
         },
         {
-          "@id": "amf://id#46/source-map/lexical/element_5"
+          "@id": "amf://id#45/source-map/lexical/element_5"
         }
       ]
     },
     {
-      "@id": "amf://id#45",
+      "@id": "amf://id#44",
       "@type": [
         "http://a.ml/vocabularies/shapes#ScalarShape",
         "http://a.ml/vocabularies/shapes#AnyShape",
@@ -1150,49 +1147,49 @@
       "http://www.w3.org/ns/shacl#name": "accept",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#45/source-map"
+          "@id": "amf://id#44/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#44/source-map",
+      "@id": "amf://id#43/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#44/source-map/synthesized-field/element_2"
+          "@id": "amf://id#43/source-map/synthesized-field/element_2"
         },
         {
-          "@id": "amf://id#44/source-map/synthesized-field/element_0"
+          "@id": "amf://id#43/source-map/synthesized-field/element_0"
         },
         {
-          "@id": "amf://id#44/source-map/synthesized-field/element_1"
+          "@id": "amf://id#43/source-map/synthesized-field/element_1"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#44/source-map/lexical/element_5"
+          "@id": "amf://id#43/source-map/lexical/element_5"
         },
         {
-          "@id": "amf://id#44/source-map/lexical/element_3"
+          "@id": "amf://id#43/source-map/lexical/element_3"
         },
         {
-          "@id": "amf://id#44/source-map/lexical/element_1"
+          "@id": "amf://id#43/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#44/source-map/lexical/element_0"
+          "@id": "amf://id#43/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#44/source-map/lexical/element_2"
+          "@id": "amf://id#43/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#44/source-map/lexical/element_4"
+          "@id": "amf://id#43/source-map/lexical/element_4"
         }
       ]
     },
     {
-      "@id": "amf://id#42",
+      "@id": "amf://id#41",
       "@type": [
         "http://a.ml/vocabularies/shapes#ScalarShape",
         "http://a.ml/vocabularies/shapes#AnyShape",
@@ -1208,204 +1205,204 @@
       "http://www.w3.org/ns/shacl#name": "schema",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#42/source-map"
+          "@id": "amf://id#41/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#41/source-map",
+      "@id": "amf://id#40/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#41/source-map/synthesized-field/element_2"
+          "@id": "amf://id#40/source-map/synthesized-field/element_2"
         },
         {
-          "@id": "amf://id#41/source-map/synthesized-field/element_0"
+          "@id": "amf://id#40/source-map/synthesized-field/element_0"
         },
         {
-          "@id": "amf://id#41/source-map/synthesized-field/element_1"
+          "@id": "amf://id#40/source-map/synthesized-field/element_1"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#41/source-map/lexical/element_2"
+          "@id": "amf://id#40/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#41/source-map/lexical/element_0"
+          "@id": "amf://id#40/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#41/source-map/lexical/element_1"
+          "@id": "amf://id#40/source-map/lexical/element_1"
         }
       ]
     },
     {
-      "@id": "amf://id#40/source-map/lexical/element_3",
+      "@id": "amf://id#39/source-map/lexical/element_3",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(103,10)-(104,0)]"
     },
     {
-      "@id": "amf://id#40/source-map/lexical/element_1",
+      "@id": "amf://id#39/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(102,8)-(102,13)]"
     },
     {
-      "@id": "amf://id#40/source-map/lexical/element_0",
+      "@id": "amf://id#39/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#header",
       "http://a.ml/vocabularies/document-source-maps#value": "[(104,10)-(108,28)]"
     },
     {
-      "@id": "amf://id#40/source-map/lexical/element_2",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#40",
+      "@id": "amf://id#39/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#39",
       "http://a.ml/vocabularies/document-source-maps#value": "[(102,8)-(108,28)]"
     },
     {
-      "@id": "amf://id#39/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#39",
+      "@id": "amf://id#38/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#38",
       "http://a.ml/vocabularies/document-source-maps#value": "[(100,10)-(100,23)]"
     },
     {
-      "@id": "amf://id#36/source-map",
+      "@id": "amf://id#35/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#auto-generated-name": [
         {
-          "@id": "amf://id#36/source-map/auto-generated-name/element_0"
+          "@id": "amf://id#35/source-map/auto-generated-name/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#36/source-map/lexical/element_2"
+          "@id": "amf://id#35/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#36/source-map/lexical/element_0"
+          "@id": "amf://id#35/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#36/source-map/lexical/element_1"
+          "@id": "amf://id#35/source-map/lexical/element_1"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
         {
-          "@id": "amf://id#36/source-map/type-property-lexical-info/element_0"
+          "@id": "amf://id#35/source-map/type-property-lexical-info/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#35/source-map/synthesized-field/element_1",
+      "@id": "amf://id#34/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#style",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#35/source-map/synthesized-field/element_0",
+      "@id": "amf://id#34/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#explode",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#35/source-map/lexical/element_6",
+      "@id": "amf://id#34/source-map/lexical/element_6",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#binding",
       "http://a.ml/vocabularies/document-source-maps#value": "[(51,8)-(52,0)]"
     },
     {
-      "@id": "amf://id#35/source-map/lexical/element_4",
+      "@id": "amf://id#34/source-map/lexical/element_4",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(50,8)-(51,0)]"
     },
     {
-      "@id": "amf://id#35/source-map/lexical/element_2",
+      "@id": "amf://id#34/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#paramName",
       "http://a.ml/vocabularies/document-source-maps#value": "[(50,8)-(51,0)]"
     },
     {
-      "@id": "amf://id#35/source-map/lexical/element_0",
+      "@id": "amf://id#34/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/shapes#schema",
       "http://a.ml/vocabularies/document-source-maps#value": "[(54,8)-(56,0)]"
     },
     {
-      "@id": "amf://id#35/source-map/lexical/element_1",
+      "@id": "amf://id#34/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#required",
       "http://a.ml/vocabularies/document-source-maps#value": "[(52,8)-(53,0)]"
     },
     {
-      "@id": "amf://id#35/source-map/lexical/element_3",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#35",
+      "@id": "amf://id#34/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#34",
       "http://a.ml/vocabularies/document-source-maps#value": "[(50,8)-(56,0)]"
     },
     {
-      "@id": "amf://id#35/source-map/lexical/element_5",
+      "@id": "amf://id#34/source-map/lexical/element_5",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(53,8)-(54,0)]"
     },
     {
-      "@id": "amf://id#34/source-map",
+      "@id": "amf://id#33/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#auto-generated-name": [
         {
-          "@id": "amf://id#34/source-map/auto-generated-name/element_0"
+          "@id": "amf://id#33/source-map/auto-generated-name/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#34/source-map/lexical/element_2"
+          "@id": "amf://id#33/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#34/source-map/lexical/element_0"
+          "@id": "amf://id#33/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#34/source-map/lexical/element_1"
+          "@id": "amf://id#33/source-map/lexical/element_1"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
         {
-          "@id": "amf://id#34/source-map/type-property-lexical-info/element_0"
+          "@id": "amf://id#33/source-map/type-property-lexical-info/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#33/source-map/synthesized-field/element_2",
+      "@id": "amf://id#32/source-map/synthesized-field/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#style",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#33/source-map/synthesized-field/element_0",
+      "@id": "amf://id#32/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#explode",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#33/source-map/synthesized-field/element_1",
+      "@id": "amf://id#32/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#required",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#33/source-map/lexical/element_5",
+      "@id": "amf://id#32/source-map/lexical/element_5",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#binding",
       "http://a.ml/vocabularies/document-source-maps#value": "[(58,8)-(59,0)]"
     },
     {
-      "@id": "amf://id#33/source-map/lexical/element_3",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#33",
+      "@id": "amf://id#32/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#32",
       "http://a.ml/vocabularies/document-source-maps#value": "[(56,8)-(61,0)]"
     },
     {
-      "@id": "amf://id#33/source-map/lexical/element_1",
+      "@id": "amf://id#32/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(57,8)-(58,0)]"
     },
     {
-      "@id": "amf://id#33/source-map/lexical/element_0",
+      "@id": "amf://id#32/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/shapes#schema",
       "http://a.ml/vocabularies/document-source-maps#value": "[(59,8)-(61,0)]"
     },
     {
-      "@id": "amf://id#33/source-map/lexical/element_2",
+      "@id": "amf://id#32/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(56,8)-(57,0)]"
     },
     {
-      "@id": "amf://id#33/source-map/lexical/element_4",
+      "@id": "amf://id#32/source-map/lexical/element_4",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#paramName",
       "http://a.ml/vocabularies/document-source-maps#value": "[(56,8)-(57,0)]"
     },
@@ -1608,295 +1605,295 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(77,12)-(83,0)]"
     },
     {
-      "@id": "amf://id#31/source-map",
+      "@id": "amf://id#30/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
         {
-          "@id": "amf://id#31/source-map/type-property-lexical-info/element_0"
+          "@id": "amf://id#30/source-map/type-property-lexical-info/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#31/source-map/lexical/element_1"
+          "@id": "amf://id#30/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#31/source-map/lexical/element_0"
+          "@id": "amf://id#30/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#30/source-map/synthesized-field/element_2",
+      "@id": "amf://id#29/source-map/synthesized-field/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#explode",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#30/source-map/synthesized-field/element_0",
+      "@id": "amf://id#29/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#binding",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#30/source-map/synthesized-field/element_1",
+      "@id": "amf://id#29/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#style",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#30/source-map/lexical/element_2",
+      "@id": "amf://id#29/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(73,14)-(74,0)]"
     },
     {
-      "@id": "amf://id#30/source-map/lexical/element_0",
+      "@id": "amf://id#29/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/shapes#schema",
       "http://a.ml/vocabularies/document-source-maps#value": "[(74,14)-(76,0)]"
     },
     {
-      "@id": "amf://id#30/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#30",
+      "@id": "amf://id#29/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#29",
       "http://a.ml/vocabularies/document-source-maps#value": "[(72,12)-(76,0)]"
     },
     {
-      "@id": "amf://id#47/source-map",
+      "@id": "amf://id#46/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#auto-generated-name": [
         {
-          "@id": "amf://id#47/source-map/auto-generated-name/element_0"
+          "@id": "amf://id#46/source-map/auto-generated-name/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#47/source-map/lexical/element_2"
+          "@id": "amf://id#46/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#47/source-map/lexical/element_0"
+          "@id": "amf://id#46/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#47/source-map/lexical/element_1"
+          "@id": "amf://id#46/source-map/lexical/element_1"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
         {
-          "@id": "amf://id#47/source-map/type-property-lexical-info/element_0"
+          "@id": "amf://id#46/source-map/type-property-lexical-info/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#46/source-map/synthesized-field/element_1",
+      "@id": "amf://id#45/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#style",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#46/source-map/synthesized-field/element_0",
+      "@id": "amf://id#45/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#explode",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#46/source-map/lexical/element_6",
+      "@id": "amf://id#45/source-map/lexical/element_6",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#binding",
       "http://a.ml/vocabularies/document-source-maps#value": "[(86,8)-(87,0)]"
     },
     {
-      "@id": "amf://id#46/source-map/lexical/element_4",
+      "@id": "amf://id#45/source-map/lexical/element_4",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(85,8)-(86,0)]"
     },
     {
-      "@id": "amf://id#46/source-map/lexical/element_2",
+      "@id": "amf://id#45/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#paramName",
       "http://a.ml/vocabularies/document-source-maps#value": "[(85,8)-(86,0)]"
     },
     {
-      "@id": "amf://id#46/source-map/lexical/element_0",
+      "@id": "amf://id#45/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/shapes#schema",
       "http://a.ml/vocabularies/document-source-maps#value": "[(89,8)-(91,0)]"
     },
     {
-      "@id": "amf://id#46/source-map/lexical/element_1",
+      "@id": "amf://id#45/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#required",
       "http://a.ml/vocabularies/document-source-maps#value": "[(87,8)-(88,0)]"
     },
     {
-      "@id": "amf://id#46/source-map/lexical/element_3",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#46",
+      "@id": "amf://id#45/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#45",
       "http://a.ml/vocabularies/document-source-maps#value": "[(85,8)-(91,0)]"
     },
     {
-      "@id": "amf://id#46/source-map/lexical/element_5",
+      "@id": "amf://id#45/source-map/lexical/element_5",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(88,8)-(89,0)]"
     },
     {
-      "@id": "amf://id#45/source-map",
+      "@id": "amf://id#44/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#auto-generated-name": [
         {
-          "@id": "amf://id#45/source-map/auto-generated-name/element_0"
+          "@id": "amf://id#44/source-map/auto-generated-name/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#45/source-map/lexical/element_2"
+          "@id": "amf://id#44/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#45/source-map/lexical/element_0"
+          "@id": "amf://id#44/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#45/source-map/lexical/element_1"
+          "@id": "amf://id#44/source-map/lexical/element_1"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
         {
-          "@id": "amf://id#45/source-map/type-property-lexical-info/element_0"
+          "@id": "amf://id#44/source-map/type-property-lexical-info/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#44/source-map/synthesized-field/element_2",
+      "@id": "amf://id#43/source-map/synthesized-field/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#style",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#44/source-map/synthesized-field/element_0",
+      "@id": "amf://id#43/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#explode",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#44/source-map/synthesized-field/element_1",
+      "@id": "amf://id#43/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#required",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#44/source-map/lexical/element_5",
+      "@id": "amf://id#43/source-map/lexical/element_5",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#binding",
       "http://a.ml/vocabularies/document-source-maps#value": "[(93,8)-(94,0)]"
     },
     {
-      "@id": "amf://id#44/source-map/lexical/element_3",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#44",
+      "@id": "amf://id#43/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#43",
       "http://a.ml/vocabularies/document-source-maps#value": "[(91,8)-(96,0)]"
     },
     {
-      "@id": "amf://id#44/source-map/lexical/element_1",
+      "@id": "amf://id#43/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(92,8)-(93,0)]"
     },
     {
-      "@id": "amf://id#44/source-map/lexical/element_0",
+      "@id": "amf://id#43/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/shapes#schema",
       "http://a.ml/vocabularies/document-source-maps#value": "[(94,8)-(96,0)]"
     },
     {
-      "@id": "amf://id#44/source-map/lexical/element_2",
+      "@id": "amf://id#43/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(91,8)-(92,0)]"
     },
     {
-      "@id": "amf://id#44/source-map/lexical/element_4",
+      "@id": "amf://id#43/source-map/lexical/element_4",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#paramName",
       "http://a.ml/vocabularies/document-source-maps#value": "[(91,8)-(92,0)]"
     },
     {
-      "@id": "amf://id#42/source-map",
+      "@id": "amf://id#41/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
         {
-          "@id": "amf://id#42/source-map/type-property-lexical-info/element_0"
+          "@id": "amf://id#41/source-map/type-property-lexical-info/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#42/source-map/lexical/element_1"
+          "@id": "amf://id#41/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#42/source-map/lexical/element_0"
+          "@id": "amf://id#41/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#41/source-map/synthesized-field/element_2",
+      "@id": "amf://id#40/source-map/synthesized-field/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#explode",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#41/source-map/synthesized-field/element_0",
+      "@id": "amf://id#40/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#binding",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#41/source-map/synthesized-field/element_1",
+      "@id": "amf://id#40/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#style",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#41/source-map/lexical/element_2",
+      "@id": "amf://id#40/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(106,14)-(107,0)]"
     },
     {
-      "@id": "amf://id#41/source-map/lexical/element_0",
+      "@id": "amf://id#40/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/shapes#schema",
       "http://a.ml/vocabularies/document-source-maps#value": "[(107,14)-(108,28)]"
     },
     {
-      "@id": "amf://id#41/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#41",
+      "@id": "amf://id#40/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#40",
       "http://a.ml/vocabularies/document-source-maps#value": "[(105,12)-(108,28)]"
     },
     {
-      "@id": "amf://id#36/source-map/auto-generated-name/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#36",
+      "@id": "amf://id#35/source-map/auto-generated-name/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#35",
       "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
-      "@id": "amf://id#36/source-map/lexical/element_2",
+      "@id": "amf://id#35/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "[(55,10)-(56,0)]"
     },
     {
-      "@id": "amf://id#36/source-map/lexical/element_0",
+      "@id": "amf://id#35/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(50,8)-(51,0)]"
     },
     {
-      "@id": "amf://id#36/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#36",
+      "@id": "amf://id#35/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#35",
       "http://a.ml/vocabularies/document-source-maps#value": "[(54,8)-(56,0)]"
     },
     {
-      "@id": "amf://id#36/source-map/type-property-lexical-info/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#36",
+      "@id": "amf://id#35/source-map/type-property-lexical-info/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#35",
       "http://a.ml/vocabularies/document-source-maps#value": "[(55,10)-(55,14)]"
     },
     {
-      "@id": "amf://id#34/source-map/auto-generated-name/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#34",
+      "@id": "amf://id#33/source-map/auto-generated-name/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#33",
       "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
-      "@id": "amf://id#34/source-map/lexical/element_2",
+      "@id": "amf://id#33/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "[(60,10)-(61,0)]"
     },
     {
-      "@id": "amf://id#34/source-map/lexical/element_0",
+      "@id": "amf://id#33/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(56,8)-(57,0)]"
     },
     {
-      "@id": "amf://id#34/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#34",
+      "@id": "amf://id#33/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#33",
       "http://a.ml/vocabularies/document-source-maps#value": "[(59,8)-(61,0)]"
     },
     {
-      "@id": "amf://id#34/source-map/type-property-lexical-info/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#34",
+      "@id": "amf://id#33/source-map/type-property-lexical-info/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#33",
       "http://a.ml/vocabularies/document-source-maps#value": "[(60,10)-(60,14)]"
     },
     {
@@ -2182,82 +2179,82 @@
       "http://a.ml/vocabularies/document-source-maps#value": "amf://id#1"
     },
     {
-      "@id": "amf://id#31/source-map/type-property-lexical-info/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#31",
+      "@id": "amf://id#30/source-map/type-property-lexical-info/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#30",
       "http://a.ml/vocabularies/document-source-maps#value": "[(75,16)-(75,20)]"
     },
     {
-      "@id": "amf://id#31/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#31",
+      "@id": "amf://id#30/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#30",
       "http://a.ml/vocabularies/document-source-maps#value": "[(74,14)-(76,0)]"
     },
     {
-      "@id": "amf://id#31/source-map/lexical/element_0",
+      "@id": "amf://id#30/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "[(75,16)-(76,0)]"
     },
     {
-      "@id": "amf://id#47/source-map/auto-generated-name/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#47",
+      "@id": "amf://id#46/source-map/auto-generated-name/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#46",
       "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
-      "@id": "amf://id#47/source-map/lexical/element_2",
+      "@id": "amf://id#46/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "[(90,10)-(91,0)]"
     },
     {
-      "@id": "amf://id#47/source-map/lexical/element_0",
+      "@id": "amf://id#46/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(85,8)-(86,0)]"
     },
     {
-      "@id": "amf://id#47/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#47",
+      "@id": "amf://id#46/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#46",
       "http://a.ml/vocabularies/document-source-maps#value": "[(89,8)-(91,0)]"
     },
     {
-      "@id": "amf://id#47/source-map/type-property-lexical-info/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#47",
+      "@id": "amf://id#46/source-map/type-property-lexical-info/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#46",
       "http://a.ml/vocabularies/document-source-maps#value": "[(90,10)-(90,14)]"
     },
     {
-      "@id": "amf://id#45/source-map/auto-generated-name/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#45",
+      "@id": "amf://id#44/source-map/auto-generated-name/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#44",
       "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
-      "@id": "amf://id#45/source-map/lexical/element_2",
+      "@id": "amf://id#44/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "[(95,10)-(96,0)]"
     },
     {
-      "@id": "amf://id#45/source-map/lexical/element_0",
+      "@id": "amf://id#44/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(91,8)-(92,0)]"
     },
     {
-      "@id": "amf://id#45/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#45",
+      "@id": "amf://id#44/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#44",
       "http://a.ml/vocabularies/document-source-maps#value": "[(94,8)-(96,0)]"
     },
     {
-      "@id": "amf://id#45/source-map/type-property-lexical-info/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#45",
+      "@id": "amf://id#44/source-map/type-property-lexical-info/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#44",
       "http://a.ml/vocabularies/document-source-maps#value": "[(95,10)-(95,14)]"
     },
     {
-      "@id": "amf://id#42/source-map/type-property-lexical-info/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#42",
+      "@id": "amf://id#41/source-map/type-property-lexical-info/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#41",
       "http://a.ml/vocabularies/document-source-maps#value": "[(108,16)-(108,20)]"
     },
     {
-      "@id": "amf://id#42/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#42",
+      "@id": "amf://id#41/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#41",
       "http://a.ml/vocabularies/document-source-maps#value": "[(107,14)-(108,28)]"
     },
     {
-      "@id": "amf://id#42/source-map/lexical/element_0",
+      "@id": "amf://id#41/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "[(108,16)-(108,28)]"
     },
@@ -2895,14 +2892,14 @@
         "http://a.ml/vocabularies/document#Unit"
       ],
       "http://a.ml/vocabularies/document#encodes": {
-        "@id": "amf://id#23"
+        "@id": "amf://id#22"
       },
       "http://a.ml/vocabularies/document#root": true,
       "http://a.ml/vocabularies/document#processingData": {
         "@id": "amf://id#21"
       },
       "http://a.ml/vocabularies/document#sourceInformation": {
-        "@id": "amf://id#22"
+        "@id": "amf://id/BaseUnitSourceInformation"
       }
     }
   ]

--- a/test/data/production/best-practices/negative6.yaml.report.jsonld
+++ b/test/data/production/best-practices/negative6.yaml.report.jsonld
@@ -105,7 +105,7 @@
               "reportSchema:ValidationResultNode",
               "shacl:ValidationResult"
             ],
-            "focusNode": "amf://id#40",
+            "focusNode": "amf://id#39",
             "location": {
               "@id": "violation_0_location",
               "@type": [

--- a/test/data/production/best-practices/negative7.yaml.jsonld
+++ b/test/data/production/best-practices/negative7.yaml.jsonld
@@ -5,19 +5,12 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
     {
       "@id": "amf://id#24",
-      "@type": [
-        "http://a.ml/vocabularies/document#BaseUnitSourceInformation"
-      ],
-      "http://a.ml/vocabularies/document#rootLocation": "file://./test/data/production/best-practices/negative7.yaml"
-    },
-    {
-      "@id": "amf://id#25",
       "@type": [
         "http://a.ml/vocabularies/apiContract#WebAPI",
         "http://a.ml/vocabularies/apiContract#API",
@@ -28,31 +21,38 @@
       "http://a.ml/vocabularies/core#description": "the awesome API",
       "http://a.ml/vocabularies/apiContract#server": [
         {
-          "@id": "amf://id#26"
+          "@id": "amf://id#25"
         }
       ],
       "http://a.ml/vocabularies/core#version": "1.0",
       "http://a.ml/vocabularies/core#documentation": [
         {
-          "@id": "amf://id#27"
+          "@id": "amf://id#26"
         }
       ],
       "http://a.ml/vocabularies/apiContract#endpoint": [
         {
-          "@id": "amf://id#28"
+          "@id": "amf://id#27"
         },
         {
-          "@id": "amf://id#41"
+          "@id": "amf://id#40"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#25/source-map"
+          "@id": "amf://id#24/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#26",
+      "@id": "amf://id/BaseUnitSourceInformation",
+      "@type": [
+        "http://a.ml/vocabularies/document#BaseUnitSourceInformation"
+      ],
+      "http://a.ml/vocabularies/document#rootLocation": "file://./test/data/production/best-practices/negative7.yaml"
+    },
+    {
+      "@id": "amf://id#25",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Server",
         "http://a.ml/vocabularies/document#DomainElement"
@@ -61,12 +61,12 @@
       "http://a.ml/vocabularies/core#description": "production environment",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#26/source-map"
+          "@id": "amf://id#25/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#27",
+      "@id": "amf://id#26",
       "@type": [
         "http://a.ml/vocabularies/core#CreativeWork",
         "http://a.ml/vocabularies/document#DomainElement"
@@ -79,12 +79,12 @@
       "http://a.ml/vocabularies/core#description": "",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#27/source-map"
+          "@id": "amf://id#26/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#28",
+      "@id": "amf://id#27",
       "@type": [
         "http://a.ml/vocabularies/apiContract#EndPoint",
         "http://a.ml/vocabularies/document#DomainElement"
@@ -92,22 +92,22 @@
       "http://a.ml/vocabularies/apiContract#path": "/users/{id}",
       "http://a.ml/vocabularies/apiContract#supportedOperation": [
         {
-          "@id": "amf://id#29"
+          "@id": "amf://id#28"
         }
       ],
       "http://a.ml/vocabularies/apiContract#server": [
         {
-          "@id": "amf://id#26"
+          "@id": "amf://id#25"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#28/source-map"
+          "@id": "amf://id#27/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#41",
+      "@id": "amf://id#40",
       "@type": [
         "http://a.ml/vocabularies/apiContract#EndPoint",
         "http://a.ml/vocabularies/document#DomainElement"
@@ -115,17 +115,43 @@
       "http://a.ml/vocabularies/apiContract#path": "/users-list/{id}",
       "http://a.ml/vocabularies/apiContract#supportedOperation": [
         {
-          "@id": "amf://id#42"
+          "@id": "amf://id#41"
         }
       ],
       "http://a.ml/vocabularies/apiContract#server": [
         {
-          "@id": "amf://id#26"
+          "@id": "amf://id#25"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#41/source-map"
+          "@id": "amf://id#40/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "amf://id#24/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "amf://id#24/source-map/lexical/element_5"
+        },
+        {
+          "@id": "amf://id#24/source-map/lexical/element_3"
+        },
+        {
+          "@id": "amf://id#24/source-map/lexical/element_1"
+        },
+        {
+          "@id": "amf://id#24/source-map/lexical/element_0"
+        },
+        {
+          "@id": "amf://id#24/source-map/lexical/element_2"
+        },
+        {
+          "@id": "amf://id#24/source-map/lexical/element_4"
         }
       ]
     },
@@ -136,22 +162,13 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#25/source-map/lexical/element_5"
-        },
-        {
-          "@id": "amf://id#25/source-map/lexical/element_3"
-        },
-        {
-          "@id": "amf://id#25/source-map/lexical/element_1"
+          "@id": "amf://id#25/source-map/lexical/element_2"
         },
         {
           "@id": "amf://id#25/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#25/source-map/lexical/element_2"
-        },
-        {
-          "@id": "amf://id#25/source-map/lexical/element_4"
+          "@id": "amf://id#25/source-map/lexical/element_1"
         }
       ]
     },
@@ -173,26 +190,10 @@
       ]
     },
     {
-      "@id": "amf://id#27/source-map",
-      "@type": [
-        "http://a.ml/vocabularies/document-source-maps#SourceMap"
-      ],
-      "http://a.ml/vocabularies/document-source-maps#lexical": [
-        {
-          "@id": "amf://id#27/source-map/lexical/element_2"
-        },
-        {
-          "@id": "amf://id#27/source-map/lexical/element_0"
-        },
-        {
-          "@id": "amf://id#27/source-map/lexical/element_1"
-        }
-      ]
-    },
-    {
-      "@id": "amf://id#29",
+      "@id": "amf://id#28",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -200,25 +201,214 @@
       "http://a.ml/vocabularies/core#description": "op-description",
       "http://a.ml/vocabularies/apiContract#expects": [
         {
-          "@id": "amf://id#35"
+          "@id": "amf://id#34"
         }
       ],
       "http://a.ml/vocabularies/apiContract#returns": [
         {
-          "@id": "amf://id#31"
+          "@id": "amf://id#30"
         }
       ],
       "http://a.ml/vocabularies/apiContract#tag": [
         {
-          "@id": "amf://id#30"
+          "@id": "amf://id#29"
         }
       ],
       "http://a.ml/vocabularies/apiContract#server": [
         {
-          "@id": "amf://id#26"
+          "@id": "amf://id#25"
         }
       ],
       "http://a.ml/vocabularies/apiContract#operationId": "opid",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "amf://id#28/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "amf://id#27/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "amf://id#27/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "amf://id#41",
+      "@type": [
+        "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/apiContract#method": "get",
+      "http://a.ml/vocabularies/core#name": "opid",
+      "http://a.ml/vocabularies/core#description": "op-description",
+      "http://a.ml/vocabularies/apiContract#expects": [
+        {
+          "@id": "amf://id#48"
+        }
+      ],
+      "http://a.ml/vocabularies/apiContract#returns": [
+        {
+          "@id": "amf://id#43"
+        }
+      ],
+      "http://a.ml/vocabularies/apiContract#tag": [
+        {
+          "@id": "amf://id#42"
+        }
+      ],
+      "http://a.ml/vocabularies/apiContract#server": [
+        {
+          "@id": "amf://id#25"
+        }
+      ],
+      "http://a.ml/vocabularies/apiContract#operationId": "opid",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "amf://id#41/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "amf://id#40/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "amf://id#40/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "amf://id#24/source-map/lexical/element_5",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#version",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(4,2)-(5,0)]"
+    },
+    {
+      "@id": "amf://id#24/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#24",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(1,0)-(123,25)]"
+    },
+    {
+      "@id": "amf://id#24/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#server",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(6,0)-(9,0)]"
+    },
+    {
+      "@id": "amf://id#24/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#endpoint",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(46,0)-(123,25)]"
+    },
+    {
+      "@id": "amf://id#24/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(3,2)-(4,0)]"
+    },
+    {
+      "@id": "amf://id#24/source-map/lexical/element_4",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(5,2)-(6,0)]"
+    },
+    {
+      "@id": "amf://id#25/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#urlTemplate",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(7,4)-(8,0)]"
+    },
+    {
+      "@id": "amf://id#25/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(8,4)-(9,0)]"
+    },
+    {
+      "@id": "amf://id#25/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#25",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(7,4)-(9,0)]"
+    },
+    {
+      "@id": "amf://id#26/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#url",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(11,2)-(13,0)]"
+    },
+    {
+      "@id": "amf://id#26/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(10,2)-(11,0)]"
+    },
+    {
+      "@id": "amf://id#26/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#26",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(10,0)-(13,0)]"
+    },
+    {
+      "@id": "amf://id#34",
+      "@type": [
+        "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
+        "http://a.ml/vocabularies/apiContract#Message",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/apiContract#uriParameter": [
+        {
+          "@id": "amf://id#38"
+        }
+      ],
+      "http://a.ml/vocabularies/core#name": "requestBody",
+      "http://a.ml/vocabularies/apiContract#payload": [
+        {
+          "@id": "amf://id#35"
+        }
+      ],
+      "http://a.ml/vocabularies/apiContract#header": [
+        {
+          "@id": "amf://id#36"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "amf://id#34/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "amf://id#30",
+      "@type": [
+        "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
+        "http://a.ml/vocabularies/apiContract#Message",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/apiContract#statusCode": "200",
+      "http://a.ml/vocabularies/core#name": "200",
+      "http://a.ml/vocabularies/core#description": "teapot",
+      "http://a.ml/vocabularies/apiContract#payload": [
+        {
+          "@id": "amf://id#33"
+        }
+      ],
+      "http://a.ml/vocabularies/apiContract#header": [
+        {
+          "@id": "amf://id#31"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "amf://id#30/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "amf://id#29",
+      "@type": [
+        "http://a.ml/vocabularies/apiContract#Tag",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/core#name": "Invoice Items",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
           "@id": "amf://id#29/source-map"
@@ -232,241 +422,54 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
+          "@id": "amf://id#28/source-map/lexical/element_5"
+        },
+        {
+          "@id": "amf://id#28/source-map/lexical/element_3"
+        },
+        {
+          "@id": "amf://id#28/source-map/lexical/element_1"
+        },
+        {
           "@id": "amf://id#28/source-map/lexical/element_0"
+        },
+        {
+          "@id": "amf://id#28/source-map/lexical/element_2"
+        },
+        {
+          "@id": "amf://id#28/source-map/lexical/element_4"
         }
       ]
-    },
-    {
-      "@id": "amf://id#42",
-      "@type": [
-        "http://a.ml/vocabularies/apiContract#Operation",
-        "http://a.ml/vocabularies/document#DomainElement"
-      ],
-      "http://a.ml/vocabularies/apiContract#method": "get",
-      "http://a.ml/vocabularies/core#name": "opid",
-      "http://a.ml/vocabularies/core#description": "op-description",
-      "http://a.ml/vocabularies/apiContract#expects": [
-        {
-          "@id": "amf://id#49"
-        }
-      ],
-      "http://a.ml/vocabularies/apiContract#returns": [
-        {
-          "@id": "amf://id#44"
-        }
-      ],
-      "http://a.ml/vocabularies/apiContract#tag": [
-        {
-          "@id": "amf://id#43"
-        }
-      ],
-      "http://a.ml/vocabularies/apiContract#server": [
-        {
-          "@id": "amf://id#26"
-        }
-      ],
-      "http://a.ml/vocabularies/apiContract#operationId": "opid",
-      "http://a.ml/vocabularies/document-source-maps#sources": [
-        {
-          "@id": "amf://id#42/source-map"
-        }
-      ]
-    },
-    {
-      "@id": "amf://id#41/source-map",
-      "@type": [
-        "http://a.ml/vocabularies/document-source-maps#SourceMap"
-      ],
-      "http://a.ml/vocabularies/document-source-maps#lexical": [
-        {
-          "@id": "amf://id#41/source-map/lexical/element_0"
-        }
-      ]
-    },
-    {
-      "@id": "amf://id#25/source-map/lexical/element_5",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#version",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(4,2)-(5,0)]"
-    },
-    {
-      "@id": "amf://id#25/source-map/lexical/element_3",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#25",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(1,0)-(123,25)]"
-    },
-    {
-      "@id": "amf://id#25/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#server",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(6,0)-(9,0)]"
-    },
-    {
-      "@id": "amf://id#25/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#endpoint",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(46,0)-(123,25)]"
-    },
-    {
-      "@id": "amf://id#25/source-map/lexical/element_2",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(3,2)-(4,0)]"
-    },
-    {
-      "@id": "amf://id#25/source-map/lexical/element_4",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(5,2)-(6,0)]"
-    },
-    {
-      "@id": "amf://id#26/source-map/lexical/element_2",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#urlTemplate",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(7,4)-(8,0)]"
-    },
-    {
-      "@id": "amf://id#26/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(8,4)-(9,0)]"
-    },
-    {
-      "@id": "amf://id#26/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#26",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(7,4)-(9,0)]"
-    },
-    {
-      "@id": "amf://id#27/source-map/lexical/element_2",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#url",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(11,2)-(13,0)]"
     },
     {
       "@id": "amf://id#27/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(10,2)-(11,0)]"
-    },
-    {
-      "@id": "amf://id#27/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "amf://id#27",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(10,0)-(13,0)]"
-    },
-    {
-      "@id": "amf://id#35",
-      "@type": [
-        "http://a.ml/vocabularies/apiContract#Request",
-        "http://a.ml/vocabularies/apiContract#Message",
-        "http://a.ml/vocabularies/document#DomainElement"
-      ],
-      "http://a.ml/vocabularies/apiContract#uriParameter": [
-        {
-          "@id": "amf://id#39"
-        }
-      ],
-      "http://a.ml/vocabularies/core#name": "requestBody",
-      "http://a.ml/vocabularies/apiContract#payload": [
-        {
-          "@id": "amf://id#36"
-        }
-      ],
-      "http://a.ml/vocabularies/apiContract#header": [
-        {
-          "@id": "amf://id#37"
-        }
-      ],
-      "http://a.ml/vocabularies/document-source-maps#sources": [
-        {
-          "@id": "amf://id#35/source-map"
-        }
-      ]
-    },
-    {
-      "@id": "amf://id#31",
-      "@type": [
-        "http://a.ml/vocabularies/apiContract#Response",
-        "http://a.ml/vocabularies/apiContract#Message",
-        "http://a.ml/vocabularies/document#DomainElement"
-      ],
-      "http://a.ml/vocabularies/apiContract#statusCode": "200",
-      "http://a.ml/vocabularies/core#name": "200",
-      "http://a.ml/vocabularies/core#description": "teapot",
-      "http://a.ml/vocabularies/apiContract#payload": [
-        {
-          "@id": "amf://id#34"
-        }
-      ],
-      "http://a.ml/vocabularies/apiContract#header": [
-        {
-          "@id": "amf://id#32"
-        }
-      ],
-      "http://a.ml/vocabularies/document-source-maps#sources": [
-        {
-          "@id": "amf://id#31/source-map"
-        }
-      ]
-    },
-    {
-      "@id": "amf://id#30",
-      "@type": [
-        "http://a.ml/vocabularies/apiContract#Tag",
-        "http://a.ml/vocabularies/document#DomainElement"
-      ],
-      "http://a.ml/vocabularies/core#name": "Invoice Items",
-      "http://a.ml/vocabularies/document-source-maps#sources": [
-        {
-          "@id": "amf://id#30/source-map"
-        }
-      ]
-    },
-    {
-      "@id": "amf://id#29/source-map",
-      "@type": [
-        "http://a.ml/vocabularies/document-source-maps#SourceMap"
-      ],
-      "http://a.ml/vocabularies/document-source-maps#lexical": [
-        {
-          "@id": "amf://id#29/source-map/lexical/element_6"
-        },
-        {
-          "@id": "amf://id#29/source-map/lexical/element_4"
-        },
-        {
-          "@id": "amf://id#29/source-map/lexical/element_2"
-        },
-        {
-          "@id": "amf://id#29/source-map/lexical/element_0"
-        },
-        {
-          "@id": "amf://id#29/source-map/lexical/element_1"
-        },
-        {
-          "@id": "amf://id#29/source-map/lexical/element_3"
-        },
-        {
-          "@id": "amf://id#29/source-map/lexical/element_5"
-        }
-      ]
-    },
-    {
-      "@id": "amf://id#28/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#28",
       "http://a.ml/vocabularies/document-source-maps#value": "[(47,2)-(84,0)]"
     },
     {
-      "@id": "amf://id#49",
+      "@id": "amf://id#48",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#uriParameter": [
         {
-          "@id": "amf://id#55"
+          "@id": "amf://id#54"
         }
       ],
       "http://a.ml/vocabularies/apiContract#header": [
         {
-          "@id": "amf://id#50"
+          "@id": "amf://id#49"
         }
       ]
     },
     {
-      "@id": "amf://id#44",
+      "@id": "amf://id#43",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -480,22 +483,9 @@
       ],
       "http://a.ml/vocabularies/apiContract#header": [
         {
-          "@id": "amf://id#45"
+          "@id": "amf://id#44"
         }
       ],
-      "http://a.ml/vocabularies/document-source-maps#sources": [
-        {
-          "@id": "amf://id#44/source-map"
-        }
-      ]
-    },
-    {
-      "@id": "amf://id#43",
-      "@type": [
-        "http://a.ml/vocabularies/apiContract#Tag",
-        "http://a.ml/vocabularies/document#DomainElement"
-      ],
-      "http://a.ml/vocabularies/core#name": "Invoice Items",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
           "@id": "amf://id#43/source-map"
@@ -503,40 +493,54 @@
       ]
     },
     {
-      "@id": "amf://id#42/source-map",
+      "@id": "amf://id#42",
+      "@type": [
+        "http://a.ml/vocabularies/apiContract#Tag",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/core#name": "Invoice Items",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "amf://id#42/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "amf://id#41/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#42/source-map/lexical/element_5"
+          "@id": "amf://id#41/source-map/lexical/element_5"
         },
         {
-          "@id": "amf://id#42/source-map/lexical/element_3"
+          "@id": "amf://id#41/source-map/lexical/element_3"
         },
         {
-          "@id": "amf://id#42/source-map/lexical/element_1"
+          "@id": "amf://id#41/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#42/source-map/lexical/element_0"
+          "@id": "amf://id#41/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#42/source-map/lexical/element_2"
+          "@id": "amf://id#41/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#42/source-map/lexical/element_4"
+          "@id": "amf://id#41/source-map/lexical/element_4"
         }
       ]
     },
     {
-      "@id": "amf://id#41/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#41",
+      "@id": "amf://id#40/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#40",
       "http://a.ml/vocabularies/document-source-maps#value": "[(84,2)-(123,25)]"
     },
     {
-      "@id": "amf://id#39",
+      "@id": "amf://id#38",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -547,18 +551,19 @@
       "http://a.ml/vocabularies/apiContract#explode": false,
       "http://a.ml/vocabularies/apiContract#binding": "path",
       "http://a.ml/vocabularies/shapes#schema": {
-        "@id": "amf://id#40"
+        "@id": "amf://id#39"
       },
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#39/source-map"
+          "@id": "amf://id#38/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#36",
+      "@id": "amf://id#35",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -567,14 +572,15 @@
       },
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#36/source-map"
+          "@id": "amf://id#35/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#37",
+      "@id": "amf://id#36",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "accept",
@@ -585,32 +591,30 @@
       "http://a.ml/vocabularies/apiContract#explode": false,
       "http://a.ml/vocabularies/apiContract#binding": "header",
       "http://a.ml/vocabularies/shapes#schema": {
-        "@id": "amf://id#38"
+        "@id": "amf://id#37"
       },
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#37/source-map"
+          "@id": "amf://id#36/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#35/source-map",
+      "@id": "amf://id#34/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#35/source-map/lexical/element_1"
-        },
-        {
-          "@id": "amf://id#35/source-map/lexical/element_0"
+          "@id": "amf://id#34/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#34",
+      "@id": "amf://id#33",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -619,14 +623,15 @@
       },
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#34/source-map"
+          "@id": "amf://id#33/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#32",
+      "@id": "amf://id#31",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "content-type",
@@ -635,34 +640,11 @@
       "http://a.ml/vocabularies/apiContract#explode": false,
       "http://a.ml/vocabularies/apiContract#binding": "header",
       "http://a.ml/vocabularies/shapes#schema": {
-        "@id": "amf://id#33"
+        "@id": "amf://id#32"
       },
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#32/source-map"
-        }
-      ]
-    },
-    {
-      "@id": "amf://id#31/source-map",
-      "@type": [
-        "http://a.ml/vocabularies/document-source-maps#SourceMap"
-      ],
-      "http://a.ml/vocabularies/document-source-maps#lexical": [
-        {
-          "@id": "amf://id#31/source-map/lexical/element_4"
-        },
-        {
-          "@id": "amf://id#31/source-map/lexical/element_2"
-        },
-        {
-          "@id": "amf://id#31/source-map/lexical/element_0"
-        },
-        {
-          "@id": "amf://id#31/source-map/lexical/element_1"
-        },
-        {
-          "@id": "amf://id#31/source-map/lexical/element_3"
+          "@id": "amf://id#31/source-map"
         }
       ]
     },
@@ -673,49 +655,68 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
+          "@id": "amf://id#30/source-map/lexical/element_4"
+        },
+        {
+          "@id": "amf://id#30/source-map/lexical/element_2"
+        },
+        {
           "@id": "amf://id#30/source-map/lexical/element_0"
+        },
+        {
+          "@id": "amf://id#30/source-map/lexical/element_1"
+        },
+        {
+          "@id": "amf://id#30/source-map/lexical/element_3"
         }
       ]
     },
     {
-      "@id": "amf://id#29/source-map/lexical/element_6",
+      "@id": "amf://id#29/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "amf://id#29/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "amf://id#28/source-map/lexical/element_5",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#tag",
       "http://a.ml/vocabularies/document-source-maps#value": "[(63,6)-(65,0)]"
     },
     {
-      "@id": "amf://id#29/source-map/lexical/element_4",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(62,6)-(63,0)]"
+      "@id": "amf://id#28/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#28",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(60,4)-(84,0)]"
     },
     {
-      "@id": "amf://id#29/source-map/lexical/element_2",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(61,6)-(62,0)]"
-    },
-    {
-      "@id": "amf://id#29/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#operationId",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(62,6)-(63,0)]"
-    },
-    {
-      "@id": "amf://id#29/source-map/lexical/element_1",
+      "@id": "amf://id#28/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#returns",
       "http://a.ml/vocabularies/document-source-maps#value": "[(71,6)-(84,0)]"
     },
     {
-      "@id": "amf://id#29/source-map/lexical/element_3",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#29",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(60,4)-(84,0)]"
+      "@id": "amf://id#28/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#operationId",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(62,6)-(63,0)]"
     },
     {
-      "@id": "amf://id#29/source-map/lexical/element_5",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#expects",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(65,6)-(71,0)]"
+      "@id": "amf://id#28/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(62,6)-(63,0)]"
     },
     {
-      "@id": "amf://id#55",
+      "@id": "amf://id#28/source-map/lexical/element_4",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(61,6)-(62,0)]"
+    },
+    {
+      "@id": "amf://id#54",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -726,18 +727,19 @@
       "http://a.ml/vocabularies/apiContract#explode": false,
       "http://a.ml/vocabularies/apiContract#binding": "path",
       "http://a.ml/vocabularies/shapes#schema": {
-        "@id": "amf://id#56"
+        "@id": "amf://id#55"
       },
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#55/source-map"
+          "@id": "amf://id#54/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#50",
+      "@id": "amf://id#49",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "accept",
@@ -748,16 +750,16 @@
       "http://a.ml/vocabularies/apiContract#explode": false,
       "http://a.ml/vocabularies/apiContract#binding": "header",
       "http://a.ml/vocabularies/shapes#schema": {
-        "@id": "amf://id#51"
+        "@id": "amf://id#50"
       },
       "http://a.ml/vocabularies/apiContract#examples": [
         {
-          "@id": "amf://id#52"
+          "@id": "amf://id#51"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#50/source-map"
+          "@id": "amf://id#49/source-map"
         }
       ]
     },
@@ -765,6 +767,7 @@
       "@id": "amf://id#19",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -778,9 +781,10 @@
       ]
     },
     {
-      "@id": "amf://id#45",
+      "@id": "amf://id#44",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "content-type",
@@ -789,39 +793,16 @@
       "http://a.ml/vocabularies/apiContract#explode": false,
       "http://a.ml/vocabularies/apiContract#binding": "header",
       "http://a.ml/vocabularies/shapes#schema": {
-        "@id": "amf://id#46"
+        "@id": "amf://id#45"
       },
       "http://a.ml/vocabularies/apiContract#examples": [
         {
-          "@id": "amf://id#47"
+          "@id": "amf://id#46"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#45/source-map"
-        }
-      ]
-    },
-    {
-      "@id": "amf://id#44/source-map",
-      "@type": [
-        "http://a.ml/vocabularies/document-source-maps#SourceMap"
-      ],
-      "http://a.ml/vocabularies/document-source-maps#lexical": [
-        {
-          "@id": "amf://id#44/source-map/lexical/element_4"
-        },
-        {
-          "@id": "amf://id#44/source-map/lexical/element_2"
-        },
-        {
-          "@id": "amf://id#44/source-map/lexical/element_0"
-        },
-        {
-          "@id": "amf://id#44/source-map/lexical/element_1"
-        },
-        {
-          "@id": "amf://id#44/source-map/lexical/element_3"
+          "@id": "amf://id#44/source-map"
         }
       ]
     },
@@ -832,42 +813,65 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
+          "@id": "amf://id#43/source-map/lexical/element_4"
+        },
+        {
+          "@id": "amf://id#43/source-map/lexical/element_2"
+        },
+        {
           "@id": "amf://id#43/source-map/lexical/element_0"
+        },
+        {
+          "@id": "amf://id#43/source-map/lexical/element_1"
+        },
+        {
+          "@id": "amf://id#43/source-map/lexical/element_3"
         }
       ]
     },
     {
-      "@id": "amf://id#42/source-map/lexical/element_5",
+      "@id": "amf://id#42/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "amf://id#42/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "amf://id#41/source-map/lexical/element_5",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#tag",
       "http://a.ml/vocabularies/document-source-maps#value": "[(104,6)-(106,0)]"
     },
     {
-      "@id": "amf://id#42/source-map/lexical/element_3",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#42",
+      "@id": "amf://id#41/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#41",
       "http://a.ml/vocabularies/document-source-maps#value": "[(101,4)-(123,25)]"
     },
     {
-      "@id": "amf://id#42/source-map/lexical/element_1",
+      "@id": "amf://id#41/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#returns",
       "http://a.ml/vocabularies/document-source-maps#value": "[(106,6)-(123,25)]"
     },
     {
-      "@id": "amf://id#42/source-map/lexical/element_0",
+      "@id": "amf://id#41/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#operationId",
       "http://a.ml/vocabularies/document-source-maps#value": "[(103,6)-(104,0)]"
     },
     {
-      "@id": "amf://id#42/source-map/lexical/element_2",
+      "@id": "amf://id#41/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(103,6)-(104,0)]"
     },
     {
-      "@id": "amf://id#42/source-map/lexical/element_4",
+      "@id": "amf://id#41/source-map/lexical/element_4",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(102,6)-(103,0)]"
     },
     {
-      "@id": "amf://id#40",
+      "@id": "amf://id#39",
       "@type": [
         "http://a.ml/vocabularies/shapes#ScalarShape",
         "http://a.ml/vocabularies/shapes#AnyShape",
@@ -883,44 +887,44 @@
       "http://www.w3.org/ns/shacl#name": "id",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#40/source-map"
+          "@id": "amf://id#39/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#39/source-map",
+      "@id": "amf://id#38/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#39/source-map/synthesized-field/element_1"
+          "@id": "amf://id#38/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "amf://id#39/source-map/synthesized-field/element_0"
+          "@id": "amf://id#38/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#39/source-map/lexical/element_6"
+          "@id": "amf://id#38/source-map/lexical/element_6"
         },
         {
-          "@id": "amf://id#39/source-map/lexical/element_4"
+          "@id": "amf://id#38/source-map/lexical/element_4"
         },
         {
-          "@id": "amf://id#39/source-map/lexical/element_2"
+          "@id": "amf://id#38/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#39/source-map/lexical/element_0"
+          "@id": "amf://id#38/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#39/source-map/lexical/element_1"
+          "@id": "amf://id#38/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#39/source-map/lexical/element_3"
+          "@id": "amf://id#38/source-map/lexical/element_3"
         },
         {
-          "@id": "amf://id#39/source-map/lexical/element_5"
+          "@id": "amf://id#38/source-map/lexical/element_5"
         }
       ]
     },
@@ -966,24 +970,24 @@
       ]
     },
     {
-      "@id": "amf://id#36/source-map",
+      "@id": "amf://id#35/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#36/source-map/lexical/element_2"
+          "@id": "amf://id#35/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#36/source-map/lexical/element_0"
+          "@id": "amf://id#35/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#36/source-map/lexical/element_1"
+          "@id": "amf://id#35/source-map/lexical/element_1"
         }
       ]
     },
     {
-      "@id": "amf://id#38",
+      "@id": "amf://id#37",
       "@type": [
         "http://a.ml/vocabularies/shapes#ScalarShape",
         "http://a.ml/vocabularies/shapes#AnyShape",
@@ -999,76 +1003,71 @@
       "http://www.w3.org/ns/shacl#name": "accept",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#38/source-map"
+          "@id": "amf://id#37/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#37/source-map",
+      "@id": "amf://id#36/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#37/source-map/synthesized-field/element_2"
+          "@id": "amf://id#36/source-map/synthesized-field/element_2"
         },
         {
-          "@id": "amf://id#37/source-map/synthesized-field/element_0"
+          "@id": "amf://id#36/source-map/synthesized-field/element_0"
         },
         {
-          "@id": "amf://id#37/source-map/synthesized-field/element_1"
+          "@id": "amf://id#36/source-map/synthesized-field/element_1"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#37/source-map/lexical/element_5"
+          "@id": "amf://id#36/source-map/lexical/element_5"
         },
         {
-          "@id": "amf://id#37/source-map/lexical/element_3"
+          "@id": "amf://id#36/source-map/lexical/element_3"
         },
         {
-          "@id": "amf://id#37/source-map/lexical/element_1"
+          "@id": "amf://id#36/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#37/source-map/lexical/element_0"
+          "@id": "amf://id#36/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#37/source-map/lexical/element_2"
+          "@id": "amf://id#36/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#37/source-map/lexical/element_4"
+          "@id": "amf://id#36/source-map/lexical/element_4"
         }
       ]
     },
     {
-      "@id": "amf://id#35/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#35",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(65,6)-(71,0)]"
-    },
-    {
-      "@id": "amf://id#35/source-map/lexical/element_0",
+      "@id": "amf://id#34/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(65,6)-(65,17)]"
     },
     {
-      "@id": "amf://id#34/source-map",
+      "@id": "amf://id#33/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#34/source-map/lexical/element_2"
+          "@id": "amf://id#33/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#34/source-map/lexical/element_0"
+          "@id": "amf://id#33/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#34/source-map/lexical/element_1"
+          "@id": "amf://id#33/source-map/lexical/element_1"
         }
       ]
     },
     {
-      "@id": "amf://id#33",
+      "@id": "amf://id#32",
       "@type": [
         "http://a.ml/vocabularies/shapes#ScalarShape",
         "http://a.ml/vocabularies/shapes#AnyShape",
@@ -1084,70 +1083,70 @@
       "http://www.w3.org/ns/shacl#name": "schema",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#33/source-map"
+          "@id": "amf://id#32/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#32/source-map",
+      "@id": "amf://id#31/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#32/source-map/synthesized-field/element_2"
+          "@id": "amf://id#31/source-map/synthesized-field/element_2"
         },
         {
-          "@id": "amf://id#32/source-map/synthesized-field/element_0"
+          "@id": "amf://id#31/source-map/synthesized-field/element_0"
         },
         {
-          "@id": "amf://id#32/source-map/synthesized-field/element_1"
+          "@id": "amf://id#31/source-map/synthesized-field/element_1"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#32/source-map/lexical/element_2"
+          "@id": "amf://id#31/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#32/source-map/lexical/element_0"
+          "@id": "amf://id#31/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#32/source-map/lexical/element_1"
+          "@id": "amf://id#31/source-map/lexical/element_1"
         }
       ]
     },
     {
-      "@id": "amf://id#31/source-map/lexical/element_4",
+      "@id": "amf://id#30/source-map/lexical/element_4",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#payload",
       "http://a.ml/vocabularies/document-source-maps#value": "[(79,10)-(84,0)]"
     },
     {
-      "@id": "amf://id#31/source-map/lexical/element_2",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#31",
+      "@id": "amf://id#30/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#30",
       "http://a.ml/vocabularies/document-source-maps#value": "[(72,8)-(84,0)]"
     },
     {
-      "@id": "amf://id#31/source-map/lexical/element_0",
+      "@id": "amf://id#30/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#header",
       "http://a.ml/vocabularies/document-source-maps#value": "[(74,10)-(79,0)]"
     },
     {
-      "@id": "amf://id#31/source-map/lexical/element_1",
+      "@id": "amf://id#30/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(73,10)-(74,0)]"
     },
     {
-      "@id": "amf://id#31/source-map/lexical/element_3",
+      "@id": "amf://id#30/source-map/lexical/element_3",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(72,8)-(72,13)]"
     },
     {
-      "@id": "amf://id#30/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#30",
+      "@id": "amf://id#29/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#29",
       "http://a.ml/vocabularies/document-source-maps#value": "[(64,10)-(64,23)]"
     },
     {
-      "@id": "amf://id#56",
+      "@id": "amf://id#55",
       "@type": [
         "http://a.ml/vocabularies/shapes#ScalarShape",
         "http://a.ml/vocabularies/shapes#AnyShape",
@@ -1163,54 +1162,54 @@
       "http://www.w3.org/ns/shacl#name": "id",
       "http://a.ml/vocabularies/apiContract#examples": [
         {
-          "@id": "amf://id#57"
+          "@id": "amf://id#56"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#56/source-map"
+          "@id": "amf://id#55/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#55/source-map",
+      "@id": "amf://id#54/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#55/source-map/synthesized-field/element_1"
+          "@id": "amf://id#54/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "amf://id#55/source-map/synthesized-field/element_0"
+          "@id": "amf://id#54/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#55/source-map/lexical/element_6"
+          "@id": "amf://id#54/source-map/lexical/element_6"
         },
         {
-          "@id": "amf://id#55/source-map/lexical/element_4"
+          "@id": "amf://id#54/source-map/lexical/element_4"
         },
         {
-          "@id": "amf://id#55/source-map/lexical/element_2"
+          "@id": "amf://id#54/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#55/source-map/lexical/element_0"
+          "@id": "amf://id#54/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#55/source-map/lexical/element_1"
+          "@id": "amf://id#54/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#55/source-map/lexical/element_3"
+          "@id": "amf://id#54/source-map/lexical/element_3"
         },
         {
-          "@id": "amf://id#55/source-map/lexical/element_5"
+          "@id": "amf://id#54/source-map/lexical/element_5"
         }
       ]
     },
     {
-      "@id": "amf://id#51",
+      "@id": "amf://id#50",
       "@type": [
         "http://a.ml/vocabularies/shapes#ScalarShape",
         "http://a.ml/vocabularies/shapes#AnyShape",
@@ -1226,64 +1225,64 @@
       "http://www.w3.org/ns/shacl#name": "accept",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#51/source-map"
+          "@id": "amf://id#50/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#52",
+      "@id": "amf://id#51",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Example",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/document#strict": true,
       "http://a.ml/vocabularies/document#structuredValue": {
-        "@id": "amf://id#53"
+        "@id": "amf://id#52"
       },
       "http://a.ml/vocabularies/document#raw": "name: a",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#52/source-map"
+          "@id": "amf://id#51/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#50/source-map",
+      "@id": "amf://id#49/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#50/source-map/synthesized-field/element_2"
+          "@id": "amf://id#49/source-map/synthesized-field/element_2"
         },
         {
-          "@id": "amf://id#50/source-map/synthesized-field/element_0"
+          "@id": "amf://id#49/source-map/synthesized-field/element_0"
         },
         {
-          "@id": "amf://id#50/source-map/synthesized-field/element_1"
+          "@id": "amf://id#49/source-map/synthesized-field/element_1"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#50/source-map/lexical/element_6"
+          "@id": "amf://id#49/source-map/lexical/element_6"
         },
         {
-          "@id": "amf://id#50/source-map/lexical/element_4"
+          "@id": "amf://id#49/source-map/lexical/element_4"
         },
         {
-          "@id": "amf://id#50/source-map/lexical/element_2"
+          "@id": "amf://id#49/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#50/source-map/lexical/element_0"
+          "@id": "amf://id#49/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#50/source-map/lexical/element_1"
+          "@id": "amf://id#49/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#50/source-map/lexical/element_3"
+          "@id": "amf://id#49/source-map/lexical/element_3"
         },
         {
-          "@id": "amf://id#50/source-map/lexical/element_5"
+          "@id": "amf://id#49/source-map/lexical/element_5"
         }
       ]
     },
@@ -1305,7 +1304,7 @@
       ]
     },
     {
-      "@id": "amf://id#46",
+      "@id": "amf://id#45",
       "@type": [
         "http://a.ml/vocabularies/shapes#ScalarShape",
         "http://a.ml/vocabularies/shapes#AnyShape",
@@ -1321,157 +1320,157 @@
       "http://www.w3.org/ns/shacl#name": "schema",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#46/source-map"
+          "@id": "amf://id#45/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#47",
+      "@id": "amf://id#46",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Example",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/document#strict": true,
       "http://a.ml/vocabularies/document#structuredValue": {
-        "@id": "amf://id#48"
+        "@id": "amf://id#47"
       },
       "http://a.ml/vocabularies/document#raw": "teapot",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#47/source-map"
+          "@id": "amf://id#46/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#45/source-map",
+      "@id": "amf://id#44/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#45/source-map/synthesized-field/element_2"
+          "@id": "amf://id#44/source-map/synthesized-field/element_2"
         },
         {
-          "@id": "amf://id#45/source-map/synthesized-field/element_0"
+          "@id": "amf://id#44/source-map/synthesized-field/element_0"
         },
         {
-          "@id": "amf://id#45/source-map/synthesized-field/element_1"
+          "@id": "amf://id#44/source-map/synthesized-field/element_1"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#45/source-map/lexical/element_3"
+          "@id": "amf://id#44/source-map/lexical/element_3"
         },
         {
-          "@id": "amf://id#45/source-map/lexical/element_1"
+          "@id": "amf://id#44/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#45/source-map/lexical/element_0"
+          "@id": "amf://id#44/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#45/source-map/lexical/element_2"
+          "@id": "amf://id#44/source-map/lexical/element_2"
         }
       ]
     },
     {
-      "@id": "amf://id#44/source-map/lexical/element_4",
+      "@id": "amf://id#43/source-map/lexical/element_4",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#payload",
       "http://a.ml/vocabularies/document-source-maps#value": "[(116,10)-(123,25)]"
     },
     {
-      "@id": "amf://id#44/source-map/lexical/element_2",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#44",
+      "@id": "amf://id#43/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#43",
       "http://a.ml/vocabularies/document-source-maps#value": "[(107,8)-(123,25)]"
     },
     {
-      "@id": "amf://id#44/source-map/lexical/element_0",
+      "@id": "amf://id#43/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#header",
       "http://a.ml/vocabularies/document-source-maps#value": "[(109,10)-(116,0)]"
     },
     {
-      "@id": "amf://id#44/source-map/lexical/element_1",
+      "@id": "amf://id#43/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(108,10)-(109,0)]"
     },
     {
-      "@id": "amf://id#44/source-map/lexical/element_3",
+      "@id": "amf://id#43/source-map/lexical/element_3",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(107,8)-(107,13)]"
     },
     {
-      "@id": "amf://id#43/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#43",
+      "@id": "amf://id#42/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#42",
       "http://a.ml/vocabularies/document-source-maps#value": "[(105,10)-(105,23)]"
     },
     {
-      "@id": "amf://id#40/source-map",
+      "@id": "amf://id#39/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#auto-generated-name": [
         {
-          "@id": "amf://id#40/source-map/auto-generated-name/element_0"
+          "@id": "amf://id#39/source-map/auto-generated-name/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#40/source-map/lexical/element_2"
+          "@id": "amf://id#39/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#40/source-map/lexical/element_0"
+          "@id": "amf://id#39/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#40/source-map/lexical/element_1"
+          "@id": "amf://id#39/source-map/lexical/element_1"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
         {
-          "@id": "amf://id#40/source-map/type-property-lexical-info/element_0"
+          "@id": "amf://id#39/source-map/type-property-lexical-info/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#39/source-map/synthesized-field/element_1",
+      "@id": "amf://id#38/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#style",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#39/source-map/synthesized-field/element_0",
+      "@id": "amf://id#38/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#explode",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#39/source-map/lexical/element_6",
+      "@id": "amf://id#38/source-map/lexical/element_6",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#binding",
       "http://a.ml/vocabularies/document-source-maps#value": "[(50,8)-(51,0)]"
     },
     {
-      "@id": "amf://id#39/source-map/lexical/element_4",
+      "@id": "amf://id#38/source-map/lexical/element_4",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(49,8)-(50,0)]"
     },
     {
-      "@id": "amf://id#39/source-map/lexical/element_2",
+      "@id": "amf://id#38/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#paramName",
       "http://a.ml/vocabularies/document-source-maps#value": "[(49,8)-(50,0)]"
     },
     {
-      "@id": "amf://id#39/source-map/lexical/element_0",
+      "@id": "amf://id#38/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/shapes#schema",
       "http://a.ml/vocabularies/document-source-maps#value": "[(53,8)-(55,0)]"
     },
     {
-      "@id": "amf://id#39/source-map/lexical/element_1",
+      "@id": "amf://id#38/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#required",
       "http://a.ml/vocabularies/document-source-maps#value": "[(51,8)-(52,0)]"
     },
     {
-      "@id": "amf://id#39/source-map/lexical/element_3",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#39",
+      "@id": "amf://id#38/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#38",
       "http://a.ml/vocabularies/document-source-maps#value": "[(49,8)-(55,0)]"
     },
     {
-      "@id": "amf://id#39/source-map/lexical/element_5",
+      "@id": "amf://id#38/source-map/lexical/element_5",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(52,8)-(53,0)]"
     },
@@ -1660,355 +1659,355 @@
       ]
     },
     {
-      "@id": "amf://id#36/source-map/lexical/element_2",
+      "@id": "amf://id#35/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#mediaType",
       "http://a.ml/vocabularies/document-source-maps#value": "[(67,10)-(67,26)]"
     },
     {
-      "@id": "amf://id#36/source-map/lexical/element_0",
+      "@id": "amf://id#35/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/shapes#schema",
       "http://a.ml/vocabularies/document-source-maps#value": "[(68,12)-(71,0)]"
     },
     {
-      "@id": "amf://id#36/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#36",
+      "@id": "amf://id#35/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#35",
       "http://a.ml/vocabularies/document-source-maps#value": "[(67,10)-(71,0)]"
     },
     {
-      "@id": "amf://id#38/source-map",
+      "@id": "amf://id#37/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#auto-generated-name": [
         {
-          "@id": "amf://id#38/source-map/auto-generated-name/element_0"
+          "@id": "amf://id#37/source-map/auto-generated-name/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#38/source-map/lexical/element_2"
+          "@id": "amf://id#37/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#38/source-map/lexical/element_0"
+          "@id": "amf://id#37/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#38/source-map/lexical/element_1"
+          "@id": "amf://id#37/source-map/lexical/element_1"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
         {
-          "@id": "amf://id#38/source-map/type-property-lexical-info/element_0"
+          "@id": "amf://id#37/source-map/type-property-lexical-info/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#37/source-map/synthesized-field/element_2",
+      "@id": "amf://id#36/source-map/synthesized-field/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#style",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#37/source-map/synthesized-field/element_0",
+      "@id": "amf://id#36/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#explode",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#37/source-map/synthesized-field/element_1",
+      "@id": "amf://id#36/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#required",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#37/source-map/lexical/element_5",
+      "@id": "amf://id#36/source-map/lexical/element_5",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#binding",
       "http://a.ml/vocabularies/document-source-maps#value": "[(57,8)-(58,0)]"
     },
     {
-      "@id": "amf://id#37/source-map/lexical/element_3",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#37",
+      "@id": "amf://id#36/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#36",
       "http://a.ml/vocabularies/document-source-maps#value": "[(55,8)-(60,0)]"
     },
     {
-      "@id": "amf://id#37/source-map/lexical/element_1",
+      "@id": "amf://id#36/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(56,8)-(57,0)]"
     },
     {
-      "@id": "amf://id#37/source-map/lexical/element_0",
+      "@id": "amf://id#36/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/shapes#schema",
       "http://a.ml/vocabularies/document-source-maps#value": "[(58,8)-(60,0)]"
     },
     {
-      "@id": "amf://id#37/source-map/lexical/element_2",
+      "@id": "amf://id#36/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(55,8)-(56,0)]"
     },
     {
-      "@id": "amf://id#37/source-map/lexical/element_4",
+      "@id": "amf://id#36/source-map/lexical/element_4",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#paramName",
       "http://a.ml/vocabularies/document-source-maps#value": "[(55,8)-(56,0)]"
     },
     {
-      "@id": "amf://id#34/source-map/lexical/element_2",
+      "@id": "amf://id#33/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#mediaType",
       "http://a.ml/vocabularies/document-source-maps#value": "[(80,12)-(80,28)]"
     },
     {
-      "@id": "amf://id#34/source-map/lexical/element_0",
+      "@id": "amf://id#33/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/shapes#schema",
       "http://a.ml/vocabularies/document-source-maps#value": "[(81,14)-(84,0)]"
     },
     {
-      "@id": "amf://id#34/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#34",
+      "@id": "amf://id#33/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#33",
       "http://a.ml/vocabularies/document-source-maps#value": "[(80,12)-(84,0)]"
     },
     {
-      "@id": "amf://id#33/source-map",
+      "@id": "amf://id#32/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
         {
-          "@id": "amf://id#33/source-map/type-property-lexical-info/element_0"
+          "@id": "amf://id#32/source-map/type-property-lexical-info/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#33/source-map/lexical/element_1"
+          "@id": "amf://id#32/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#33/source-map/lexical/element_0"
+          "@id": "amf://id#32/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#32/source-map/synthesized-field/element_2",
+      "@id": "amf://id#31/source-map/synthesized-field/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#explode",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#32/source-map/synthesized-field/element_0",
+      "@id": "amf://id#31/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#binding",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#32/source-map/synthesized-field/element_1",
+      "@id": "amf://id#31/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#style",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#32/source-map/lexical/element_2",
+      "@id": "amf://id#31/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(76,14)-(77,0)]"
     },
     {
-      "@id": "amf://id#32/source-map/lexical/element_0",
+      "@id": "amf://id#31/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/shapes#schema",
       "http://a.ml/vocabularies/document-source-maps#value": "[(77,14)-(79,0)]"
     },
     {
-      "@id": "amf://id#32/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#32",
+      "@id": "amf://id#31/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#31",
       "http://a.ml/vocabularies/document-source-maps#value": "[(75,12)-(79,0)]"
     },
     {
-      "@id": "amf://id#57",
+      "@id": "amf://id#56",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Example",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/document#strict": true,
       "http://a.ml/vocabularies/document#structuredValue": {
-        "@id": "amf://id#58"
+        "@id": "amf://id#57"
       },
       "http://a.ml/vocabularies/document#raw": "id: 34",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#57/source-map"
+          "@id": "amf://id#56/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#56/source-map",
+      "@id": "amf://id#55/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#auto-generated-name": [
         {
-          "@id": "amf://id#56/source-map/auto-generated-name/element_0"
+          "@id": "amf://id#55/source-map/auto-generated-name/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#56/source-map/lexical/element_2"
+          "@id": "amf://id#55/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#56/source-map/lexical/element_0"
+          "@id": "amf://id#55/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#56/source-map/lexical/element_1"
+          "@id": "amf://id#55/source-map/lexical/element_1"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
         {
-          "@id": "amf://id#56/source-map/type-property-lexical-info/element_0"
+          "@id": "amf://id#55/source-map/type-property-lexical-info/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#55/source-map/synthesized-field/element_1",
+      "@id": "amf://id#54/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#style",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#55/source-map/synthesized-field/element_0",
+      "@id": "amf://id#54/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#explode",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#55/source-map/lexical/element_6",
+      "@id": "amf://id#54/source-map/lexical/element_6",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#binding",
       "http://a.ml/vocabularies/document-source-maps#value": "[(87,8)-(88,0)]"
     },
     {
-      "@id": "amf://id#55/source-map/lexical/element_4",
+      "@id": "amf://id#54/source-map/lexical/element_4",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(86,8)-(87,0)]"
     },
     {
-      "@id": "amf://id#55/source-map/lexical/element_2",
+      "@id": "amf://id#54/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#paramName",
       "http://a.ml/vocabularies/document-source-maps#value": "[(86,8)-(87,0)]"
     },
     {
-      "@id": "amf://id#55/source-map/lexical/element_0",
+      "@id": "amf://id#54/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/shapes#schema",
       "http://a.ml/vocabularies/document-source-maps#value": "[(90,8)-(92,0)]"
     },
     {
-      "@id": "amf://id#55/source-map/lexical/element_1",
+      "@id": "amf://id#54/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#required",
       "http://a.ml/vocabularies/document-source-maps#value": "[(88,8)-(89,0)]"
     },
     {
-      "@id": "amf://id#55/source-map/lexical/element_3",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#55",
+      "@id": "amf://id#54/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#54",
       "http://a.ml/vocabularies/document-source-maps#value": "[(86,8)-(94,0)]"
     },
     {
-      "@id": "amf://id#55/source-map/lexical/element_5",
+      "@id": "amf://id#54/source-map/lexical/element_5",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(89,8)-(90,0)]"
     },
     {
-      "@id": "amf://id#51/source-map",
+      "@id": "amf://id#50/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#auto-generated-name": [
         {
-          "@id": "amf://id#51/source-map/auto-generated-name/element_0"
+          "@id": "amf://id#50/source-map/auto-generated-name/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#51/source-map/lexical/element_2"
+          "@id": "amf://id#50/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#51/source-map/lexical/element_0"
+          "@id": "amf://id#50/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#51/source-map/lexical/element_1"
+          "@id": "amf://id#50/source-map/lexical/element_1"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
         {
-          "@id": "amf://id#51/source-map/type-property-lexical-info/element_0"
+          "@id": "amf://id#50/source-map/type-property-lexical-info/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#53",
+      "@id": "amf://id#52",
       "@type": [
         "http://a.ml/vocabularies/data#Object",
         "http://a.ml/vocabularies/data#Node",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/data#name": {
-        "@id": "amf://id#54"
+        "@id": "amf://id#53"
       },
       "http://a.ml/vocabularies/core#name": "object_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#53/source-map"
+          "@id": "amf://id#52/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#52/source-map",
+      "@id": "amf://id#51/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#52/source-map/synthesized-field/element_1"
+          "@id": "amf://id#51/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "amf://id#52/source-map/synthesized-field/element_0"
+          "@id": "amf://id#51/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#52/source-map/lexical/element_0"
+          "@id": "amf://id#51/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#50/source-map/synthesized-field/element_2",
+      "@id": "amf://id#49/source-map/synthesized-field/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#style",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#50/source-map/synthesized-field/element_0",
+      "@id": "amf://id#49/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#explode",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#50/source-map/synthesized-field/element_1",
+      "@id": "amf://id#49/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#required",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#50/source-map/lexical/element_6",
+      "@id": "amf://id#49/source-map/lexical/element_6",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/shapes#schema",
       "http://a.ml/vocabularies/document-source-maps#value": "[(97,8)-(99,0)]"
     },
     {
-      "@id": "amf://id#50/source-map/lexical/element_4",
+      "@id": "amf://id#49/source-map/lexical/element_4",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(94,8)-(95,0)]"
     },
     {
-      "@id": "amf://id#50/source-map/lexical/element_2",
+      "@id": "amf://id#49/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#paramName",
       "http://a.ml/vocabularies/document-source-maps#value": "[(94,8)-(95,0)]"
     },
     {
-      "@id": "amf://id#50/source-map/lexical/element_0",
+      "@id": "amf://id#49/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#examples",
       "http://a.ml/vocabularies/document-source-maps#value": "[(99,8)-(101,0)]"
     },
     {
-      "@id": "amf://id#50/source-map/lexical/element_1",
+      "@id": "amf://id#49/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#binding",
       "http://a.ml/vocabularies/document-source-maps#value": "[(96,8)-(97,0)]"
     },
     {
-      "@id": "amf://id#50/source-map/lexical/element_3",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#50",
+      "@id": "amf://id#49/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#49",
       "http://a.ml/vocabularies/document-source-maps#value": "[(94,8)-(101,0)]"
     },
     {
-      "@id": "amf://id#50/source-map/lexical/element_5",
+      "@id": "amf://id#49/source-map/lexical/element_5",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(95,8)-(96,0)]"
     },
@@ -2028,26 +2027,26 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(117,12)-(123,25)]"
     },
     {
-      "@id": "amf://id#46/source-map",
+      "@id": "amf://id#45/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
         {
-          "@id": "amf://id#46/source-map/type-property-lexical-info/element_0"
+          "@id": "amf://id#45/source-map/type-property-lexical-info/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#46/source-map/lexical/element_1"
+          "@id": "amf://id#45/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#46/source-map/lexical/element_0"
+          "@id": "amf://id#45/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#48",
+      "@id": "amf://id#47",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -2062,87 +2061,87 @@
       "http://a.ml/vocabularies/core#name": "scalar_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#48/source-map"
+          "@id": "amf://id#47/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#47/source-map",
+      "@id": "amf://id#46/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#47/source-map/synthesized-field/element_1"
+          "@id": "amf://id#46/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "amf://id#47/source-map/synthesized-field/element_0"
+          "@id": "amf://id#46/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#47/source-map/lexical/element_0"
+          "@id": "amf://id#46/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#45/source-map/synthesized-field/element_2",
+      "@id": "amf://id#44/source-map/synthesized-field/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#explode",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#45/source-map/synthesized-field/element_0",
+      "@id": "amf://id#44/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#binding",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#45/source-map/synthesized-field/element_1",
+      "@id": "amf://id#44/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#style",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#45/source-map/lexical/element_3",
+      "@id": "amf://id#44/source-map/lexical/element_3",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/shapes#schema",
       "http://a.ml/vocabularies/document-source-maps#value": "[(112,14)-(114,0)]"
     },
     {
-      "@id": "amf://id#45/source-map/lexical/element_1",
+      "@id": "amf://id#44/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(111,14)-(112,0)]"
     },
     {
-      "@id": "amf://id#45/source-map/lexical/element_0",
+      "@id": "amf://id#44/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#examples",
       "http://a.ml/vocabularies/document-source-maps#value": "[(114,14)-(116,0)]"
     },
     {
-      "@id": "amf://id#45/source-map/lexical/element_2",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#45",
+      "@id": "amf://id#44/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#44",
       "http://a.ml/vocabularies/document-source-maps#value": "[(110,12)-(116,0)]"
     },
     {
-      "@id": "amf://id#40/source-map/auto-generated-name/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#40",
+      "@id": "amf://id#39/source-map/auto-generated-name/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#39",
       "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
-      "@id": "amf://id#40/source-map/lexical/element_2",
+      "@id": "amf://id#39/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "[(54,10)-(55,0)]"
     },
     {
-      "@id": "amf://id#40/source-map/lexical/element_0",
+      "@id": "amf://id#39/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(49,8)-(50,0)]"
     },
     {
-      "@id": "amf://id#40/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#40",
+      "@id": "amf://id#39/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#39",
       "http://a.ml/vocabularies/document-source-maps#value": "[(53,8)-(55,0)]"
     },
     {
-      "@id": "amf://id#40/source-map/type-property-lexical-info/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#40",
+      "@id": "amf://id#39/source-map/type-property-lexical-info/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#39",
       "http://a.ml/vocabularies/document-source-maps#value": "[(54,10)-(54,14)]"
     },
     {
@@ -2434,138 +2433,138 @@
       "http://a.ml/vocabularies/document-source-maps#value": "amf://id#1"
     },
     {
-      "@id": "amf://id#38/source-map/auto-generated-name/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#38",
+      "@id": "amf://id#37/source-map/auto-generated-name/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#37",
       "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
-      "@id": "amf://id#38/source-map/lexical/element_2",
+      "@id": "amf://id#37/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "[(59,10)-(60,0)]"
     },
     {
-      "@id": "amf://id#38/source-map/lexical/element_0",
+      "@id": "amf://id#37/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(55,8)-(56,0)]"
     },
     {
-      "@id": "amf://id#38/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#38",
+      "@id": "amf://id#37/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#37",
       "http://a.ml/vocabularies/document-source-maps#value": "[(58,8)-(60,0)]"
     },
     {
-      "@id": "amf://id#38/source-map/type-property-lexical-info/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#38",
+      "@id": "amf://id#37/source-map/type-property-lexical-info/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#37",
       "http://a.ml/vocabularies/document-source-maps#value": "[(59,10)-(59,14)]"
     },
     {
-      "@id": "amf://id#33/source-map/type-property-lexical-info/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#33",
+      "@id": "amf://id#32/source-map/type-property-lexical-info/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#32",
       "http://a.ml/vocabularies/document-source-maps#value": "[(78,16)-(78,20)]"
     },
     {
-      "@id": "amf://id#33/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#33",
+      "@id": "amf://id#32/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#32",
       "http://a.ml/vocabularies/document-source-maps#value": "[(77,14)-(79,0)]"
     },
     {
-      "@id": "amf://id#33/source-map/lexical/element_0",
+      "@id": "amf://id#32/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "[(78,16)-(79,0)]"
     },
     {
-      "@id": "amf://id#58",
+      "@id": "amf://id#57",
       "@type": [
         "http://a.ml/vocabularies/data#Object",
         "http://a.ml/vocabularies/data#Node",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/data#id": {
-        "@id": "amf://id#59"
+        "@id": "amf://id#58"
       },
       "http://a.ml/vocabularies/core#name": "object_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#58/source-map"
+          "@id": "amf://id#57/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#57/source-map",
+      "@id": "amf://id#56/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#57/source-map/synthesized-field/element_1"
+          "@id": "amf://id#56/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "amf://id#57/source-map/synthesized-field/element_0"
+          "@id": "amf://id#56/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#57/source-map/lexical/element_0"
+          "@id": "amf://id#56/source-map/lexical/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#tracked-element": [
         {
-          "@id": "amf://id#57/source-map/tracked-element/element_0"
+          "@id": "amf://id#56/source-map/tracked-element/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#56/source-map/auto-generated-name/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#56",
+      "@id": "amf://id#55/source-map/auto-generated-name/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#55",
       "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
-      "@id": "amf://id#56/source-map/lexical/element_2",
+      "@id": "amf://id#55/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "[(91,10)-(92,0)]"
     },
     {
-      "@id": "amf://id#56/source-map/lexical/element_0",
+      "@id": "amf://id#55/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(86,8)-(87,0)]"
     },
     {
-      "@id": "amf://id#56/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#56",
+      "@id": "amf://id#55/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#55",
       "http://a.ml/vocabularies/document-source-maps#value": "[(90,8)-(92,0)]"
     },
     {
-      "@id": "amf://id#56/source-map/type-property-lexical-info/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#56",
+      "@id": "amf://id#55/source-map/type-property-lexical-info/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#55",
       "http://a.ml/vocabularies/document-source-maps#value": "[(91,10)-(91,14)]"
     },
     {
-      "@id": "amf://id#51/source-map/auto-generated-name/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#51",
+      "@id": "amf://id#50/source-map/auto-generated-name/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#50",
       "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
-      "@id": "amf://id#51/source-map/lexical/element_2",
+      "@id": "amf://id#50/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "[(98,10)-(99,0)]"
     },
     {
-      "@id": "amf://id#51/source-map/lexical/element_0",
+      "@id": "amf://id#50/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(94,8)-(95,0)]"
     },
     {
-      "@id": "amf://id#51/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#51",
+      "@id": "amf://id#50/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#50",
       "http://a.ml/vocabularies/document-source-maps#value": "[(97,8)-(99,0)]"
     },
     {
-      "@id": "amf://id#51/source-map/type-property-lexical-info/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#51",
+      "@id": "amf://id#50/source-map/type-property-lexical-info/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#50",
       "http://a.ml/vocabularies/document-source-maps#value": "[(98,10)-(98,14)]"
     },
     {
-      "@id": "amf://id#54",
+      "@id": "amf://id#53",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -2580,91 +2579,91 @@
       "http://a.ml/vocabularies/core#name": "name",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#54/source-map"
+          "@id": "amf://id#53/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#53/source-map",
+      "@id": "amf://id#52/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#53/source-map/synthesized-field/element_0"
+          "@id": "amf://id#52/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#53/source-map/lexical/element_1"
+          "@id": "amf://id#52/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#53/source-map/lexical/element_0"
+          "@id": "amf://id#52/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#52/source-map/synthesized-field/element_1",
+      "@id": "amf://id#51/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#strict",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#52/source-map/synthesized-field/element_0",
+      "@id": "amf://id#51/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#raw",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#52/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#52",
+      "@id": "amf://id#51/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#51",
       "http://a.ml/vocabularies/document-source-maps#value": "[(99,16)-(101,0)]"
     },
     {
-      "@id": "amf://id#46/source-map/type-property-lexical-info/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#46",
+      "@id": "amf://id#45/source-map/type-property-lexical-info/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#45",
       "http://a.ml/vocabularies/document-source-maps#value": "[(113,16)-(113,20)]"
     },
     {
-      "@id": "amf://id#46/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#46",
+      "@id": "amf://id#45/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#45",
       "http://a.ml/vocabularies/document-source-maps#value": "[(112,14)-(114,0)]"
     },
     {
-      "@id": "amf://id#46/source-map/lexical/element_0",
+      "@id": "amf://id#45/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "[(113,16)-(114,0)]"
     },
     {
-      "@id": "amf://id#48/source-map",
+      "@id": "amf://id#47/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#48/source-map/synthesized-field/element_1"
+          "@id": "amf://id#47/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "amf://id#48/source-map/synthesized-field/element_0"
+          "@id": "amf://id#47/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#48/source-map/lexical/element_0"
+          "@id": "amf://id#47/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#47/source-map/synthesized-field/element_1",
+      "@id": "amf://id#46/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#strict",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#47/source-map/synthesized-field/element_0",
+      "@id": "amf://id#46/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#raw",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#47/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#47",
+      "@id": "amf://id#46/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#46",
       "http://a.ml/vocabularies/document-source-maps#value": "[(115,16)-(115,22)]"
     },
     {
@@ -2955,7 +2954,7 @@
       "http://a.ml/vocabularies/document-source-maps#value": "amf://id#19"
     },
     {
-      "@id": "amf://id#59",
+      "@id": "amf://id#58",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -2970,96 +2969,96 @@
       "http://a.ml/vocabularies/core#name": "id",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#59/source-map"
+          "@id": "amf://id#58/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#58/source-map",
+      "@id": "amf://id#57/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#58/source-map/synthesized-field/element_0"
+          "@id": "amf://id#57/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#58/source-map/lexical/element_1"
+          "@id": "amf://id#57/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#58/source-map/lexical/element_0"
+          "@id": "amf://id#57/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#57/source-map/synthesized-field/element_1",
+      "@id": "amf://id#56/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#strict",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#57/source-map/synthesized-field/element_0",
+      "@id": "amf://id#56/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#raw",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#57/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#57",
+      "@id": "amf://id#56/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#56",
       "http://a.ml/vocabularies/document-source-maps#value": "[(92,16)-(94,0)]"
     },
     {
-      "@id": "amf://id#57/source-map/tracked-element/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#57",
-      "http://a.ml/vocabularies/document-source-maps#value": "amf://id#55"
+      "@id": "amf://id#56/source-map/tracked-element/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#56",
+      "http://a.ml/vocabularies/document-source-maps#value": "amf://id#54"
     },
     {
-      "@id": "amf://id#54/source-map",
+      "@id": "amf://id#53/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#54/source-map/synthesized-field/element_1"
+          "@id": "amf://id#53/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "amf://id#54/source-map/synthesized-field/element_0"
+          "@id": "amf://id#53/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#54/source-map/lexical/element_0"
+          "@id": "amf://id#53/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#53/source-map/synthesized-field/element_0",
+      "@id": "amf://id#52/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#53/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#53",
+      "@id": "amf://id#52/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#52",
       "http://a.ml/vocabularies/document-source-maps#value": "[(100,0)-(101,0)]"
     },
     {
-      "@id": "amf://id#53/source-map/lexical/element_0",
+      "@id": "amf://id#52/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(100,10)-(101,0)]"
     },
     {
-      "@id": "amf://id#48/source-map/synthesized-field/element_1",
+      "@id": "amf://id#47/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#48/source-map/synthesized-field/element_0",
+      "@id": "amf://id#47/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#48/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#48",
+      "@id": "amf://id#47/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#47",
       "http://a.ml/vocabularies/document-source-maps#value": "[(115,16)-(115,22)]"
     },
     {
@@ -3279,52 +3278,52 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(123,20)-(123,25)]"
     },
     {
-      "@id": "amf://id#59/source-map",
+      "@id": "amf://id#58/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#59/source-map/synthesized-field/element_1"
+          "@id": "amf://id#58/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "amf://id#59/source-map/synthesized-field/element_0"
+          "@id": "amf://id#58/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#59/source-map/lexical/element_0"
+          "@id": "amf://id#58/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#58/source-map/synthesized-field/element_0",
+      "@id": "amf://id#57/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#58/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#58",
+      "@id": "amf://id#57/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#57",
       "http://a.ml/vocabularies/document-source-maps#value": "[(93,0)-(94,0)]"
     },
     {
-      "@id": "amf://id#58/source-map/lexical/element_0",
+      "@id": "amf://id#57/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#id",
       "http://a.ml/vocabularies/document-source-maps#value": "[(93,10)-(94,0)]"
     },
     {
-      "@id": "amf://id#54/source-map/synthesized-field/element_1",
+      "@id": "amf://id#53/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#54/source-map/synthesized-field/element_0",
+      "@id": "amf://id#53/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#54/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#54",
+      "@id": "amf://id#53/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#53",
       "http://a.ml/vocabularies/document-source-maps#value": "[(100,16)-(100,17)]"
     },
     {
@@ -3410,18 +3409,18 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(123,24)-(123,25)]"
     },
     {
-      "@id": "amf://id#59/source-map/synthesized-field/element_1",
+      "@id": "amf://id#58/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#59/source-map/synthesized-field/element_0",
+      "@id": "amf://id#58/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#59/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#59",
+      "@id": "amf://id#58/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#58",
       "http://a.ml/vocabularies/document-source-maps#value": "[(93,14)-(93,16)]"
     },
     {
@@ -3483,14 +3482,14 @@
         "http://a.ml/vocabularies/document#Unit"
       ],
       "http://a.ml/vocabularies/document#encodes": {
-        "@id": "amf://id#25"
+        "@id": "amf://id#24"
       },
       "http://a.ml/vocabularies/document#root": true,
       "http://a.ml/vocabularies/document#processingData": {
         "@id": "amf://id#23"
       },
       "http://a.ml/vocabularies/document#sourceInformation": {
-        "@id": "amf://id#24"
+        "@id": "amf://id/BaseUnitSourceInformation"
       }
     }
   ]

--- a/test/data/production/best-practices/negative7.yaml.report.jsonld
+++ b/test/data/production/best-practices/negative7.yaml.report.jsonld
@@ -105,7 +105,7 @@
               "reportSchema:ValidationResultNode",
               "shacl:ValidationResult"
             ],
-            "focusNode": "amf://id#34",
+            "focusNode": "amf://id#33",
             "location": {
               "@id": "violation_0_location",
               "@type": [
@@ -201,7 +201,7 @@
               "reportSchema:ValidationResultNode",
               "shacl:ValidationResult"
             ],
-            "focusNode": "amf://id#36",
+            "focusNode": "amf://id#35",
             "location": {
               "@id": "violation_1_location",
               "@type": [

--- a/test/data/production/best-practices/negative8.yaml
+++ b/test/data/production/best-practices/negative8.yaml
@@ -1,3 +1,4 @@
+# test-for: preferred-media-type-representations
 openapi: "3.0.0"
 info:
   title: Awesome API

--- a/test/data/production/best-practices/negative8.yaml.jsonld
+++ b/test/data/production/best-practices/negative8.yaml.jsonld
@@ -5,19 +5,12 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
     {
       "@id": "amf://id#35",
-      "@type": [
-        "http://a.ml/vocabularies/document#BaseUnitSourceInformation"
-      ],
-      "http://a.ml/vocabularies/document#rootLocation": "file://./test/data/production/best-practices/negative8.yaml"
-    },
-    {
-      "@id": "amf://id#36",
       "@type": [
         "http://a.ml/vocabularies/apiContract#WebAPI",
         "http://a.ml/vocabularies/apiContract#API",
@@ -28,31 +21,38 @@
       "http://a.ml/vocabularies/core#description": "the awesome API",
       "http://a.ml/vocabularies/apiContract#server": [
         {
-          "@id": "amf://id#37"
+          "@id": "amf://id#36"
         }
       ],
       "http://a.ml/vocabularies/core#version": "1.0",
       "http://a.ml/vocabularies/core#documentation": [
         {
-          "@id": "amf://id#38"
+          "@id": "amf://id#37"
         }
       ],
       "http://a.ml/vocabularies/apiContract#endpoint": [
         {
-          "@id": "amf://id#39"
+          "@id": "amf://id#38"
         },
         {
-          "@id": "amf://id#51"
+          "@id": "amf://id#50"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#36/source-map"
+          "@id": "amf://id#35/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#37",
+      "@id": "amf://id/BaseUnitSourceInformation",
+      "@type": [
+        "http://a.ml/vocabularies/document#BaseUnitSourceInformation"
+      ],
+      "http://a.ml/vocabularies/document#rootLocation": "file://./test/data/production/best-practices/negative8.yaml"
+    },
+    {
+      "@id": "amf://id#36",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Server",
         "http://a.ml/vocabularies/document#DomainElement"
@@ -61,12 +61,12 @@
       "http://a.ml/vocabularies/core#description": "production environment",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#37/source-map"
+          "@id": "amf://id#36/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#38",
+      "@id": "amf://id#37",
       "@type": [
         "http://a.ml/vocabularies/core#CreativeWork",
         "http://a.ml/vocabularies/document#DomainElement"
@@ -79,12 +79,12 @@
       "http://a.ml/vocabularies/core#description": "",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#38/source-map"
+          "@id": "amf://id#37/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#39",
+      "@id": "amf://id#38",
       "@type": [
         "http://a.ml/vocabularies/apiContract#EndPoint",
         "http://a.ml/vocabularies/document#DomainElement"
@@ -93,22 +93,22 @@
       "http://a.ml/vocabularies/core#description": "path description",
       "http://a.ml/vocabularies/apiContract#supportedOperation": [
         {
-          "@id": "amf://id#40"
+          "@id": "amf://id#39"
         }
       ],
       "http://a.ml/vocabularies/apiContract#server": [
         {
-          "@id": "amf://id#37"
+          "@id": "amf://id#36"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#39/source-map"
+          "@id": "amf://id#38/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#51",
+      "@id": "amf://id#50",
       "@type": [
         "http://a.ml/vocabularies/apiContract#EndPoint",
         "http://a.ml/vocabularies/document#DomainElement"
@@ -117,17 +117,43 @@
       "http://a.ml/vocabularies/core#description": "path description",
       "http://a.ml/vocabularies/apiContract#supportedOperation": [
         {
-          "@id": "amf://id#52"
+          "@id": "amf://id#51"
         }
       ],
       "http://a.ml/vocabularies/apiContract#server": [
         {
-          "@id": "amf://id#37"
+          "@id": "amf://id#36"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#51/source-map"
+          "@id": "amf://id#50/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "amf://id#35/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "amf://id#35/source-map/lexical/element_5"
+        },
+        {
+          "@id": "amf://id#35/source-map/lexical/element_3"
+        },
+        {
+          "@id": "amf://id#35/source-map/lexical/element_1"
+        },
+        {
+          "@id": "amf://id#35/source-map/lexical/element_0"
+        },
+        {
+          "@id": "amf://id#35/source-map/lexical/element_2"
+        },
+        {
+          "@id": "amf://id#35/source-map/lexical/element_4"
         }
       ]
     },
@@ -138,22 +164,13 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#36/source-map/lexical/element_5"
-        },
-        {
-          "@id": "amf://id#36/source-map/lexical/element_3"
-        },
-        {
-          "@id": "amf://id#36/source-map/lexical/element_1"
+          "@id": "amf://id#36/source-map/lexical/element_2"
         },
         {
           "@id": "amf://id#36/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#36/source-map/lexical/element_2"
-        },
-        {
-          "@id": "amf://id#36/source-map/lexical/element_4"
+          "@id": "amf://id#36/source-map/lexical/element_1"
         }
       ]
     },
@@ -175,26 +192,61 @@
       ]
     },
     {
+      "@id": "amf://id#39",
+      "@type": [
+        "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/apiContract#method": "get",
+      "http://a.ml/vocabularies/core#name": "opid",
+      "http://a.ml/vocabularies/core#description": "op-description",
+      "http://a.ml/vocabularies/apiContract#expects": [
+        {
+          "@id": "amf://id#44"
+        }
+      ],
+      "http://a.ml/vocabularies/apiContract#returns": [
+        {
+          "@id": "amf://id#41"
+        }
+      ],
+      "http://a.ml/vocabularies/apiContract#tag": [
+        {
+          "@id": "amf://id#40"
+        }
+      ],
+      "http://a.ml/vocabularies/apiContract#server": [
+        {
+          "@id": "amf://id#36"
+        }
+      ],
+      "http://a.ml/vocabularies/apiContract#operationId": "opid",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "amf://id#39/source-map"
+        }
+      ]
+    },
+    {
       "@id": "amf://id#38/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#38/source-map/lexical/element_2"
+          "@id": "amf://id#38/source-map/lexical/element_1"
         },
         {
           "@id": "amf://id#38/source-map/lexical/element_0"
-        },
-        {
-          "@id": "amf://id#38/source-map/lexical/element_1"
         }
       ]
     },
     {
-      "@id": "amf://id#40",
+      "@id": "amf://id#51",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -202,170 +254,121 @@
       "http://a.ml/vocabularies/core#description": "op-description",
       "http://a.ml/vocabularies/apiContract#expects": [
         {
-          "@id": "amf://id#45"
+          "@id": "amf://id#58"
         }
       ],
       "http://a.ml/vocabularies/apiContract#returns": [
-        {
-          "@id": "amf://id#42"
-        }
-      ],
-      "http://a.ml/vocabularies/apiContract#tag": [
-        {
-          "@id": "amf://id#41"
-        }
-      ],
-      "http://a.ml/vocabularies/apiContract#server": [
-        {
-          "@id": "amf://id#37"
-        }
-      ],
-      "http://a.ml/vocabularies/apiContract#operationId": "opid",
-      "http://a.ml/vocabularies/document-source-maps#sources": [
-        {
-          "@id": "amf://id#40/source-map"
-        }
-      ]
-    },
-    {
-      "@id": "amf://id#39/source-map",
-      "@type": [
-        "http://a.ml/vocabularies/document-source-maps#SourceMap"
-      ],
-      "http://a.ml/vocabularies/document-source-maps#lexical": [
-        {
-          "@id": "amf://id#39/source-map/lexical/element_1"
-        },
-        {
-          "@id": "amf://id#39/source-map/lexical/element_0"
-        }
-      ]
-    },
-    {
-      "@id": "amf://id#52",
-      "@type": [
-        "http://a.ml/vocabularies/apiContract#Operation",
-        "http://a.ml/vocabularies/document#DomainElement"
-      ],
-      "http://a.ml/vocabularies/apiContract#method": "get",
-      "http://a.ml/vocabularies/core#name": "opid",
-      "http://a.ml/vocabularies/core#description": "op-description",
-      "http://a.ml/vocabularies/apiContract#expects": [
-        {
-          "@id": "amf://id#59"
-        }
-      ],
-      "http://a.ml/vocabularies/apiContract#returns": [
-        {
-          "@id": "amf://id#54"
-        }
-      ],
-      "http://a.ml/vocabularies/apiContract#tag": [
         {
           "@id": "amf://id#53"
         }
       ],
+      "http://a.ml/vocabularies/apiContract#tag": [
+        {
+          "@id": "amf://id#52"
+        }
+      ],
       "http://a.ml/vocabularies/apiContract#server": [
         {
-          "@id": "amf://id#37"
+          "@id": "amf://id#36"
         }
       ],
       "http://a.ml/vocabularies/apiContract#operationId": "opid",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#52/source-map"
+          "@id": "amf://id#51/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#51/source-map",
+      "@id": "amf://id#50/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#51/source-map/lexical/element_1"
+          "@id": "amf://id#50/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#51/source-map/lexical/element_0"
+          "@id": "amf://id#50/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#36/source-map/lexical/element_5",
+      "@id": "amf://id#35/source-map/lexical/element_5",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#version",
       "http://a.ml/vocabularies/document-source-maps#value": "[(4,2)-(5,0)]"
     },
     {
-      "@id": "amf://id#36/source-map/lexical/element_3",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#36",
+      "@id": "amf://id#35/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#35",
       "http://a.ml/vocabularies/document-source-maps#value": "[(1,0)-(136,25)]"
     },
     {
-      "@id": "amf://id#36/source-map/lexical/element_1",
+      "@id": "amf://id#35/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#server",
       "http://a.ml/vocabularies/document-source-maps#value": "[(6,0)-(9,0)]"
     },
     {
-      "@id": "amf://id#36/source-map/lexical/element_0",
+      "@id": "amf://id#35/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#endpoint",
       "http://a.ml/vocabularies/document-source-maps#value": "[(46,0)-(136,25)]"
     },
     {
-      "@id": "amf://id#36/source-map/lexical/element_2",
+      "@id": "amf://id#35/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(3,2)-(4,0)]"
     },
     {
-      "@id": "amf://id#36/source-map/lexical/element_4",
+      "@id": "amf://id#35/source-map/lexical/element_4",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(5,2)-(6,0)]"
     },
     {
-      "@id": "amf://id#37/source-map/lexical/element_2",
+      "@id": "amf://id#36/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#urlTemplate",
       "http://a.ml/vocabularies/document-source-maps#value": "[(7,4)-(8,0)]"
     },
     {
-      "@id": "amf://id#37/source-map/lexical/element_0",
+      "@id": "amf://id#36/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(8,4)-(9,0)]"
     },
     {
-      "@id": "amf://id#37/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#37",
+      "@id": "amf://id#36/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#36",
       "http://a.ml/vocabularies/document-source-maps#value": "[(7,4)-(9,0)]"
     },
     {
-      "@id": "amf://id#38/source-map/lexical/element_2",
+      "@id": "amf://id#37/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#url",
       "http://a.ml/vocabularies/document-source-maps#value": "[(11,2)-(13,0)]"
     },
     {
-      "@id": "amf://id#38/source-map/lexical/element_0",
+      "@id": "amf://id#37/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(10,2)-(11,0)]"
     },
     {
-      "@id": "amf://id#38/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#38",
+      "@id": "amf://id#37/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#37",
       "http://a.ml/vocabularies/document-source-maps#value": "[(10,0)-(13,0)]"
     },
     {
-      "@id": "amf://id#45",
+      "@id": "amf://id#44",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#parameter": [
         {
-          "@id": "amf://id#46"
+          "@id": "amf://id#45"
         }
       ],
       "http://a.ml/vocabularies/apiContract#uriParameter": [
         {
-          "@id": "amf://id#49"
+          "@id": "amf://id#48"
         }
       ],
       "http://a.ml/vocabularies/core#name": "requestBody",
@@ -376,19 +379,20 @@
       ],
       "http://a.ml/vocabularies/apiContract#header": [
         {
-          "@id": "amf://id#47"
+          "@id": "amf://id#46"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#45/source-map"
+          "@id": "amf://id#44/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#42",
+      "@id": "amf://id#41",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -402,22 +406,9 @@
       ],
       "http://a.ml/vocabularies/apiContract#header": [
         {
-          "@id": "amf://id#43"
+          "@id": "amf://id#42"
         }
       ],
-      "http://a.ml/vocabularies/document-source-maps#sources": [
-        {
-          "@id": "amf://id#42/source-map"
-        }
-      ]
-    },
-    {
-      "@id": "amf://id#41",
-      "@type": [
-        "http://a.ml/vocabularies/apiContract#Tag",
-        "http://a.ml/vocabularies/document#DomainElement"
-      ],
-      "http://a.ml/vocabularies/core#name": "Invoice Items",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
           "@id": "amf://id#41/source-map"
@@ -425,66 +416,78 @@
       ]
     },
     {
-      "@id": "amf://id#40/source-map",
+      "@id": "amf://id#40",
+      "@type": [
+        "http://a.ml/vocabularies/apiContract#Tag",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/core#name": "Invoice Items",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "amf://id#40/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "amf://id#39/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#40/source-map/lexical/element_6"
+          "@id": "amf://id#39/source-map/lexical/element_5"
         },
         {
-          "@id": "amf://id#40/source-map/lexical/element_4"
+          "@id": "amf://id#39/source-map/lexical/element_3"
         },
         {
-          "@id": "amf://id#40/source-map/lexical/element_2"
+          "@id": "amf://id#39/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#40/source-map/lexical/element_0"
+          "@id": "amf://id#39/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#40/source-map/lexical/element_1"
+          "@id": "amf://id#39/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#40/source-map/lexical/element_3"
-        },
-        {
-          "@id": "amf://id#40/source-map/lexical/element_5"
+          "@id": "amf://id#39/source-map/lexical/element_4"
         }
       ]
     },
     {
-      "@id": "amf://id#39/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#39",
+      "@id": "amf://id#38/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#38",
       "http://a.ml/vocabularies/document-source-maps#value": "[(47,2)-(96,0)]"
     },
     {
-      "@id": "amf://id#39/source-map/lexical/element_0",
+      "@id": "amf://id#38/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(48,4)-(49,0)]"
     },
     {
-      "@id": "amf://id#59",
+      "@id": "amf://id#58",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#uriParameter": [
         {
-          "@id": "amf://id#65"
+          "@id": "amf://id#64"
         }
       ],
       "http://a.ml/vocabularies/apiContract#header": [
         {
-          "@id": "amf://id#60"
+          "@id": "amf://id#59"
         }
       ]
     },
     {
-      "@id": "amf://id#54",
+      "@id": "amf://id#53",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -498,22 +501,9 @@
       ],
       "http://a.ml/vocabularies/apiContract#header": [
         {
-          "@id": "amf://id#55"
+          "@id": "amf://id#54"
         }
       ],
-      "http://a.ml/vocabularies/document-source-maps#sources": [
-        {
-          "@id": "amf://id#54/source-map"
-        }
-      ]
-    },
-    {
-      "@id": "amf://id#53",
-      "@type": [
-        "http://a.ml/vocabularies/apiContract#Tag",
-        "http://a.ml/vocabularies/document#DomainElement"
-      ],
-      "http://a.ml/vocabularies/core#name": "Invoice Items",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
           "@id": "amf://id#53/source-map"
@@ -521,45 +511,59 @@
       ]
     },
     {
-      "@id": "amf://id#52/source-map",
+      "@id": "amf://id#52",
+      "@type": [
+        "http://a.ml/vocabularies/apiContract#Tag",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/core#name": "Invoice Items",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "amf://id#52/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "amf://id#51/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#52/source-map/lexical/element_5"
+          "@id": "amf://id#51/source-map/lexical/element_5"
         },
         {
-          "@id": "amf://id#52/source-map/lexical/element_3"
+          "@id": "amf://id#51/source-map/lexical/element_3"
         },
         {
-          "@id": "amf://id#52/source-map/lexical/element_1"
+          "@id": "amf://id#51/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#52/source-map/lexical/element_0"
+          "@id": "amf://id#51/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#52/source-map/lexical/element_2"
+          "@id": "amf://id#51/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#52/source-map/lexical/element_4"
+          "@id": "amf://id#51/source-map/lexical/element_4"
         }
       ]
     },
     {
-      "@id": "amf://id#51/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#51",
+      "@id": "amf://id#50/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#50",
       "http://a.ml/vocabularies/document-source-maps#value": "[(96,2)-(136,25)]"
     },
     {
-      "@id": "amf://id#51/source-map/lexical/element_0",
+      "@id": "amf://id#50/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(97,4)-(98,0)]"
     },
     {
-      "@id": "amf://id#46",
+      "@id": "amf://id#45",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "other",
@@ -573,14 +577,15 @@
       "http://a.ml/vocabularies/apiContract#binding": "query",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#46/source-map"
+          "@id": "amf://id#45/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#49",
+      "@id": "amf://id#48",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -591,11 +596,11 @@
       "http://a.ml/vocabularies/apiContract#explode": false,
       "http://a.ml/vocabularies/apiContract#binding": "path",
       "http://a.ml/vocabularies/shapes#schema": {
-        "@id": "amf://id#50"
+        "@id": "amf://id#49"
       },
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#49/source-map"
+          "@id": "amf://id#48/source-map"
         }
       ]
     },
@@ -603,6 +608,7 @@
       "@id": "amf://id#23",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -616,9 +622,10 @@
       ]
     },
     {
-      "@id": "amf://id#47",
+      "@id": "amf://id#46",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "accept",
@@ -629,25 +636,22 @@
       "http://a.ml/vocabularies/apiContract#explode": false,
       "http://a.ml/vocabularies/apiContract#binding": "header",
       "http://a.ml/vocabularies/shapes#schema": {
-        "@id": "amf://id#48"
+        "@id": "amf://id#47"
       },
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#47/source-map"
+          "@id": "amf://id#46/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#45/source-map",
+      "@id": "amf://id#44/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#45/source-map/lexical/element_1"
-        },
-        {
-          "@id": "amf://id#45/source-map/lexical/element_0"
+          "@id": "amf://id#44/source-map/lexical/element_0"
         }
       ]
     },
@@ -655,6 +659,7 @@
       "@id": "amf://id#19",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -668,9 +673,10 @@
       ]
     },
     {
-      "@id": "amf://id#43",
+      "@id": "amf://id#42",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "content-type",
@@ -679,34 +685,11 @@
       "http://a.ml/vocabularies/apiContract#explode": false,
       "http://a.ml/vocabularies/apiContract#binding": "header",
       "http://a.ml/vocabularies/shapes#schema": {
-        "@id": "amf://id#44"
+        "@id": "amf://id#43"
       },
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#43/source-map"
-        }
-      ]
-    },
-    {
-      "@id": "amf://id#42/source-map",
-      "@type": [
-        "http://a.ml/vocabularies/document-source-maps#SourceMap"
-      ],
-      "http://a.ml/vocabularies/document-source-maps#lexical": [
-        {
-          "@id": "amf://id#42/source-map/lexical/element_4"
-        },
-        {
-          "@id": "amf://id#42/source-map/lexical/element_2"
-        },
-        {
-          "@id": "amf://id#42/source-map/lexical/element_0"
-        },
-        {
-          "@id": "amf://id#42/source-map/lexical/element_1"
-        },
-        {
-          "@id": "amf://id#42/source-map/lexical/element_3"
+          "@id": "amf://id#42/source-map"
         }
       ]
     },
@@ -717,49 +700,68 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
+          "@id": "amf://id#41/source-map/lexical/element_4"
+        },
+        {
+          "@id": "amf://id#41/source-map/lexical/element_2"
+        },
+        {
           "@id": "amf://id#41/source-map/lexical/element_0"
+        },
+        {
+          "@id": "amf://id#41/source-map/lexical/element_1"
+        },
+        {
+          "@id": "amf://id#41/source-map/lexical/element_3"
         }
       ]
     },
     {
-      "@id": "amf://id#40/source-map/lexical/element_6",
+      "@id": "amf://id#40/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "amf://id#40/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "amf://id#39/source-map/lexical/element_5",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#tag",
       "http://a.ml/vocabularies/document-source-maps#value": "[(67,6)-(69,0)]"
     },
     {
-      "@id": "amf://id#40/source-map/lexical/element_4",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(66,6)-(67,0)]"
+      "@id": "amf://id#39/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#39",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(64,4)-(96,0)]"
     },
     {
-      "@id": "amf://id#40/source-map/lexical/element_2",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(65,6)-(66,0)]"
-    },
-    {
-      "@id": "amf://id#40/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#operationId",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(66,6)-(67,0)]"
-    },
-    {
-      "@id": "amf://id#40/source-map/lexical/element_1",
+      "@id": "amf://id#39/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#returns",
       "http://a.ml/vocabularies/document-source-maps#value": "[(81,6)-(96,0)]"
     },
     {
-      "@id": "amf://id#40/source-map/lexical/element_3",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#40",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(64,4)-(96,0)]"
+      "@id": "amf://id#39/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#operationId",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(66,6)-(67,0)]"
     },
     {
-      "@id": "amf://id#40/source-map/lexical/element_5",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#expects",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(69,6)-(81,0)]"
+      "@id": "amf://id#39/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(66,6)-(67,0)]"
     },
     {
-      "@id": "amf://id#65",
+      "@id": "amf://id#39/source-map/lexical/element_4",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(65,6)-(66,0)]"
+    },
+    {
+      "@id": "amf://id#64",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -770,18 +772,19 @@
       "http://a.ml/vocabularies/apiContract#explode": false,
       "http://a.ml/vocabularies/apiContract#binding": "path",
       "http://a.ml/vocabularies/shapes#schema": {
-        "@id": "amf://id#66"
+        "@id": "amf://id#65"
       },
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#65/source-map"
+          "@id": "amf://id#64/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#60",
+      "@id": "amf://id#59",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "accept",
@@ -792,16 +795,16 @@
       "http://a.ml/vocabularies/apiContract#explode": false,
       "http://a.ml/vocabularies/apiContract#binding": "header",
       "http://a.ml/vocabularies/shapes#schema": {
-        "@id": "amf://id#61"
+        "@id": "amf://id#60"
       },
       "http://a.ml/vocabularies/apiContract#examples": [
         {
-          "@id": "amf://id#62"
+          "@id": "amf://id#61"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#60/source-map"
+          "@id": "amf://id#59/source-map"
         }
       ]
     },
@@ -809,6 +812,7 @@
       "@id": "amf://id#30",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/other",
@@ -822,9 +826,10 @@
       ]
     },
     {
-      "@id": "amf://id#55",
+      "@id": "amf://id#54",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "content-type",
@@ -833,39 +838,16 @@
       "http://a.ml/vocabularies/apiContract#explode": false,
       "http://a.ml/vocabularies/apiContract#binding": "header",
       "http://a.ml/vocabularies/shapes#schema": {
-        "@id": "amf://id#56"
+        "@id": "amf://id#55"
       },
       "http://a.ml/vocabularies/apiContract#examples": [
         {
-          "@id": "amf://id#57"
+          "@id": "amf://id#56"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#55/source-map"
-        }
-      ]
-    },
-    {
-      "@id": "amf://id#54/source-map",
-      "@type": [
-        "http://a.ml/vocabularies/document-source-maps#SourceMap"
-      ],
-      "http://a.ml/vocabularies/document-source-maps#lexical": [
-        {
-          "@id": "amf://id#54/source-map/lexical/element_4"
-        },
-        {
-          "@id": "amf://id#54/source-map/lexical/element_2"
-        },
-        {
-          "@id": "amf://id#54/source-map/lexical/element_0"
-        },
-        {
-          "@id": "amf://id#54/source-map/lexical/element_1"
-        },
-        {
-          "@id": "amf://id#54/source-map/lexical/element_3"
+          "@id": "amf://id#54/source-map"
         }
       ]
     },
@@ -876,76 +858,99 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
+          "@id": "amf://id#53/source-map/lexical/element_4"
+        },
+        {
+          "@id": "amf://id#53/source-map/lexical/element_2"
+        },
+        {
           "@id": "amf://id#53/source-map/lexical/element_0"
+        },
+        {
+          "@id": "amf://id#53/source-map/lexical/element_1"
+        },
+        {
+          "@id": "amf://id#53/source-map/lexical/element_3"
         }
       ]
     },
     {
-      "@id": "amf://id#52/source-map/lexical/element_5",
+      "@id": "amf://id#52/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "amf://id#52/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "amf://id#51/source-map/lexical/element_5",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#tag",
       "http://a.ml/vocabularies/document-source-maps#value": "[(117,6)-(119,0)]"
     },
     {
-      "@id": "amf://id#52/source-map/lexical/element_3",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#52",
+      "@id": "amf://id#51/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#51",
       "http://a.ml/vocabularies/document-source-maps#value": "[(114,4)-(136,25)]"
     },
     {
-      "@id": "amf://id#52/source-map/lexical/element_1",
+      "@id": "amf://id#51/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#returns",
       "http://a.ml/vocabularies/document-source-maps#value": "[(119,6)-(136,25)]"
     },
     {
-      "@id": "amf://id#52/source-map/lexical/element_0",
+      "@id": "amf://id#51/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#operationId",
       "http://a.ml/vocabularies/document-source-maps#value": "[(116,6)-(117,0)]"
     },
     {
-      "@id": "amf://id#52/source-map/lexical/element_2",
+      "@id": "amf://id#51/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(116,6)-(117,0)]"
     },
     {
-      "@id": "amf://id#52/source-map/lexical/element_4",
+      "@id": "amf://id#51/source-map/lexical/element_4",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(115,6)-(116,0)]"
     },
     {
-      "@id": "amf://id#46/source-map",
+      "@id": "amf://id#45/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#46/source-map/synthesized-field/element_2"
+          "@id": "amf://id#45/source-map/synthesized-field/element_2"
         },
         {
-          "@id": "amf://id#46/source-map/synthesized-field/element_0"
+          "@id": "amf://id#45/source-map/synthesized-field/element_0"
         },
         {
-          "@id": "amf://id#46/source-map/synthesized-field/element_1"
+          "@id": "amf://id#45/source-map/synthesized-field/element_1"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#46/source-map/lexical/element_4"
+          "@id": "amf://id#45/source-map/lexical/element_4"
         },
         {
-          "@id": "amf://id#46/source-map/lexical/element_2"
+          "@id": "amf://id#45/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#46/source-map/lexical/element_0"
+          "@id": "amf://id#45/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#46/source-map/lexical/element_1"
+          "@id": "amf://id#45/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#46/source-map/lexical/element_3"
+          "@id": "amf://id#45/source-map/lexical/element_3"
         }
       ]
     },
     {
-      "@id": "amf://id#50",
+      "@id": "amf://id#49",
       "@type": [
         "http://a.ml/vocabularies/shapes#ScalarShape",
         "http://a.ml/vocabularies/shapes#AnyShape",
@@ -961,44 +966,44 @@
       "http://www.w3.org/ns/shacl#name": "id",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#50/source-map"
+          "@id": "amf://id#49/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#49/source-map",
+      "@id": "amf://id#48/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#49/source-map/synthesized-field/element_1"
+          "@id": "amf://id#48/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "amf://id#49/source-map/synthesized-field/element_0"
+          "@id": "amf://id#48/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#49/source-map/lexical/element_6"
+          "@id": "amf://id#48/source-map/lexical/element_6"
         },
         {
-          "@id": "amf://id#49/source-map/lexical/element_4"
+          "@id": "amf://id#48/source-map/lexical/element_4"
         },
         {
-          "@id": "amf://id#49/source-map/lexical/element_2"
+          "@id": "amf://id#48/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#49/source-map/lexical/element_0"
+          "@id": "amf://id#48/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#49/source-map/lexical/element_1"
+          "@id": "amf://id#48/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#49/source-map/lexical/element_3"
+          "@id": "amf://id#48/source-map/lexical/element_3"
         },
         {
-          "@id": "amf://id#49/source-map/lexical/element_5"
+          "@id": "amf://id#48/source-map/lexical/element_5"
         }
       ]
     },
@@ -1070,7 +1075,7 @@
       ]
     },
     {
-      "@id": "amf://id#48",
+      "@id": "amf://id#47",
       "@type": [
         "http://a.ml/vocabularies/shapes#ScalarShape",
         "http://a.ml/vocabularies/shapes#AnyShape",
@@ -1086,54 +1091,49 @@
       "http://www.w3.org/ns/shacl#name": "accept",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#48/source-map"
+          "@id": "amf://id#47/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#47/source-map",
+      "@id": "amf://id#46/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#47/source-map/synthesized-field/element_2"
+          "@id": "amf://id#46/source-map/synthesized-field/element_2"
         },
         {
-          "@id": "amf://id#47/source-map/synthesized-field/element_0"
+          "@id": "amf://id#46/source-map/synthesized-field/element_0"
         },
         {
-          "@id": "amf://id#47/source-map/synthesized-field/element_1"
+          "@id": "amf://id#46/source-map/synthesized-field/element_1"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#47/source-map/lexical/element_5"
+          "@id": "amf://id#46/source-map/lexical/element_5"
         },
         {
-          "@id": "amf://id#47/source-map/lexical/element_3"
+          "@id": "amf://id#46/source-map/lexical/element_3"
         },
         {
-          "@id": "amf://id#47/source-map/lexical/element_1"
+          "@id": "amf://id#46/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#47/source-map/lexical/element_0"
+          "@id": "amf://id#46/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#47/source-map/lexical/element_2"
+          "@id": "amf://id#46/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#47/source-map/lexical/element_4"
+          "@id": "amf://id#46/source-map/lexical/element_4"
         }
       ]
     },
     {
-      "@id": "amf://id#45/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#45",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(69,6)-(81,0)]"
-    },
-    {
-      "@id": "amf://id#45/source-map/lexical/element_0",
+      "@id": "amf://id#44/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(69,6)-(69,17)]"
     },
@@ -1155,7 +1155,7 @@
       ]
     },
     {
-      "@id": "amf://id#44",
+      "@id": "amf://id#43",
       "@type": [
         "http://a.ml/vocabularies/shapes#ScalarShape",
         "http://a.ml/vocabularies/shapes#AnyShape",
@@ -1171,70 +1171,70 @@
       "http://www.w3.org/ns/shacl#name": "schema",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#44/source-map"
+          "@id": "amf://id#43/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#43/source-map",
+      "@id": "amf://id#42/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#43/source-map/synthesized-field/element_2"
+          "@id": "amf://id#42/source-map/synthesized-field/element_2"
         },
         {
-          "@id": "amf://id#43/source-map/synthesized-field/element_0"
+          "@id": "amf://id#42/source-map/synthesized-field/element_0"
         },
         {
-          "@id": "amf://id#43/source-map/synthesized-field/element_1"
+          "@id": "amf://id#42/source-map/synthesized-field/element_1"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#43/source-map/lexical/element_2"
+          "@id": "amf://id#42/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#43/source-map/lexical/element_0"
+          "@id": "amf://id#42/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#43/source-map/lexical/element_1"
+          "@id": "amf://id#42/source-map/lexical/element_1"
         }
       ]
     },
     {
-      "@id": "amf://id#42/source-map/lexical/element_4",
+      "@id": "amf://id#41/source-map/lexical/element_4",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#payload",
       "http://a.ml/vocabularies/document-source-maps#value": "[(89,10)-(96,0)]"
     },
     {
-      "@id": "amf://id#42/source-map/lexical/element_2",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#42",
+      "@id": "amf://id#41/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#41",
       "http://a.ml/vocabularies/document-source-maps#value": "[(82,8)-(96,0)]"
     },
     {
-      "@id": "amf://id#42/source-map/lexical/element_0",
+      "@id": "amf://id#41/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#header",
       "http://a.ml/vocabularies/document-source-maps#value": "[(84,10)-(89,0)]"
     },
     {
-      "@id": "amf://id#42/source-map/lexical/element_1",
+      "@id": "amf://id#41/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(83,10)-(84,0)]"
     },
     {
-      "@id": "amf://id#42/source-map/lexical/element_3",
+      "@id": "amf://id#41/source-map/lexical/element_3",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(82,8)-(82,13)]"
     },
     {
-      "@id": "amf://id#41/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#41",
+      "@id": "amf://id#40/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#40",
       "http://a.ml/vocabularies/document-source-maps#value": "[(68,10)-(68,23)]"
     },
     {
-      "@id": "amf://id#66",
+      "@id": "amf://id#65",
       "@type": [
         "http://a.ml/vocabularies/shapes#ScalarShape",
         "http://a.ml/vocabularies/shapes#AnyShape",
@@ -1250,54 +1250,54 @@
       "http://www.w3.org/ns/shacl#name": "id",
       "http://a.ml/vocabularies/apiContract#examples": [
         {
-          "@id": "amf://id#67"
+          "@id": "amf://id#66"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#66/source-map"
+          "@id": "amf://id#65/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#65/source-map",
+      "@id": "amf://id#64/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#65/source-map/synthesized-field/element_1"
+          "@id": "amf://id#64/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "amf://id#65/source-map/synthesized-field/element_0"
+          "@id": "amf://id#64/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#65/source-map/lexical/element_6"
+          "@id": "amf://id#64/source-map/lexical/element_6"
         },
         {
-          "@id": "amf://id#65/source-map/lexical/element_4"
+          "@id": "amf://id#64/source-map/lexical/element_4"
         },
         {
-          "@id": "amf://id#65/source-map/lexical/element_2"
+          "@id": "amf://id#64/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#65/source-map/lexical/element_0"
+          "@id": "amf://id#64/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#65/source-map/lexical/element_1"
+          "@id": "amf://id#64/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#65/source-map/lexical/element_3"
+          "@id": "amf://id#64/source-map/lexical/element_3"
         },
         {
-          "@id": "amf://id#65/source-map/lexical/element_5"
+          "@id": "amf://id#64/source-map/lexical/element_5"
         }
       ]
     },
     {
-      "@id": "amf://id#61",
+      "@id": "amf://id#60",
       "@type": [
         "http://a.ml/vocabularies/shapes#ScalarShape",
         "http://a.ml/vocabularies/shapes#AnyShape",
@@ -1313,64 +1313,64 @@
       "http://www.w3.org/ns/shacl#name": "accept",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#61/source-map"
+          "@id": "amf://id#60/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#62",
+      "@id": "amf://id#61",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Example",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/document#strict": true,
       "http://a.ml/vocabularies/document#structuredValue": {
-        "@id": "amf://id#63"
+        "@id": "amf://id#62"
       },
       "http://a.ml/vocabularies/document#raw": "name: a",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#62/source-map"
+          "@id": "amf://id#61/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#60/source-map",
+      "@id": "amf://id#59/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#60/source-map/synthesized-field/element_2"
+          "@id": "amf://id#59/source-map/synthesized-field/element_2"
         },
         {
-          "@id": "amf://id#60/source-map/synthesized-field/element_0"
+          "@id": "amf://id#59/source-map/synthesized-field/element_0"
         },
         {
-          "@id": "amf://id#60/source-map/synthesized-field/element_1"
+          "@id": "amf://id#59/source-map/synthesized-field/element_1"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#60/source-map/lexical/element_6"
+          "@id": "amf://id#59/source-map/lexical/element_6"
         },
         {
-          "@id": "amf://id#60/source-map/lexical/element_4"
+          "@id": "amf://id#59/source-map/lexical/element_4"
         },
         {
-          "@id": "amf://id#60/source-map/lexical/element_2"
+          "@id": "amf://id#59/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#60/source-map/lexical/element_0"
+          "@id": "amf://id#59/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#60/source-map/lexical/element_1"
+          "@id": "amf://id#59/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#60/source-map/lexical/element_3"
+          "@id": "amf://id#59/source-map/lexical/element_3"
         },
         {
-          "@id": "amf://id#60/source-map/lexical/element_5"
+          "@id": "amf://id#59/source-map/lexical/element_5"
         }
       ]
     },
@@ -1392,7 +1392,7 @@
       ]
     },
     {
-      "@id": "amf://id#56",
+      "@id": "amf://id#55",
       "@type": [
         "http://a.ml/vocabularies/shapes#ScalarShape",
         "http://a.ml/vocabularies/shapes#AnyShape",
@@ -1408,197 +1408,197 @@
       "http://www.w3.org/ns/shacl#name": "schema",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#56/source-map"
+          "@id": "amf://id#55/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#57",
+      "@id": "amf://id#56",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Example",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/document#strict": true,
       "http://a.ml/vocabularies/document#structuredValue": {
-        "@id": "amf://id#58"
+        "@id": "amf://id#57"
       },
       "http://a.ml/vocabularies/document#raw": "teapot",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#57/source-map"
+          "@id": "amf://id#56/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#55/source-map",
+      "@id": "amf://id#54/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#55/source-map/synthesized-field/element_2"
+          "@id": "amf://id#54/source-map/synthesized-field/element_2"
         },
         {
-          "@id": "amf://id#55/source-map/synthesized-field/element_0"
+          "@id": "amf://id#54/source-map/synthesized-field/element_0"
         },
         {
-          "@id": "amf://id#55/source-map/synthesized-field/element_1"
+          "@id": "amf://id#54/source-map/synthesized-field/element_1"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#55/source-map/lexical/element_3"
+          "@id": "amf://id#54/source-map/lexical/element_3"
         },
         {
-          "@id": "amf://id#55/source-map/lexical/element_1"
+          "@id": "amf://id#54/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#55/source-map/lexical/element_0"
+          "@id": "amf://id#54/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#55/source-map/lexical/element_2"
+          "@id": "amf://id#54/source-map/lexical/element_2"
         }
       ]
     },
     {
-      "@id": "amf://id#54/source-map/lexical/element_4",
+      "@id": "amf://id#53/source-map/lexical/element_4",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#payload",
       "http://a.ml/vocabularies/document-source-maps#value": "[(129,10)-(136,25)]"
     },
     {
-      "@id": "amf://id#54/source-map/lexical/element_2",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#54",
+      "@id": "amf://id#53/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#53",
       "http://a.ml/vocabularies/document-source-maps#value": "[(120,8)-(136,25)]"
     },
     {
-      "@id": "amf://id#54/source-map/lexical/element_0",
+      "@id": "amf://id#53/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#header",
       "http://a.ml/vocabularies/document-source-maps#value": "[(122,10)-(129,0)]"
     },
     {
-      "@id": "amf://id#54/source-map/lexical/element_1",
+      "@id": "amf://id#53/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(121,10)-(122,0)]"
     },
     {
-      "@id": "amf://id#54/source-map/lexical/element_3",
+      "@id": "amf://id#53/source-map/lexical/element_3",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(120,8)-(120,13)]"
     },
     {
-      "@id": "amf://id#53/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#53",
+      "@id": "amf://id#52/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#52",
       "http://a.ml/vocabularies/document-source-maps#value": "[(118,10)-(118,23)]"
     },
     {
-      "@id": "amf://id#46/source-map/synthesized-field/element_2",
+      "@id": "amf://id#45/source-map/synthesized-field/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#style",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#46/source-map/synthesized-field/element_0",
+      "@id": "amf://id#45/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#explode",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#46/source-map/synthesized-field/element_1",
+      "@id": "amf://id#45/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#required",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#46/source-map/lexical/element_4",
+      "@id": "amf://id#45/source-map/lexical/element_4",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(63,8)-(64,0)]"
     },
     {
-      "@id": "amf://id#46/source-map/lexical/element_2",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#46",
+      "@id": "amf://id#45/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#45",
       "http://a.ml/vocabularies/document-source-maps#value": "[(61,8)-(64,0)]"
     },
     {
-      "@id": "amf://id#46/source-map/lexical/element_0",
+      "@id": "amf://id#45/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#binding",
       "http://a.ml/vocabularies/document-source-maps#value": "[(62,8)-(63,0)]"
     },
     {
-      "@id": "amf://id#46/source-map/lexical/element_1",
+      "@id": "amf://id#45/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#paramName",
       "http://a.ml/vocabularies/document-source-maps#value": "[(61,8)-(62,0)]"
     },
     {
-      "@id": "amf://id#46/source-map/lexical/element_3",
+      "@id": "amf://id#45/source-map/lexical/element_3",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(61,8)-(62,0)]"
     },
     {
-      "@id": "amf://id#50/source-map",
+      "@id": "amf://id#49/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#auto-generated-name": [
         {
-          "@id": "amf://id#50/source-map/auto-generated-name/element_0"
+          "@id": "amf://id#49/source-map/auto-generated-name/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#50/source-map/lexical/element_2"
+          "@id": "amf://id#49/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#50/source-map/lexical/element_0"
+          "@id": "amf://id#49/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#50/source-map/lexical/element_1"
+          "@id": "amf://id#49/source-map/lexical/element_1"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
         {
-          "@id": "amf://id#50/source-map/type-property-lexical-info/element_0"
+          "@id": "amf://id#49/source-map/type-property-lexical-info/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#49/source-map/synthesized-field/element_1",
+      "@id": "amf://id#48/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#style",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#49/source-map/synthesized-field/element_0",
+      "@id": "amf://id#48/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#explode",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#49/source-map/lexical/element_6",
+      "@id": "amf://id#48/source-map/lexical/element_6",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#binding",
       "http://a.ml/vocabularies/document-source-maps#value": "[(51,8)-(52,0)]"
     },
     {
-      "@id": "amf://id#49/source-map/lexical/element_4",
+      "@id": "amf://id#48/source-map/lexical/element_4",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(50,8)-(51,0)]"
     },
     {
-      "@id": "amf://id#49/source-map/lexical/element_2",
+      "@id": "amf://id#48/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#paramName",
       "http://a.ml/vocabularies/document-source-maps#value": "[(50,8)-(51,0)]"
     },
     {
-      "@id": "amf://id#49/source-map/lexical/element_0",
+      "@id": "amf://id#48/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/shapes#schema",
       "http://a.ml/vocabularies/document-source-maps#value": "[(54,8)-(56,0)]"
     },
     {
-      "@id": "amf://id#49/source-map/lexical/element_1",
+      "@id": "amf://id#48/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#required",
       "http://a.ml/vocabularies/document-source-maps#value": "[(52,8)-(53,0)]"
     },
     {
-      "@id": "amf://id#49/source-map/lexical/element_3",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#49",
+      "@id": "amf://id#48/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#48",
       "http://a.ml/vocabularies/document-source-maps#value": "[(50,8)-(56,0)]"
     },
     {
-      "@id": "amf://id#49/source-map/lexical/element_5",
+      "@id": "amf://id#48/source-map/lexical/element_5",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(53,8)-(54,0)]"
     },
@@ -1858,74 +1858,74 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(71,10)-(81,0)]"
     },
     {
-      "@id": "amf://id#48/source-map",
+      "@id": "amf://id#47/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#auto-generated-name": [
         {
-          "@id": "amf://id#48/source-map/auto-generated-name/element_0"
+          "@id": "amf://id#47/source-map/auto-generated-name/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#48/source-map/lexical/element_2"
+          "@id": "amf://id#47/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#48/source-map/lexical/element_0"
+          "@id": "amf://id#47/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#48/source-map/lexical/element_1"
+          "@id": "amf://id#47/source-map/lexical/element_1"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
         {
-          "@id": "amf://id#48/source-map/type-property-lexical-info/element_0"
+          "@id": "amf://id#47/source-map/type-property-lexical-info/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#47/source-map/synthesized-field/element_2",
+      "@id": "amf://id#46/source-map/synthesized-field/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#style",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#47/source-map/synthesized-field/element_0",
+      "@id": "amf://id#46/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#explode",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#47/source-map/synthesized-field/element_1",
+      "@id": "amf://id#46/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#required",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#47/source-map/lexical/element_5",
+      "@id": "amf://id#46/source-map/lexical/element_5",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#binding",
       "http://a.ml/vocabularies/document-source-maps#value": "[(57,8)-(58,0)]"
     },
     {
-      "@id": "amf://id#47/source-map/lexical/element_3",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#47",
+      "@id": "amf://id#46/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#46",
       "http://a.ml/vocabularies/document-source-maps#value": "[(56,8)-(61,0)]"
     },
     {
-      "@id": "amf://id#47/source-map/lexical/element_1",
+      "@id": "amf://id#46/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(58,8)-(59,0)]"
     },
     {
-      "@id": "amf://id#47/source-map/lexical/element_0",
+      "@id": "amf://id#46/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/shapes#schema",
       "http://a.ml/vocabularies/document-source-maps#value": "[(59,8)-(61,0)]"
     },
     {
-      "@id": "amf://id#47/source-map/lexical/element_2",
+      "@id": "amf://id#46/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(56,8)-(57,0)]"
     },
     {
-      "@id": "amf://id#47/source-map/lexical/element_4",
+      "@id": "amf://id#46/source-map/lexical/element_4",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#paramName",
       "http://a.ml/vocabularies/document-source-maps#value": "[(56,8)-(57,0)]"
     },
@@ -1945,253 +1945,253 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(90,12)-(96,0)]"
     },
     {
-      "@id": "amf://id#44/source-map",
+      "@id": "amf://id#43/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
         {
-          "@id": "amf://id#44/source-map/type-property-lexical-info/element_0"
+          "@id": "amf://id#43/source-map/type-property-lexical-info/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#44/source-map/lexical/element_1"
+          "@id": "amf://id#43/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#44/source-map/lexical/element_0"
+          "@id": "amf://id#43/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#43/source-map/synthesized-field/element_2",
+      "@id": "amf://id#42/source-map/synthesized-field/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#explode",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#43/source-map/synthesized-field/element_0",
+      "@id": "amf://id#42/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#binding",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#43/source-map/synthesized-field/element_1",
+      "@id": "amf://id#42/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#style",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#43/source-map/lexical/element_2",
+      "@id": "amf://id#42/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(86,14)-(87,0)]"
     },
     {
-      "@id": "amf://id#43/source-map/lexical/element_0",
+      "@id": "amf://id#42/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/shapes#schema",
       "http://a.ml/vocabularies/document-source-maps#value": "[(87,14)-(89,0)]"
     },
     {
-      "@id": "amf://id#43/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#43",
+      "@id": "amf://id#42/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#42",
       "http://a.ml/vocabularies/document-source-maps#value": "[(85,12)-(89,0)]"
     },
     {
-      "@id": "amf://id#67",
+      "@id": "amf://id#66",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Example",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/document#strict": true,
       "http://a.ml/vocabularies/document#structuredValue": {
-        "@id": "amf://id#68"
+        "@id": "amf://id#67"
       },
       "http://a.ml/vocabularies/document#raw": "id: 34",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#67/source-map"
+          "@id": "amf://id#66/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#66/source-map",
+      "@id": "amf://id#65/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#auto-generated-name": [
         {
-          "@id": "amf://id#66/source-map/auto-generated-name/element_0"
+          "@id": "amf://id#65/source-map/auto-generated-name/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#66/source-map/lexical/element_2"
+          "@id": "amf://id#65/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#66/source-map/lexical/element_0"
+          "@id": "amf://id#65/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#66/source-map/lexical/element_1"
+          "@id": "amf://id#65/source-map/lexical/element_1"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
         {
-          "@id": "amf://id#66/source-map/type-property-lexical-info/element_0"
+          "@id": "amf://id#65/source-map/type-property-lexical-info/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#65/source-map/synthesized-field/element_1",
+      "@id": "amf://id#64/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#style",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#65/source-map/synthesized-field/element_0",
+      "@id": "amf://id#64/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#explode",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#65/source-map/lexical/element_6",
+      "@id": "amf://id#64/source-map/lexical/element_6",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#binding",
       "http://a.ml/vocabularies/document-source-maps#value": "[(100,8)-(101,0)]"
     },
     {
-      "@id": "amf://id#65/source-map/lexical/element_4",
+      "@id": "amf://id#64/source-map/lexical/element_4",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(99,8)-(100,0)]"
     },
     {
-      "@id": "amf://id#65/source-map/lexical/element_2",
+      "@id": "amf://id#64/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#paramName",
       "http://a.ml/vocabularies/document-source-maps#value": "[(99,8)-(100,0)]"
     },
     {
-      "@id": "amf://id#65/source-map/lexical/element_0",
+      "@id": "amf://id#64/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/shapes#schema",
       "http://a.ml/vocabularies/document-source-maps#value": "[(103,8)-(105,0)]"
     },
     {
-      "@id": "amf://id#65/source-map/lexical/element_1",
+      "@id": "amf://id#64/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#required",
       "http://a.ml/vocabularies/document-source-maps#value": "[(101,8)-(102,0)]"
     },
     {
-      "@id": "amf://id#65/source-map/lexical/element_3",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#65",
+      "@id": "amf://id#64/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#64",
       "http://a.ml/vocabularies/document-source-maps#value": "[(99,8)-(107,0)]"
     },
     {
-      "@id": "amf://id#65/source-map/lexical/element_5",
+      "@id": "amf://id#64/source-map/lexical/element_5",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(102,8)-(103,0)]"
     },
     {
-      "@id": "amf://id#61/source-map",
+      "@id": "amf://id#60/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#auto-generated-name": [
         {
-          "@id": "amf://id#61/source-map/auto-generated-name/element_0"
+          "@id": "amf://id#60/source-map/auto-generated-name/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#61/source-map/lexical/element_2"
+          "@id": "amf://id#60/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#61/source-map/lexical/element_0"
+          "@id": "amf://id#60/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#61/source-map/lexical/element_1"
+          "@id": "amf://id#60/source-map/lexical/element_1"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
         {
-          "@id": "amf://id#61/source-map/type-property-lexical-info/element_0"
+          "@id": "amf://id#60/source-map/type-property-lexical-info/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#63",
+      "@id": "amf://id#62",
       "@type": [
         "http://a.ml/vocabularies/data#Object",
         "http://a.ml/vocabularies/data#Node",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/data#name": {
-        "@id": "amf://id#64"
+        "@id": "amf://id#63"
       },
       "http://a.ml/vocabularies/core#name": "object_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#63/source-map"
+          "@id": "amf://id#62/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#62/source-map",
+      "@id": "amf://id#61/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#62/source-map/synthesized-field/element_1"
+          "@id": "amf://id#61/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "amf://id#62/source-map/synthesized-field/element_0"
+          "@id": "amf://id#61/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#62/source-map/lexical/element_0"
+          "@id": "amf://id#61/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#60/source-map/synthesized-field/element_2",
+      "@id": "amf://id#59/source-map/synthesized-field/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#style",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#60/source-map/synthesized-field/element_0",
+      "@id": "amf://id#59/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#explode",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#60/source-map/synthesized-field/element_1",
+      "@id": "amf://id#59/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#required",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#60/source-map/lexical/element_6",
+      "@id": "amf://id#59/source-map/lexical/element_6",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/shapes#schema",
       "http://a.ml/vocabularies/document-source-maps#value": "[(110,8)-(112,0)]"
     },
     {
-      "@id": "amf://id#60/source-map/lexical/element_4",
+      "@id": "amf://id#59/source-map/lexical/element_4",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(107,8)-(108,0)]"
     },
     {
-      "@id": "amf://id#60/source-map/lexical/element_2",
+      "@id": "amf://id#59/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#paramName",
       "http://a.ml/vocabularies/document-source-maps#value": "[(107,8)-(108,0)]"
     },
     {
-      "@id": "amf://id#60/source-map/lexical/element_0",
+      "@id": "amf://id#59/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#examples",
       "http://a.ml/vocabularies/document-source-maps#value": "[(112,8)-(114,0)]"
     },
     {
-      "@id": "amf://id#60/source-map/lexical/element_1",
+      "@id": "amf://id#59/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#binding",
       "http://a.ml/vocabularies/document-source-maps#value": "[(109,8)-(110,0)]"
     },
     {
-      "@id": "amf://id#60/source-map/lexical/element_3",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#60",
+      "@id": "amf://id#59/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#59",
       "http://a.ml/vocabularies/document-source-maps#value": "[(107,8)-(114,0)]"
     },
     {
-      "@id": "amf://id#60/source-map/lexical/element_5",
+      "@id": "amf://id#59/source-map/lexical/element_5",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(108,8)-(109,0)]"
     },
@@ -2211,26 +2211,26 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(130,12)-(136,25)]"
     },
     {
-      "@id": "amf://id#56/source-map",
+      "@id": "amf://id#55/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
         {
-          "@id": "amf://id#56/source-map/type-property-lexical-info/element_0"
+          "@id": "amf://id#55/source-map/type-property-lexical-info/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#56/source-map/lexical/element_1"
+          "@id": "amf://id#55/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#56/source-map/lexical/element_0"
+          "@id": "amf://id#55/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#58",
+      "@id": "amf://id#57",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -2245,87 +2245,87 @@
       "http://a.ml/vocabularies/core#name": "scalar_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#58/source-map"
+          "@id": "amf://id#57/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#57/source-map",
+      "@id": "amf://id#56/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#57/source-map/synthesized-field/element_1"
+          "@id": "amf://id#56/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "amf://id#57/source-map/synthesized-field/element_0"
+          "@id": "amf://id#56/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#57/source-map/lexical/element_0"
+          "@id": "amf://id#56/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#55/source-map/synthesized-field/element_2",
+      "@id": "amf://id#54/source-map/synthesized-field/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#explode",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#55/source-map/synthesized-field/element_0",
+      "@id": "amf://id#54/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#binding",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#55/source-map/synthesized-field/element_1",
+      "@id": "amf://id#54/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#style",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#55/source-map/lexical/element_3",
+      "@id": "amf://id#54/source-map/lexical/element_3",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/shapes#schema",
       "http://a.ml/vocabularies/document-source-maps#value": "[(125,14)-(127,0)]"
     },
     {
-      "@id": "amf://id#55/source-map/lexical/element_1",
+      "@id": "amf://id#54/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(124,14)-(125,0)]"
     },
     {
-      "@id": "amf://id#55/source-map/lexical/element_0",
+      "@id": "amf://id#54/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#examples",
       "http://a.ml/vocabularies/document-source-maps#value": "[(127,14)-(129,0)]"
     },
     {
-      "@id": "amf://id#55/source-map/lexical/element_2",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#55",
+      "@id": "amf://id#54/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#54",
       "http://a.ml/vocabularies/document-source-maps#value": "[(123,12)-(129,0)]"
     },
     {
-      "@id": "amf://id#50/source-map/auto-generated-name/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#50",
+      "@id": "amf://id#49/source-map/auto-generated-name/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#49",
       "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
-      "@id": "amf://id#50/source-map/lexical/element_2",
+      "@id": "amf://id#49/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "[(55,10)-(56,0)]"
     },
     {
-      "@id": "amf://id#50/source-map/lexical/element_0",
+      "@id": "amf://id#49/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(50,8)-(51,0)]"
     },
     {
-      "@id": "amf://id#50/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#50",
+      "@id": "amf://id#49/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#49",
       "http://a.ml/vocabularies/document-source-maps#value": "[(54,8)-(56,0)]"
     },
     {
-      "@id": "amf://id#50/source-map/type-property-lexical-info/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#50",
+      "@id": "amf://id#49/source-map/type-property-lexical-info/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#49",
       "http://a.ml/vocabularies/document-source-maps#value": "[(55,10)-(55,14)]"
     },
     {
@@ -2761,138 +2761,138 @@
       "http://a.ml/vocabularies/document-source-maps#value": "amf://id#1"
     },
     {
-      "@id": "amf://id#48/source-map/auto-generated-name/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#48",
+      "@id": "amf://id#47/source-map/auto-generated-name/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#47",
       "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
-      "@id": "amf://id#48/source-map/lexical/element_2",
+      "@id": "amf://id#47/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "[(60,10)-(61,0)]"
     },
     {
-      "@id": "amf://id#48/source-map/lexical/element_0",
+      "@id": "amf://id#47/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(56,8)-(57,0)]"
     },
     {
-      "@id": "amf://id#48/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#48",
+      "@id": "amf://id#47/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#47",
       "http://a.ml/vocabularies/document-source-maps#value": "[(59,8)-(61,0)]"
     },
     {
-      "@id": "amf://id#48/source-map/type-property-lexical-info/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#48",
+      "@id": "amf://id#47/source-map/type-property-lexical-info/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#47",
       "http://a.ml/vocabularies/document-source-maps#value": "[(60,10)-(60,14)]"
     },
     {
-      "@id": "amf://id#44/source-map/type-property-lexical-info/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#44",
+      "@id": "amf://id#43/source-map/type-property-lexical-info/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#43",
       "http://a.ml/vocabularies/document-source-maps#value": "[(88,16)-(88,20)]"
     },
     {
-      "@id": "amf://id#44/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#44",
+      "@id": "amf://id#43/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#43",
       "http://a.ml/vocabularies/document-source-maps#value": "[(87,14)-(89,0)]"
     },
     {
-      "@id": "amf://id#44/source-map/lexical/element_0",
+      "@id": "amf://id#43/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "[(88,16)-(89,0)]"
     },
     {
-      "@id": "amf://id#68",
+      "@id": "amf://id#67",
       "@type": [
         "http://a.ml/vocabularies/data#Object",
         "http://a.ml/vocabularies/data#Node",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/data#id": {
-        "@id": "amf://id#69"
+        "@id": "amf://id#68"
       },
       "http://a.ml/vocabularies/core#name": "object_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#68/source-map"
+          "@id": "amf://id#67/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#67/source-map",
+      "@id": "amf://id#66/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#67/source-map/synthesized-field/element_1"
+          "@id": "amf://id#66/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "amf://id#67/source-map/synthesized-field/element_0"
+          "@id": "amf://id#66/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#67/source-map/lexical/element_0"
+          "@id": "amf://id#66/source-map/lexical/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#tracked-element": [
         {
-          "@id": "amf://id#67/source-map/tracked-element/element_0"
+          "@id": "amf://id#66/source-map/tracked-element/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#66/source-map/auto-generated-name/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#66",
+      "@id": "amf://id#65/source-map/auto-generated-name/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#65",
       "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
-      "@id": "amf://id#66/source-map/lexical/element_2",
+      "@id": "amf://id#65/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "[(104,10)-(105,0)]"
     },
     {
-      "@id": "amf://id#66/source-map/lexical/element_0",
+      "@id": "amf://id#65/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(99,8)-(100,0)]"
     },
     {
-      "@id": "amf://id#66/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#66",
+      "@id": "amf://id#65/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#65",
       "http://a.ml/vocabularies/document-source-maps#value": "[(103,8)-(105,0)]"
     },
     {
-      "@id": "amf://id#66/source-map/type-property-lexical-info/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#66",
+      "@id": "amf://id#65/source-map/type-property-lexical-info/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#65",
       "http://a.ml/vocabularies/document-source-maps#value": "[(104,10)-(104,14)]"
     },
     {
-      "@id": "amf://id#61/source-map/auto-generated-name/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#61",
+      "@id": "amf://id#60/source-map/auto-generated-name/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#60",
       "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
-      "@id": "amf://id#61/source-map/lexical/element_2",
+      "@id": "amf://id#60/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "[(111,10)-(112,0)]"
     },
     {
-      "@id": "amf://id#61/source-map/lexical/element_0",
+      "@id": "amf://id#60/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(107,8)-(108,0)]"
     },
     {
-      "@id": "amf://id#61/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#61",
+      "@id": "amf://id#60/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#60",
       "http://a.ml/vocabularies/document-source-maps#value": "[(110,8)-(112,0)]"
     },
     {
-      "@id": "amf://id#61/source-map/type-property-lexical-info/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#61",
+      "@id": "amf://id#60/source-map/type-property-lexical-info/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#60",
       "http://a.ml/vocabularies/document-source-maps#value": "[(111,10)-(111,14)]"
     },
     {
-      "@id": "amf://id#64",
+      "@id": "amf://id#63",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -2907,91 +2907,91 @@
       "http://a.ml/vocabularies/core#name": "name",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#64/source-map"
+          "@id": "amf://id#63/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#63/source-map",
+      "@id": "amf://id#62/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#63/source-map/synthesized-field/element_0"
+          "@id": "amf://id#62/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#63/source-map/lexical/element_1"
+          "@id": "amf://id#62/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#63/source-map/lexical/element_0"
+          "@id": "amf://id#62/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#62/source-map/synthesized-field/element_1",
+      "@id": "amf://id#61/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#strict",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#62/source-map/synthesized-field/element_0",
+      "@id": "amf://id#61/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#raw",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#62/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#62",
+      "@id": "amf://id#61/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#61",
       "http://a.ml/vocabularies/document-source-maps#value": "[(112,16)-(114,0)]"
     },
     {
-      "@id": "amf://id#56/source-map/type-property-lexical-info/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#56",
+      "@id": "amf://id#55/source-map/type-property-lexical-info/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#55",
       "http://a.ml/vocabularies/document-source-maps#value": "[(126,16)-(126,20)]"
     },
     {
-      "@id": "amf://id#56/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#56",
+      "@id": "amf://id#55/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#55",
       "http://a.ml/vocabularies/document-source-maps#value": "[(125,14)-(127,0)]"
     },
     {
-      "@id": "amf://id#56/source-map/lexical/element_0",
+      "@id": "amf://id#55/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "[(126,16)-(127,0)]"
     },
     {
-      "@id": "amf://id#58/source-map",
+      "@id": "amf://id#57/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#58/source-map/synthesized-field/element_1"
+          "@id": "amf://id#57/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "amf://id#58/source-map/synthesized-field/element_0"
+          "@id": "amf://id#57/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#58/source-map/lexical/element_0"
+          "@id": "amf://id#57/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#57/source-map/synthesized-field/element_1",
+      "@id": "amf://id#56/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#strict",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#57/source-map/synthesized-field/element_0",
+      "@id": "amf://id#56/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#raw",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#57/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#57",
+      "@id": "amf://id#56/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#56",
       "http://a.ml/vocabularies/document-source-maps#value": "[(128,16)-(128,22)]"
     },
     {
@@ -3494,7 +3494,7 @@
       "http://a.ml/vocabularies/document-source-maps#value": "amf://id#30"
     },
     {
-      "@id": "amf://id#69",
+      "@id": "amf://id#68",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -3509,96 +3509,96 @@
       "http://a.ml/vocabularies/core#name": "id",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#69/source-map"
+          "@id": "amf://id#68/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#68/source-map",
+      "@id": "amf://id#67/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#68/source-map/synthesized-field/element_0"
+          "@id": "amf://id#67/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#68/source-map/lexical/element_1"
+          "@id": "amf://id#67/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#68/source-map/lexical/element_0"
+          "@id": "amf://id#67/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#67/source-map/synthesized-field/element_1",
+      "@id": "amf://id#66/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#strict",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#67/source-map/synthesized-field/element_0",
+      "@id": "amf://id#66/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#raw",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#67/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#67",
+      "@id": "amf://id#66/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#66",
       "http://a.ml/vocabularies/document-source-maps#value": "[(105,16)-(107,0)]"
     },
     {
-      "@id": "amf://id#67/source-map/tracked-element/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#67",
-      "http://a.ml/vocabularies/document-source-maps#value": "amf://id#65"
+      "@id": "amf://id#66/source-map/tracked-element/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#66",
+      "http://a.ml/vocabularies/document-source-maps#value": "amf://id#64"
     },
     {
-      "@id": "amf://id#64/source-map",
+      "@id": "amf://id#63/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#64/source-map/synthesized-field/element_1"
+          "@id": "amf://id#63/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "amf://id#64/source-map/synthesized-field/element_0"
+          "@id": "amf://id#63/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#64/source-map/lexical/element_0"
+          "@id": "amf://id#63/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#63/source-map/synthesized-field/element_0",
+      "@id": "amf://id#62/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#63/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#63",
+      "@id": "amf://id#62/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#62",
       "http://a.ml/vocabularies/document-source-maps#value": "[(113,0)-(114,0)]"
     },
     {
-      "@id": "amf://id#63/source-map/lexical/element_0",
+      "@id": "amf://id#62/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(113,10)-(114,0)]"
     },
     {
-      "@id": "amf://id#58/source-map/synthesized-field/element_1",
+      "@id": "amf://id#57/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#58/source-map/synthesized-field/element_0",
+      "@id": "amf://id#57/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#58/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#58",
+      "@id": "amf://id#57/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#57",
       "http://a.ml/vocabularies/document-source-maps#value": "[(128,16)-(128,22)]"
     },
     {
@@ -3920,52 +3920,52 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(136,20)-(136,25)]"
     },
     {
-      "@id": "amf://id#69/source-map",
+      "@id": "amf://id#68/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#69/source-map/synthesized-field/element_1"
+          "@id": "amf://id#68/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "amf://id#69/source-map/synthesized-field/element_0"
+          "@id": "amf://id#68/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#69/source-map/lexical/element_0"
+          "@id": "amf://id#68/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#68/source-map/synthesized-field/element_0",
+      "@id": "amf://id#67/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#68/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#68",
+      "@id": "amf://id#67/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#67",
       "http://a.ml/vocabularies/document-source-maps#value": "[(106,0)-(107,0)]"
     },
     {
-      "@id": "amf://id#68/source-map/lexical/element_0",
+      "@id": "amf://id#67/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#id",
       "http://a.ml/vocabularies/document-source-maps#value": "[(106,10)-(107,0)]"
     },
     {
-      "@id": "amf://id#64/source-map/synthesized-field/element_1",
+      "@id": "amf://id#63/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#64/source-map/synthesized-field/element_0",
+      "@id": "amf://id#63/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#64/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#64",
+      "@id": "amf://id#63/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#63",
       "http://a.ml/vocabularies/document-source-maps#value": "[(113,16)-(113,17)]"
     },
     {
@@ -4096,18 +4096,18 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(136,24)-(136,25)]"
     },
     {
-      "@id": "amf://id#69/source-map/synthesized-field/element_1",
+      "@id": "amf://id#68/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#69/source-map/synthesized-field/element_0",
+      "@id": "amf://id#68/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#69/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#69",
+      "@id": "amf://id#68/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#68",
       "http://a.ml/vocabularies/document-source-maps#value": "[(106,14)-(106,16)]"
     },
     {
@@ -4169,14 +4169,14 @@
         "http://a.ml/vocabularies/document#Unit"
       ],
       "http://a.ml/vocabularies/document#encodes": {
-        "@id": "amf://id#36"
+        "@id": "amf://id#35"
       },
       "http://a.ml/vocabularies/document#root": true,
       "http://a.ml/vocabularies/document#processingData": {
         "@id": "amf://id#34"
       },
       "http://a.ml/vocabularies/document#sourceInformation": {
-        "@id": "amf://id#35"
+        "@id": "amf://id/BaseUnitSourceInformation"
       }
     }
   ]

--- a/test/data/production/best-practices/negative8.yaml.report.jsonld
+++ b/test/data/production/best-practices/negative8.yaml.report.jsonld
@@ -96,30 +96,30 @@
           "reportSchema:ReportNode",
           "shacl:ValidationReport"
         ],
-        "conforms": true,
+        "conforms": false,
         "profileName": "Anypoint Best Practices",
         "result": [
           {
-            "@id": "warning_0",
+            "@id": "violation_0",
             "@type": [
               "reportSchema:ValidationResultNode",
               "shacl:ValidationResult"
             ],
             "focusNode": "amf://id#30",
             "location": {
-              "@id": "warning_0_location",
+              "@id": "violation_0_location",
               "@type": [
                 "lexicalSchema:LocationNode",
                 "lexical:Location"
               ],
               "range": {
-                "@id": "warning_0_location_range",
+                "@id": "violation_0_location_range",
                 "@type": [
                   "lexicalSchema:RangeNode",
                   "lexical:Range"
                 ],
                 "end": {
-                  "@id": "warning_0_location_range_end",
+                  "@id": "violation_0_location_range_end",
                   "@type": [
                     "lexicalSchema:PositionNode",
                     "lexical:Position"
@@ -128,7 +128,7 @@
                   "line": 136
                 },
                 "start": {
-                  "@id": "warning_0_location_range_start",
+                  "@id": "violation_0_location_range_start",
                   "@type": [
                     "lexicalSchema:PositionNode",
                     "lexical:Position"
@@ -140,30 +140,30 @@
               "uri": "file://./test/data/production/best-practices/negative8.yaml"
             },
             "resultMessage": "If there is no standard media type and format, try to use as much as possible extensible formats such as JSON\n(application/json) and XML (application/xml), preferably JSON.\n",
-            "resultSeverity": "http://www.w3.org/ns/shacl#Warning",
+            "resultSeverity": "http://www.w3.org/ns/shacl#Violation",
             "sourceShapeName": "preferred-media-type-representations",
             "trace": [
               {
-                "@id": "warning_0_0",
+                "@id": "violation_0_0",
                 "@type": [
                   "reportSchema:TraceMessageNode",
                   "validation:TraceMessage"
                 ],
                 "component": "in",
                 "location": {
-                  "@id": "warning_0_0_location",
+                  "@id": "violation_0_0_location",
                   "@type": [
                     "lexicalSchema:LocationNode",
                     "lexical:Location"
                   ],
                   "range": {
-                    "@id": "warning_0_0_location_range",
+                    "@id": "violation_0_0_location_range",
                     "@type": [
                       "lexicalSchema:RangeNode",
                       "lexical:Range"
                     ],
                     "end": {
-                      "@id": "warning_0_0_location_range_end",
+                      "@id": "violation_0_0_location_range_end",
                       "@type": [
                         "lexicalSchema:PositionNode",
                         "lexical:Position"
@@ -172,7 +172,7 @@
                       "line": 136
                     },
                     "start": {
-                      "@id": "warning_0_0_location_range_start",
+                      "@id": "violation_0_0_location_range_start",
                       "@type": [
                         "lexicalSchema:PositionNode",
                         "lexical:Position"
@@ -185,7 +185,7 @@
                 },
                 "resultPath": "http://a.ml/vocabularies/core#mediaType",
                 "traceValue": {
-                  "@id": "warning_0_0_traceValue",
+                  "@id": "violation_0_0_traceValue",
                   "@type": [
                     "reportSchema:TraceValueNode",
                     "validation:TraceValue"

--- a/test/data/production/best-practices/negative9.yaml.jsonld
+++ b/test/data/production/best-practices/negative9.yaml.jsonld
@@ -5,19 +5,12 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
     {
       "@id": "amf://id#35",
-      "@type": [
-        "http://a.ml/vocabularies/document#BaseUnitSourceInformation"
-      ],
-      "http://a.ml/vocabularies/document#rootLocation": "file://./test/data/production/best-practices/negative9.yaml"
-    },
-    {
-      "@id": "amf://id#36",
       "@type": [
         "http://a.ml/vocabularies/apiContract#WebAPI",
         "http://a.ml/vocabularies/apiContract#API",
@@ -28,31 +21,38 @@
       "http://a.ml/vocabularies/core#description": "the awesome API",
       "http://a.ml/vocabularies/apiContract#server": [
         {
-          "@id": "amf://id#37"
+          "@id": "amf://id#36"
         }
       ],
       "http://a.ml/vocabularies/core#version": "1.0",
       "http://a.ml/vocabularies/core#documentation": [
         {
-          "@id": "amf://id#38"
+          "@id": "amf://id#37"
         }
       ],
       "http://a.ml/vocabularies/apiContract#endpoint": [
         {
-          "@id": "amf://id#39"
+          "@id": "amf://id#38"
         },
         {
-          "@id": "amf://id#51"
+          "@id": "amf://id#50"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#36/source-map"
+          "@id": "amf://id#35/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#37",
+      "@id": "amf://id/BaseUnitSourceInformation",
+      "@type": [
+        "http://a.ml/vocabularies/document#BaseUnitSourceInformation"
+      ],
+      "http://a.ml/vocabularies/document#rootLocation": "file://./test/data/production/best-practices/negative9.yaml"
+    },
+    {
+      "@id": "amf://id#36",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Server",
         "http://a.ml/vocabularies/document#DomainElement"
@@ -61,12 +61,12 @@
       "http://a.ml/vocabularies/core#description": "production environment",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#37/source-map"
+          "@id": "amf://id#36/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#38",
+      "@id": "amf://id#37",
       "@type": [
         "http://a.ml/vocabularies/core#CreativeWork",
         "http://a.ml/vocabularies/document#DomainElement"
@@ -79,12 +79,12 @@
       "http://a.ml/vocabularies/core#description": "",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#38/source-map"
+          "@id": "amf://id#37/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#39",
+      "@id": "amf://id#38",
       "@type": [
         "http://a.ml/vocabularies/apiContract#EndPoint",
         "http://a.ml/vocabularies/document#DomainElement"
@@ -93,22 +93,22 @@
       "http://a.ml/vocabularies/core#description": "path description",
       "http://a.ml/vocabularies/apiContract#supportedOperation": [
         {
-          "@id": "amf://id#40"
+          "@id": "amf://id#39"
         }
       ],
       "http://a.ml/vocabularies/apiContract#server": [
         {
-          "@id": "amf://id#37"
+          "@id": "amf://id#36"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#39/source-map"
+          "@id": "amf://id#38/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#51",
+      "@id": "amf://id#50",
       "@type": [
         "http://a.ml/vocabularies/apiContract#EndPoint",
         "http://a.ml/vocabularies/document#DomainElement"
@@ -117,17 +117,43 @@
       "http://a.ml/vocabularies/core#description": "path description",
       "http://a.ml/vocabularies/apiContract#supportedOperation": [
         {
-          "@id": "amf://id#52"
+          "@id": "amf://id#51"
         }
       ],
       "http://a.ml/vocabularies/apiContract#server": [
         {
-          "@id": "amf://id#37"
+          "@id": "amf://id#36"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#51/source-map"
+          "@id": "amf://id#50/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "amf://id#35/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "amf://id#35/source-map/lexical/element_5"
+        },
+        {
+          "@id": "amf://id#35/source-map/lexical/element_3"
+        },
+        {
+          "@id": "amf://id#35/source-map/lexical/element_1"
+        },
+        {
+          "@id": "amf://id#35/source-map/lexical/element_0"
+        },
+        {
+          "@id": "amf://id#35/source-map/lexical/element_2"
+        },
+        {
+          "@id": "amf://id#35/source-map/lexical/element_4"
         }
       ]
     },
@@ -138,22 +164,13 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#36/source-map/lexical/element_5"
-        },
-        {
-          "@id": "amf://id#36/source-map/lexical/element_3"
-        },
-        {
-          "@id": "amf://id#36/source-map/lexical/element_1"
+          "@id": "amf://id#36/source-map/lexical/element_2"
         },
         {
           "@id": "amf://id#36/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#36/source-map/lexical/element_2"
-        },
-        {
-          "@id": "amf://id#36/source-map/lexical/element_4"
+          "@id": "amf://id#36/source-map/lexical/element_1"
         }
       ]
     },
@@ -175,26 +192,61 @@
       ]
     },
     {
+      "@id": "amf://id#39",
+      "@type": [
+        "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/apiContract#method": "get",
+      "http://a.ml/vocabularies/core#name": "opid",
+      "http://a.ml/vocabularies/core#description": "op-description",
+      "http://a.ml/vocabularies/apiContract#expects": [
+        {
+          "@id": "amf://id#44"
+        }
+      ],
+      "http://a.ml/vocabularies/apiContract#returns": [
+        {
+          "@id": "amf://id#41"
+        }
+      ],
+      "http://a.ml/vocabularies/apiContract#tag": [
+        {
+          "@id": "amf://id#40"
+        }
+      ],
+      "http://a.ml/vocabularies/apiContract#server": [
+        {
+          "@id": "amf://id#36"
+        }
+      ],
+      "http://a.ml/vocabularies/apiContract#operationId": "opid",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "amf://id#39/source-map"
+        }
+      ]
+    },
+    {
       "@id": "amf://id#38/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#38/source-map/lexical/element_2"
+          "@id": "amf://id#38/source-map/lexical/element_1"
         },
         {
           "@id": "amf://id#38/source-map/lexical/element_0"
-        },
-        {
-          "@id": "amf://id#38/source-map/lexical/element_1"
         }
       ]
     },
     {
-      "@id": "amf://id#40",
+      "@id": "amf://id#51",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -202,170 +254,121 @@
       "http://a.ml/vocabularies/core#description": "op-description",
       "http://a.ml/vocabularies/apiContract#expects": [
         {
-          "@id": "amf://id#45"
+          "@id": "amf://id#58"
         }
       ],
       "http://a.ml/vocabularies/apiContract#returns": [
-        {
-          "@id": "amf://id#42"
-        }
-      ],
-      "http://a.ml/vocabularies/apiContract#tag": [
-        {
-          "@id": "amf://id#41"
-        }
-      ],
-      "http://a.ml/vocabularies/apiContract#server": [
-        {
-          "@id": "amf://id#37"
-        }
-      ],
-      "http://a.ml/vocabularies/apiContract#operationId": "opid",
-      "http://a.ml/vocabularies/document-source-maps#sources": [
-        {
-          "@id": "amf://id#40/source-map"
-        }
-      ]
-    },
-    {
-      "@id": "amf://id#39/source-map",
-      "@type": [
-        "http://a.ml/vocabularies/document-source-maps#SourceMap"
-      ],
-      "http://a.ml/vocabularies/document-source-maps#lexical": [
-        {
-          "@id": "amf://id#39/source-map/lexical/element_1"
-        },
-        {
-          "@id": "amf://id#39/source-map/lexical/element_0"
-        }
-      ]
-    },
-    {
-      "@id": "amf://id#52",
-      "@type": [
-        "http://a.ml/vocabularies/apiContract#Operation",
-        "http://a.ml/vocabularies/document#DomainElement"
-      ],
-      "http://a.ml/vocabularies/apiContract#method": "get",
-      "http://a.ml/vocabularies/core#name": "opid",
-      "http://a.ml/vocabularies/core#description": "op-description",
-      "http://a.ml/vocabularies/apiContract#expects": [
-        {
-          "@id": "amf://id#59"
-        }
-      ],
-      "http://a.ml/vocabularies/apiContract#returns": [
-        {
-          "@id": "amf://id#54"
-        }
-      ],
-      "http://a.ml/vocabularies/apiContract#tag": [
         {
           "@id": "amf://id#53"
         }
       ],
+      "http://a.ml/vocabularies/apiContract#tag": [
+        {
+          "@id": "amf://id#52"
+        }
+      ],
       "http://a.ml/vocabularies/apiContract#server": [
         {
-          "@id": "amf://id#37"
+          "@id": "amf://id#36"
         }
       ],
       "http://a.ml/vocabularies/apiContract#operationId": "opid",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#52/source-map"
+          "@id": "amf://id#51/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#51/source-map",
+      "@id": "amf://id#50/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#51/source-map/lexical/element_1"
+          "@id": "amf://id#50/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#51/source-map/lexical/element_0"
+          "@id": "amf://id#50/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#36/source-map/lexical/element_5",
+      "@id": "amf://id#35/source-map/lexical/element_5",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#version",
       "http://a.ml/vocabularies/document-source-maps#value": "[(4,2)-(5,0)]"
     },
     {
-      "@id": "amf://id#36/source-map/lexical/element_3",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#36",
+      "@id": "amf://id#35/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#35",
       "http://a.ml/vocabularies/document-source-maps#value": "[(1,0)-(136,25)]"
     },
     {
-      "@id": "amf://id#36/source-map/lexical/element_1",
+      "@id": "amf://id#35/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#server",
       "http://a.ml/vocabularies/document-source-maps#value": "[(6,0)-(9,0)]"
     },
     {
-      "@id": "amf://id#36/source-map/lexical/element_0",
+      "@id": "amf://id#35/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#endpoint",
       "http://a.ml/vocabularies/document-source-maps#value": "[(46,0)-(136,25)]"
     },
     {
-      "@id": "amf://id#36/source-map/lexical/element_2",
+      "@id": "amf://id#35/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(3,2)-(4,0)]"
     },
     {
-      "@id": "amf://id#36/source-map/lexical/element_4",
+      "@id": "amf://id#35/source-map/lexical/element_4",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(5,2)-(6,0)]"
     },
     {
-      "@id": "amf://id#37/source-map/lexical/element_2",
+      "@id": "amf://id#36/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#urlTemplate",
       "http://a.ml/vocabularies/document-source-maps#value": "[(7,4)-(8,0)]"
     },
     {
-      "@id": "amf://id#37/source-map/lexical/element_0",
+      "@id": "amf://id#36/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(8,4)-(9,0)]"
     },
     {
-      "@id": "amf://id#37/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#37",
+      "@id": "amf://id#36/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#36",
       "http://a.ml/vocabularies/document-source-maps#value": "[(7,4)-(9,0)]"
     },
     {
-      "@id": "amf://id#38/source-map/lexical/element_2",
+      "@id": "amf://id#37/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#url",
       "http://a.ml/vocabularies/document-source-maps#value": "[(11,2)-(13,0)]"
     },
     {
-      "@id": "amf://id#38/source-map/lexical/element_0",
+      "@id": "amf://id#37/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(10,2)-(11,0)]"
     },
     {
-      "@id": "amf://id#38/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#38",
+      "@id": "amf://id#37/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#37",
       "http://a.ml/vocabularies/document-source-maps#value": "[(10,0)-(13,0)]"
     },
     {
-      "@id": "amf://id#45",
+      "@id": "amf://id#44",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#parameter": [
         {
-          "@id": "amf://id#46"
+          "@id": "amf://id#45"
         }
       ],
       "http://a.ml/vocabularies/apiContract#uriParameter": [
         {
-          "@id": "amf://id#49"
+          "@id": "amf://id#48"
         }
       ],
       "http://a.ml/vocabularies/core#name": "requestBody",
@@ -376,19 +379,20 @@
       ],
       "http://a.ml/vocabularies/apiContract#header": [
         {
-          "@id": "amf://id#47"
+          "@id": "amf://id#46"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#45/source-map"
+          "@id": "amf://id#44/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#42",
+      "@id": "amf://id#41",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -402,22 +406,9 @@
       ],
       "http://a.ml/vocabularies/apiContract#header": [
         {
-          "@id": "amf://id#43"
+          "@id": "amf://id#42"
         }
       ],
-      "http://a.ml/vocabularies/document-source-maps#sources": [
-        {
-          "@id": "amf://id#42/source-map"
-        }
-      ]
-    },
-    {
-      "@id": "amf://id#41",
-      "@type": [
-        "http://a.ml/vocabularies/apiContract#Tag",
-        "http://a.ml/vocabularies/document#DomainElement"
-      ],
-      "http://a.ml/vocabularies/core#name": "Invoice Items",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
           "@id": "amf://id#41/source-map"
@@ -425,66 +416,78 @@
       ]
     },
     {
-      "@id": "amf://id#40/source-map",
+      "@id": "amf://id#40",
+      "@type": [
+        "http://a.ml/vocabularies/apiContract#Tag",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/core#name": "Invoice Items",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "amf://id#40/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "amf://id#39/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#40/source-map/lexical/element_6"
+          "@id": "amf://id#39/source-map/lexical/element_5"
         },
         {
-          "@id": "amf://id#40/source-map/lexical/element_4"
+          "@id": "amf://id#39/source-map/lexical/element_3"
         },
         {
-          "@id": "amf://id#40/source-map/lexical/element_2"
+          "@id": "amf://id#39/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#40/source-map/lexical/element_0"
+          "@id": "amf://id#39/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#40/source-map/lexical/element_1"
+          "@id": "amf://id#39/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#40/source-map/lexical/element_3"
-        },
-        {
-          "@id": "amf://id#40/source-map/lexical/element_5"
+          "@id": "amf://id#39/source-map/lexical/element_4"
         }
       ]
     },
     {
-      "@id": "amf://id#39/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#39",
+      "@id": "amf://id#38/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#38",
       "http://a.ml/vocabularies/document-source-maps#value": "[(47,2)-(96,0)]"
     },
     {
-      "@id": "amf://id#39/source-map/lexical/element_0",
+      "@id": "amf://id#38/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(48,4)-(49,0)]"
     },
     {
-      "@id": "amf://id#59",
+      "@id": "amf://id#58",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#uriParameter": [
         {
-          "@id": "amf://id#65"
+          "@id": "amf://id#64"
         }
       ],
       "http://a.ml/vocabularies/apiContract#header": [
         {
-          "@id": "amf://id#60"
+          "@id": "amf://id#59"
         }
       ]
     },
     {
-      "@id": "amf://id#54",
+      "@id": "amf://id#53",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -498,22 +501,9 @@
       ],
       "http://a.ml/vocabularies/apiContract#header": [
         {
-          "@id": "amf://id#55"
+          "@id": "amf://id#54"
         }
       ],
-      "http://a.ml/vocabularies/document-source-maps#sources": [
-        {
-          "@id": "amf://id#54/source-map"
-        }
-      ]
-    },
-    {
-      "@id": "amf://id#53",
-      "@type": [
-        "http://a.ml/vocabularies/apiContract#Tag",
-        "http://a.ml/vocabularies/document#DomainElement"
-      ],
-      "http://a.ml/vocabularies/core#name": "Invoice Items",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
           "@id": "amf://id#53/source-map"
@@ -521,45 +511,59 @@
       ]
     },
     {
-      "@id": "amf://id#52/source-map",
+      "@id": "amf://id#52",
+      "@type": [
+        "http://a.ml/vocabularies/apiContract#Tag",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/core#name": "Invoice Items",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "amf://id#52/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "amf://id#51/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#52/source-map/lexical/element_5"
+          "@id": "amf://id#51/source-map/lexical/element_5"
         },
         {
-          "@id": "amf://id#52/source-map/lexical/element_3"
+          "@id": "amf://id#51/source-map/lexical/element_3"
         },
         {
-          "@id": "amf://id#52/source-map/lexical/element_1"
+          "@id": "amf://id#51/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#52/source-map/lexical/element_0"
+          "@id": "amf://id#51/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#52/source-map/lexical/element_2"
+          "@id": "amf://id#51/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#52/source-map/lexical/element_4"
+          "@id": "amf://id#51/source-map/lexical/element_4"
         }
       ]
     },
     {
-      "@id": "amf://id#51/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#51",
+      "@id": "amf://id#50/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#50",
       "http://a.ml/vocabularies/document-source-maps#value": "[(96,2)-(136,25)]"
     },
     {
-      "@id": "amf://id#51/source-map/lexical/element_0",
+      "@id": "amf://id#50/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(97,4)-(98,0)]"
     },
     {
-      "@id": "amf://id#46",
+      "@id": "amf://id#45",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "other",
@@ -573,14 +577,15 @@
       "http://a.ml/vocabularies/apiContract#binding": "query",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#46/source-map"
+          "@id": "amf://id#45/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#49",
+      "@id": "amf://id#48",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -591,11 +596,11 @@
       "http://a.ml/vocabularies/apiContract#explode": false,
       "http://a.ml/vocabularies/apiContract#binding": "path",
       "http://a.ml/vocabularies/shapes#schema": {
-        "@id": "amf://id#50"
+        "@id": "amf://id#49"
       },
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#49/source-map"
+          "@id": "amf://id#48/source-map"
         }
       ]
     },
@@ -603,6 +608,7 @@
       "@id": "amf://id#23",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -616,9 +622,10 @@
       ]
     },
     {
-      "@id": "amf://id#47",
+      "@id": "amf://id#46",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "accept",
@@ -629,25 +636,22 @@
       "http://a.ml/vocabularies/apiContract#explode": false,
       "http://a.ml/vocabularies/apiContract#binding": "header",
       "http://a.ml/vocabularies/shapes#schema": {
-        "@id": "amf://id#48"
+        "@id": "amf://id#47"
       },
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#47/source-map"
+          "@id": "amf://id#46/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#45/source-map",
+      "@id": "amf://id#44/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#45/source-map/lexical/element_1"
-        },
-        {
-          "@id": "amf://id#45/source-map/lexical/element_0"
+          "@id": "amf://id#44/source-map/lexical/element_0"
         }
       ]
     },
@@ -655,6 +659,7 @@
       "@id": "amf://id#19",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -668,9 +673,10 @@
       ]
     },
     {
-      "@id": "amf://id#43",
+      "@id": "amf://id#42",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "content-type",
@@ -679,34 +685,11 @@
       "http://a.ml/vocabularies/apiContract#explode": false,
       "http://a.ml/vocabularies/apiContract#binding": "header",
       "http://a.ml/vocabularies/shapes#schema": {
-        "@id": "amf://id#44"
+        "@id": "amf://id#43"
       },
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#43/source-map"
-        }
-      ]
-    },
-    {
-      "@id": "amf://id#42/source-map",
-      "@type": [
-        "http://a.ml/vocabularies/document-source-maps#SourceMap"
-      ],
-      "http://a.ml/vocabularies/document-source-maps#lexical": [
-        {
-          "@id": "amf://id#42/source-map/lexical/element_4"
-        },
-        {
-          "@id": "amf://id#42/source-map/lexical/element_2"
-        },
-        {
-          "@id": "amf://id#42/source-map/lexical/element_0"
-        },
-        {
-          "@id": "amf://id#42/source-map/lexical/element_1"
-        },
-        {
-          "@id": "amf://id#42/source-map/lexical/element_3"
+          "@id": "amf://id#42/source-map"
         }
       ]
     },
@@ -717,49 +700,68 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
+          "@id": "amf://id#41/source-map/lexical/element_4"
+        },
+        {
+          "@id": "amf://id#41/source-map/lexical/element_2"
+        },
+        {
           "@id": "amf://id#41/source-map/lexical/element_0"
+        },
+        {
+          "@id": "amf://id#41/source-map/lexical/element_1"
+        },
+        {
+          "@id": "amf://id#41/source-map/lexical/element_3"
         }
       ]
     },
     {
-      "@id": "amf://id#40/source-map/lexical/element_6",
+      "@id": "amf://id#40/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "amf://id#40/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "amf://id#39/source-map/lexical/element_5",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#tag",
       "http://a.ml/vocabularies/document-source-maps#value": "[(67,6)-(69,0)]"
     },
     {
-      "@id": "amf://id#40/source-map/lexical/element_4",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(66,6)-(67,0)]"
+      "@id": "amf://id#39/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#39",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(64,4)-(96,0)]"
     },
     {
-      "@id": "amf://id#40/source-map/lexical/element_2",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(65,6)-(66,0)]"
-    },
-    {
-      "@id": "amf://id#40/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#operationId",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(66,6)-(67,0)]"
-    },
-    {
-      "@id": "amf://id#40/source-map/lexical/element_1",
+      "@id": "amf://id#39/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#returns",
       "http://a.ml/vocabularies/document-source-maps#value": "[(81,6)-(96,0)]"
     },
     {
-      "@id": "amf://id#40/source-map/lexical/element_3",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#40",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(64,4)-(96,0)]"
+      "@id": "amf://id#39/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#operationId",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(66,6)-(67,0)]"
     },
     {
-      "@id": "amf://id#40/source-map/lexical/element_5",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#expects",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(69,6)-(81,0)]"
+      "@id": "amf://id#39/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(66,6)-(67,0)]"
     },
     {
-      "@id": "amf://id#65",
+      "@id": "amf://id#39/source-map/lexical/element_4",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(65,6)-(66,0)]"
+    },
+    {
+      "@id": "amf://id#64",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -770,18 +772,19 @@
       "http://a.ml/vocabularies/apiContract#explode": false,
       "http://a.ml/vocabularies/apiContract#binding": "path",
       "http://a.ml/vocabularies/shapes#schema": {
-        "@id": "amf://id#66"
+        "@id": "amf://id#65"
       },
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#65/source-map"
+          "@id": "amf://id#64/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#60",
+      "@id": "amf://id#59",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "accept",
@@ -792,16 +795,16 @@
       "http://a.ml/vocabularies/apiContract#explode": false,
       "http://a.ml/vocabularies/apiContract#binding": "header",
       "http://a.ml/vocabularies/shapes#schema": {
-        "@id": "amf://id#61"
+        "@id": "amf://id#60"
       },
       "http://a.ml/vocabularies/apiContract#examples": [
         {
-          "@id": "amf://id#62"
+          "@id": "amf://id#61"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#60/source-map"
+          "@id": "amf://id#59/source-map"
         }
       ]
     },
@@ -809,6 +812,7 @@
       "@id": "amf://id#30",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -822,9 +826,10 @@
       ]
     },
     {
-      "@id": "amf://id#55",
+      "@id": "amf://id#54",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "content-type",
@@ -833,39 +838,16 @@
       "http://a.ml/vocabularies/apiContract#explode": false,
       "http://a.ml/vocabularies/apiContract#binding": "header",
       "http://a.ml/vocabularies/shapes#schema": {
-        "@id": "amf://id#56"
+        "@id": "amf://id#55"
       },
       "http://a.ml/vocabularies/apiContract#examples": [
         {
-          "@id": "amf://id#57"
+          "@id": "amf://id#56"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#55/source-map"
-        }
-      ]
-    },
-    {
-      "@id": "amf://id#54/source-map",
-      "@type": [
-        "http://a.ml/vocabularies/document-source-maps#SourceMap"
-      ],
-      "http://a.ml/vocabularies/document-source-maps#lexical": [
-        {
-          "@id": "amf://id#54/source-map/lexical/element_4"
-        },
-        {
-          "@id": "amf://id#54/source-map/lexical/element_2"
-        },
-        {
-          "@id": "amf://id#54/source-map/lexical/element_0"
-        },
-        {
-          "@id": "amf://id#54/source-map/lexical/element_1"
-        },
-        {
-          "@id": "amf://id#54/source-map/lexical/element_3"
+          "@id": "amf://id#54/source-map"
         }
       ]
     },
@@ -876,76 +858,99 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
+          "@id": "amf://id#53/source-map/lexical/element_4"
+        },
+        {
+          "@id": "amf://id#53/source-map/lexical/element_2"
+        },
+        {
           "@id": "amf://id#53/source-map/lexical/element_0"
+        },
+        {
+          "@id": "amf://id#53/source-map/lexical/element_1"
+        },
+        {
+          "@id": "amf://id#53/source-map/lexical/element_3"
         }
       ]
     },
     {
-      "@id": "amf://id#52/source-map/lexical/element_5",
+      "@id": "amf://id#52/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "amf://id#52/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "amf://id#51/source-map/lexical/element_5",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#tag",
       "http://a.ml/vocabularies/document-source-maps#value": "[(117,6)-(119,0)]"
     },
     {
-      "@id": "amf://id#52/source-map/lexical/element_3",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#52",
+      "@id": "amf://id#51/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#51",
       "http://a.ml/vocabularies/document-source-maps#value": "[(114,4)-(136,25)]"
     },
     {
-      "@id": "amf://id#52/source-map/lexical/element_1",
+      "@id": "amf://id#51/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#returns",
       "http://a.ml/vocabularies/document-source-maps#value": "[(119,6)-(136,25)]"
     },
     {
-      "@id": "amf://id#52/source-map/lexical/element_0",
+      "@id": "amf://id#51/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#operationId",
       "http://a.ml/vocabularies/document-source-maps#value": "[(116,6)-(117,0)]"
     },
     {
-      "@id": "amf://id#52/source-map/lexical/element_2",
+      "@id": "amf://id#51/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(116,6)-(117,0)]"
     },
     {
-      "@id": "amf://id#52/source-map/lexical/element_4",
+      "@id": "amf://id#51/source-map/lexical/element_4",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(115,6)-(116,0)]"
     },
     {
-      "@id": "amf://id#46/source-map",
+      "@id": "amf://id#45/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#46/source-map/synthesized-field/element_2"
+          "@id": "amf://id#45/source-map/synthesized-field/element_2"
         },
         {
-          "@id": "amf://id#46/source-map/synthesized-field/element_0"
+          "@id": "amf://id#45/source-map/synthesized-field/element_0"
         },
         {
-          "@id": "amf://id#46/source-map/synthesized-field/element_1"
+          "@id": "amf://id#45/source-map/synthesized-field/element_1"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#46/source-map/lexical/element_4"
+          "@id": "amf://id#45/source-map/lexical/element_4"
         },
         {
-          "@id": "amf://id#46/source-map/lexical/element_2"
+          "@id": "amf://id#45/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#46/source-map/lexical/element_0"
+          "@id": "amf://id#45/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#46/source-map/lexical/element_1"
+          "@id": "amf://id#45/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#46/source-map/lexical/element_3"
+          "@id": "amf://id#45/source-map/lexical/element_3"
         }
       ]
     },
     {
-      "@id": "amf://id#50",
+      "@id": "amf://id#49",
       "@type": [
         "http://a.ml/vocabularies/shapes#ScalarShape",
         "http://a.ml/vocabularies/shapes#AnyShape",
@@ -961,44 +966,44 @@
       "http://www.w3.org/ns/shacl#name": "id",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#50/source-map"
+          "@id": "amf://id#49/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#49/source-map",
+      "@id": "amf://id#48/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#49/source-map/synthesized-field/element_1"
+          "@id": "amf://id#48/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "amf://id#49/source-map/synthesized-field/element_0"
+          "@id": "amf://id#48/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#49/source-map/lexical/element_6"
+          "@id": "amf://id#48/source-map/lexical/element_6"
         },
         {
-          "@id": "amf://id#49/source-map/lexical/element_4"
+          "@id": "amf://id#48/source-map/lexical/element_4"
         },
         {
-          "@id": "amf://id#49/source-map/lexical/element_2"
+          "@id": "amf://id#48/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#49/source-map/lexical/element_0"
+          "@id": "amf://id#48/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#49/source-map/lexical/element_1"
+          "@id": "amf://id#48/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#49/source-map/lexical/element_3"
+          "@id": "amf://id#48/source-map/lexical/element_3"
         },
         {
-          "@id": "amf://id#49/source-map/lexical/element_5"
+          "@id": "amf://id#48/source-map/lexical/element_5"
         }
       ]
     },
@@ -1070,7 +1075,7 @@
       ]
     },
     {
-      "@id": "amf://id#48",
+      "@id": "amf://id#47",
       "@type": [
         "http://a.ml/vocabularies/shapes#ScalarShape",
         "http://a.ml/vocabularies/shapes#AnyShape",
@@ -1086,54 +1091,49 @@
       "http://www.w3.org/ns/shacl#name": "accept",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#48/source-map"
+          "@id": "amf://id#47/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#47/source-map",
+      "@id": "amf://id#46/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#47/source-map/synthesized-field/element_2"
+          "@id": "amf://id#46/source-map/synthesized-field/element_2"
         },
         {
-          "@id": "amf://id#47/source-map/synthesized-field/element_0"
+          "@id": "amf://id#46/source-map/synthesized-field/element_0"
         },
         {
-          "@id": "amf://id#47/source-map/synthesized-field/element_1"
+          "@id": "amf://id#46/source-map/synthesized-field/element_1"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#47/source-map/lexical/element_5"
+          "@id": "amf://id#46/source-map/lexical/element_5"
         },
         {
-          "@id": "amf://id#47/source-map/lexical/element_3"
+          "@id": "amf://id#46/source-map/lexical/element_3"
         },
         {
-          "@id": "amf://id#47/source-map/lexical/element_1"
+          "@id": "amf://id#46/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#47/source-map/lexical/element_0"
+          "@id": "amf://id#46/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#47/source-map/lexical/element_2"
+          "@id": "amf://id#46/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#47/source-map/lexical/element_4"
+          "@id": "amf://id#46/source-map/lexical/element_4"
         }
       ]
     },
     {
-      "@id": "amf://id#45/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#45",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(69,6)-(81,0)]"
-    },
-    {
-      "@id": "amf://id#45/source-map/lexical/element_0",
+      "@id": "amf://id#44/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(69,6)-(69,17)]"
     },
@@ -1155,7 +1155,7 @@
       ]
     },
     {
-      "@id": "amf://id#44",
+      "@id": "amf://id#43",
       "@type": [
         "http://a.ml/vocabularies/shapes#ScalarShape",
         "http://a.ml/vocabularies/shapes#AnyShape",
@@ -1171,70 +1171,70 @@
       "http://www.w3.org/ns/shacl#name": "schema",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#44/source-map"
+          "@id": "amf://id#43/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#43/source-map",
+      "@id": "amf://id#42/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#43/source-map/synthesized-field/element_2"
+          "@id": "amf://id#42/source-map/synthesized-field/element_2"
         },
         {
-          "@id": "amf://id#43/source-map/synthesized-field/element_0"
+          "@id": "amf://id#42/source-map/synthesized-field/element_0"
         },
         {
-          "@id": "amf://id#43/source-map/synthesized-field/element_1"
+          "@id": "amf://id#42/source-map/synthesized-field/element_1"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#43/source-map/lexical/element_2"
+          "@id": "amf://id#42/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#43/source-map/lexical/element_0"
+          "@id": "amf://id#42/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#43/source-map/lexical/element_1"
+          "@id": "amf://id#42/source-map/lexical/element_1"
         }
       ]
     },
     {
-      "@id": "amf://id#42/source-map/lexical/element_4",
+      "@id": "amf://id#41/source-map/lexical/element_4",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#payload",
       "http://a.ml/vocabularies/document-source-maps#value": "[(89,10)-(96,0)]"
     },
     {
-      "@id": "amf://id#42/source-map/lexical/element_2",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#42",
+      "@id": "amf://id#41/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#41",
       "http://a.ml/vocabularies/document-source-maps#value": "[(82,8)-(96,0)]"
     },
     {
-      "@id": "amf://id#42/source-map/lexical/element_0",
+      "@id": "amf://id#41/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#header",
       "http://a.ml/vocabularies/document-source-maps#value": "[(84,10)-(89,0)]"
     },
     {
-      "@id": "amf://id#42/source-map/lexical/element_1",
+      "@id": "amf://id#41/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(83,10)-(84,0)]"
     },
     {
-      "@id": "amf://id#42/source-map/lexical/element_3",
+      "@id": "amf://id#41/source-map/lexical/element_3",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(82,8)-(82,13)]"
     },
     {
-      "@id": "amf://id#41/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#41",
+      "@id": "amf://id#40/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#40",
       "http://a.ml/vocabularies/document-source-maps#value": "[(68,10)-(68,23)]"
     },
     {
-      "@id": "amf://id#66",
+      "@id": "amf://id#65",
       "@type": [
         "http://a.ml/vocabularies/shapes#ScalarShape",
         "http://a.ml/vocabularies/shapes#AnyShape",
@@ -1250,54 +1250,54 @@
       "http://www.w3.org/ns/shacl#name": "id",
       "http://a.ml/vocabularies/apiContract#examples": [
         {
-          "@id": "amf://id#67"
+          "@id": "amf://id#66"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#66/source-map"
+          "@id": "amf://id#65/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#65/source-map",
+      "@id": "amf://id#64/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#65/source-map/synthesized-field/element_1"
+          "@id": "amf://id#64/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "amf://id#65/source-map/synthesized-field/element_0"
+          "@id": "amf://id#64/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#65/source-map/lexical/element_6"
+          "@id": "amf://id#64/source-map/lexical/element_6"
         },
         {
-          "@id": "amf://id#65/source-map/lexical/element_4"
+          "@id": "amf://id#64/source-map/lexical/element_4"
         },
         {
-          "@id": "amf://id#65/source-map/lexical/element_2"
+          "@id": "amf://id#64/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#65/source-map/lexical/element_0"
+          "@id": "amf://id#64/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#65/source-map/lexical/element_1"
+          "@id": "amf://id#64/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#65/source-map/lexical/element_3"
+          "@id": "amf://id#64/source-map/lexical/element_3"
         },
         {
-          "@id": "amf://id#65/source-map/lexical/element_5"
+          "@id": "amf://id#64/source-map/lexical/element_5"
         }
       ]
     },
     {
-      "@id": "amf://id#61",
+      "@id": "amf://id#60",
       "@type": [
         "http://a.ml/vocabularies/shapes#ScalarShape",
         "http://a.ml/vocabularies/shapes#AnyShape",
@@ -1313,64 +1313,64 @@
       "http://www.w3.org/ns/shacl#name": "accept",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#61/source-map"
+          "@id": "amf://id#60/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#62",
+      "@id": "amf://id#61",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Example",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/document#strict": true,
       "http://a.ml/vocabularies/document#structuredValue": {
-        "@id": "amf://id#63"
+        "@id": "amf://id#62"
       },
       "http://a.ml/vocabularies/document#raw": "name: a",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#62/source-map"
+          "@id": "amf://id#61/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#60/source-map",
+      "@id": "amf://id#59/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#60/source-map/synthesized-field/element_2"
+          "@id": "amf://id#59/source-map/synthesized-field/element_2"
         },
         {
-          "@id": "amf://id#60/source-map/synthesized-field/element_0"
+          "@id": "amf://id#59/source-map/synthesized-field/element_0"
         },
         {
-          "@id": "amf://id#60/source-map/synthesized-field/element_1"
+          "@id": "amf://id#59/source-map/synthesized-field/element_1"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#60/source-map/lexical/element_6"
+          "@id": "amf://id#59/source-map/lexical/element_6"
         },
         {
-          "@id": "amf://id#60/source-map/lexical/element_4"
+          "@id": "amf://id#59/source-map/lexical/element_4"
         },
         {
-          "@id": "amf://id#60/source-map/lexical/element_2"
+          "@id": "amf://id#59/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#60/source-map/lexical/element_0"
+          "@id": "amf://id#59/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#60/source-map/lexical/element_1"
+          "@id": "amf://id#59/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#60/source-map/lexical/element_3"
+          "@id": "amf://id#59/source-map/lexical/element_3"
         },
         {
-          "@id": "amf://id#60/source-map/lexical/element_5"
+          "@id": "amf://id#59/source-map/lexical/element_5"
         }
       ]
     },
@@ -1392,7 +1392,7 @@
       ]
     },
     {
-      "@id": "amf://id#56",
+      "@id": "amf://id#55",
       "@type": [
         "http://a.ml/vocabularies/shapes#ScalarShape",
         "http://a.ml/vocabularies/shapes#AnyShape",
@@ -1408,197 +1408,197 @@
       "http://www.w3.org/ns/shacl#name": "schema",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#56/source-map"
+          "@id": "amf://id#55/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#57",
+      "@id": "amf://id#56",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Example",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/document#strict": true,
       "http://a.ml/vocabularies/document#structuredValue": {
-        "@id": "amf://id#58"
+        "@id": "amf://id#57"
       },
       "http://a.ml/vocabularies/document#raw": "teapot",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#57/source-map"
+          "@id": "amf://id#56/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#55/source-map",
+      "@id": "amf://id#54/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#55/source-map/synthesized-field/element_2"
+          "@id": "amf://id#54/source-map/synthesized-field/element_2"
         },
         {
-          "@id": "amf://id#55/source-map/synthesized-field/element_0"
+          "@id": "amf://id#54/source-map/synthesized-field/element_0"
         },
         {
-          "@id": "amf://id#55/source-map/synthesized-field/element_1"
+          "@id": "amf://id#54/source-map/synthesized-field/element_1"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#55/source-map/lexical/element_3"
+          "@id": "amf://id#54/source-map/lexical/element_3"
         },
         {
-          "@id": "amf://id#55/source-map/lexical/element_1"
+          "@id": "amf://id#54/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#55/source-map/lexical/element_0"
+          "@id": "amf://id#54/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#55/source-map/lexical/element_2"
+          "@id": "amf://id#54/source-map/lexical/element_2"
         }
       ]
     },
     {
-      "@id": "amf://id#54/source-map/lexical/element_4",
+      "@id": "amf://id#53/source-map/lexical/element_4",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#payload",
       "http://a.ml/vocabularies/document-source-maps#value": "[(129,10)-(136,25)]"
     },
     {
-      "@id": "amf://id#54/source-map/lexical/element_2",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#54",
+      "@id": "amf://id#53/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#53",
       "http://a.ml/vocabularies/document-source-maps#value": "[(120,8)-(136,25)]"
     },
     {
-      "@id": "amf://id#54/source-map/lexical/element_0",
+      "@id": "amf://id#53/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#header",
       "http://a.ml/vocabularies/document-source-maps#value": "[(122,10)-(129,0)]"
     },
     {
-      "@id": "amf://id#54/source-map/lexical/element_1",
+      "@id": "amf://id#53/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(121,10)-(122,0)]"
     },
     {
-      "@id": "amf://id#54/source-map/lexical/element_3",
+      "@id": "amf://id#53/source-map/lexical/element_3",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(120,8)-(120,13)]"
     },
     {
-      "@id": "amf://id#53/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#53",
+      "@id": "amf://id#52/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#52",
       "http://a.ml/vocabularies/document-source-maps#value": "[(118,10)-(118,23)]"
     },
     {
-      "@id": "amf://id#46/source-map/synthesized-field/element_2",
+      "@id": "amf://id#45/source-map/synthesized-field/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#style",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#46/source-map/synthesized-field/element_0",
+      "@id": "amf://id#45/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#explode",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#46/source-map/synthesized-field/element_1",
+      "@id": "amf://id#45/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#required",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#46/source-map/lexical/element_4",
+      "@id": "amf://id#45/source-map/lexical/element_4",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(63,8)-(64,0)]"
     },
     {
-      "@id": "amf://id#46/source-map/lexical/element_2",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#46",
+      "@id": "amf://id#45/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#45",
       "http://a.ml/vocabularies/document-source-maps#value": "[(61,8)-(64,0)]"
     },
     {
-      "@id": "amf://id#46/source-map/lexical/element_0",
+      "@id": "amf://id#45/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#binding",
       "http://a.ml/vocabularies/document-source-maps#value": "[(62,8)-(63,0)]"
     },
     {
-      "@id": "amf://id#46/source-map/lexical/element_1",
+      "@id": "amf://id#45/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#paramName",
       "http://a.ml/vocabularies/document-source-maps#value": "[(61,8)-(62,0)]"
     },
     {
-      "@id": "amf://id#46/source-map/lexical/element_3",
+      "@id": "amf://id#45/source-map/lexical/element_3",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(61,8)-(62,0)]"
     },
     {
-      "@id": "amf://id#50/source-map",
+      "@id": "amf://id#49/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#auto-generated-name": [
         {
-          "@id": "amf://id#50/source-map/auto-generated-name/element_0"
+          "@id": "amf://id#49/source-map/auto-generated-name/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#50/source-map/lexical/element_2"
+          "@id": "amf://id#49/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#50/source-map/lexical/element_0"
+          "@id": "amf://id#49/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#50/source-map/lexical/element_1"
+          "@id": "amf://id#49/source-map/lexical/element_1"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
         {
-          "@id": "amf://id#50/source-map/type-property-lexical-info/element_0"
+          "@id": "amf://id#49/source-map/type-property-lexical-info/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#49/source-map/synthesized-field/element_1",
+      "@id": "amf://id#48/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#style",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#49/source-map/synthesized-field/element_0",
+      "@id": "amf://id#48/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#explode",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#49/source-map/lexical/element_6",
+      "@id": "amf://id#48/source-map/lexical/element_6",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#binding",
       "http://a.ml/vocabularies/document-source-maps#value": "[(51,8)-(52,0)]"
     },
     {
-      "@id": "amf://id#49/source-map/lexical/element_4",
+      "@id": "amf://id#48/source-map/lexical/element_4",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(50,8)-(51,0)]"
     },
     {
-      "@id": "amf://id#49/source-map/lexical/element_2",
+      "@id": "amf://id#48/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#paramName",
       "http://a.ml/vocabularies/document-source-maps#value": "[(50,8)-(51,0)]"
     },
     {
-      "@id": "amf://id#49/source-map/lexical/element_0",
+      "@id": "amf://id#48/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/shapes#schema",
       "http://a.ml/vocabularies/document-source-maps#value": "[(54,8)-(56,0)]"
     },
     {
-      "@id": "amf://id#49/source-map/lexical/element_1",
+      "@id": "amf://id#48/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#required",
       "http://a.ml/vocabularies/document-source-maps#value": "[(52,8)-(53,0)]"
     },
     {
-      "@id": "amf://id#49/source-map/lexical/element_3",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#49",
+      "@id": "amf://id#48/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#48",
       "http://a.ml/vocabularies/document-source-maps#value": "[(50,8)-(56,0)]"
     },
     {
-      "@id": "amf://id#49/source-map/lexical/element_5",
+      "@id": "amf://id#48/source-map/lexical/element_5",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(53,8)-(54,0)]"
     },
@@ -1858,74 +1858,74 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(71,10)-(81,0)]"
     },
     {
-      "@id": "amf://id#48/source-map",
+      "@id": "amf://id#47/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#auto-generated-name": [
         {
-          "@id": "amf://id#48/source-map/auto-generated-name/element_0"
+          "@id": "amf://id#47/source-map/auto-generated-name/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#48/source-map/lexical/element_2"
+          "@id": "amf://id#47/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#48/source-map/lexical/element_0"
+          "@id": "amf://id#47/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#48/source-map/lexical/element_1"
+          "@id": "amf://id#47/source-map/lexical/element_1"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
         {
-          "@id": "amf://id#48/source-map/type-property-lexical-info/element_0"
+          "@id": "amf://id#47/source-map/type-property-lexical-info/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#47/source-map/synthesized-field/element_2",
+      "@id": "amf://id#46/source-map/synthesized-field/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#style",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#47/source-map/synthesized-field/element_0",
+      "@id": "amf://id#46/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#explode",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#47/source-map/synthesized-field/element_1",
+      "@id": "amf://id#46/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#required",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#47/source-map/lexical/element_5",
+      "@id": "amf://id#46/source-map/lexical/element_5",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#binding",
       "http://a.ml/vocabularies/document-source-maps#value": "[(57,8)-(58,0)]"
     },
     {
-      "@id": "amf://id#47/source-map/lexical/element_3",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#47",
+      "@id": "amf://id#46/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#46",
       "http://a.ml/vocabularies/document-source-maps#value": "[(56,8)-(61,0)]"
     },
     {
-      "@id": "amf://id#47/source-map/lexical/element_1",
+      "@id": "amf://id#46/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(58,8)-(59,0)]"
     },
     {
-      "@id": "amf://id#47/source-map/lexical/element_0",
+      "@id": "amf://id#46/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/shapes#schema",
       "http://a.ml/vocabularies/document-source-maps#value": "[(59,8)-(61,0)]"
     },
     {
-      "@id": "amf://id#47/source-map/lexical/element_2",
+      "@id": "amf://id#46/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(56,8)-(57,0)]"
     },
     {
-      "@id": "amf://id#47/source-map/lexical/element_4",
+      "@id": "amf://id#46/source-map/lexical/element_4",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#paramName",
       "http://a.ml/vocabularies/document-source-maps#value": "[(56,8)-(57,0)]"
     },
@@ -1945,253 +1945,253 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(90,12)-(96,0)]"
     },
     {
-      "@id": "amf://id#44/source-map",
+      "@id": "amf://id#43/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
         {
-          "@id": "amf://id#44/source-map/type-property-lexical-info/element_0"
+          "@id": "amf://id#43/source-map/type-property-lexical-info/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#44/source-map/lexical/element_1"
+          "@id": "amf://id#43/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#44/source-map/lexical/element_0"
+          "@id": "amf://id#43/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#43/source-map/synthesized-field/element_2",
+      "@id": "amf://id#42/source-map/synthesized-field/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#explode",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#43/source-map/synthesized-field/element_0",
+      "@id": "amf://id#42/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#binding",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#43/source-map/synthesized-field/element_1",
+      "@id": "amf://id#42/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#style",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#43/source-map/lexical/element_2",
+      "@id": "amf://id#42/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(86,14)-(87,0)]"
     },
     {
-      "@id": "amf://id#43/source-map/lexical/element_0",
+      "@id": "amf://id#42/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/shapes#schema",
       "http://a.ml/vocabularies/document-source-maps#value": "[(87,14)-(89,0)]"
     },
     {
-      "@id": "amf://id#43/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#43",
+      "@id": "amf://id#42/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#42",
       "http://a.ml/vocabularies/document-source-maps#value": "[(85,12)-(89,0)]"
     },
     {
-      "@id": "amf://id#67",
+      "@id": "amf://id#66",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Example",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/document#strict": true,
       "http://a.ml/vocabularies/document#structuredValue": {
-        "@id": "amf://id#68"
+        "@id": "amf://id#67"
       },
       "http://a.ml/vocabularies/document#raw": "id: 34",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#67/source-map"
+          "@id": "amf://id#66/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#66/source-map",
+      "@id": "amf://id#65/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#auto-generated-name": [
         {
-          "@id": "amf://id#66/source-map/auto-generated-name/element_0"
+          "@id": "amf://id#65/source-map/auto-generated-name/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#66/source-map/lexical/element_2"
+          "@id": "amf://id#65/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#66/source-map/lexical/element_0"
+          "@id": "amf://id#65/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#66/source-map/lexical/element_1"
+          "@id": "amf://id#65/source-map/lexical/element_1"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
         {
-          "@id": "amf://id#66/source-map/type-property-lexical-info/element_0"
+          "@id": "amf://id#65/source-map/type-property-lexical-info/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#65/source-map/synthesized-field/element_1",
+      "@id": "amf://id#64/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#style",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#65/source-map/synthesized-field/element_0",
+      "@id": "amf://id#64/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#explode",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#65/source-map/lexical/element_6",
+      "@id": "amf://id#64/source-map/lexical/element_6",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#binding",
       "http://a.ml/vocabularies/document-source-maps#value": "[(100,8)-(101,0)]"
     },
     {
-      "@id": "amf://id#65/source-map/lexical/element_4",
+      "@id": "amf://id#64/source-map/lexical/element_4",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(99,8)-(100,0)]"
     },
     {
-      "@id": "amf://id#65/source-map/lexical/element_2",
+      "@id": "amf://id#64/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#paramName",
       "http://a.ml/vocabularies/document-source-maps#value": "[(99,8)-(100,0)]"
     },
     {
-      "@id": "amf://id#65/source-map/lexical/element_0",
+      "@id": "amf://id#64/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/shapes#schema",
       "http://a.ml/vocabularies/document-source-maps#value": "[(103,8)-(105,0)]"
     },
     {
-      "@id": "amf://id#65/source-map/lexical/element_1",
+      "@id": "amf://id#64/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#required",
       "http://a.ml/vocabularies/document-source-maps#value": "[(101,8)-(102,0)]"
     },
     {
-      "@id": "amf://id#65/source-map/lexical/element_3",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#65",
+      "@id": "amf://id#64/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#64",
       "http://a.ml/vocabularies/document-source-maps#value": "[(99,8)-(107,0)]"
     },
     {
-      "@id": "amf://id#65/source-map/lexical/element_5",
+      "@id": "amf://id#64/source-map/lexical/element_5",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(102,8)-(103,0)]"
     },
     {
-      "@id": "amf://id#61/source-map",
+      "@id": "amf://id#60/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#auto-generated-name": [
         {
-          "@id": "amf://id#61/source-map/auto-generated-name/element_0"
+          "@id": "amf://id#60/source-map/auto-generated-name/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#61/source-map/lexical/element_2"
+          "@id": "amf://id#60/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#61/source-map/lexical/element_0"
+          "@id": "amf://id#60/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#61/source-map/lexical/element_1"
+          "@id": "amf://id#60/source-map/lexical/element_1"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
         {
-          "@id": "amf://id#61/source-map/type-property-lexical-info/element_0"
+          "@id": "amf://id#60/source-map/type-property-lexical-info/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#63",
+      "@id": "amf://id#62",
       "@type": [
         "http://a.ml/vocabularies/data#Object",
         "http://a.ml/vocabularies/data#Node",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/data#name": {
-        "@id": "amf://id#64"
+        "@id": "amf://id#63"
       },
       "http://a.ml/vocabularies/core#name": "object_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#63/source-map"
+          "@id": "amf://id#62/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#62/source-map",
+      "@id": "amf://id#61/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#62/source-map/synthesized-field/element_1"
+          "@id": "amf://id#61/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "amf://id#62/source-map/synthesized-field/element_0"
+          "@id": "amf://id#61/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#62/source-map/lexical/element_0"
+          "@id": "amf://id#61/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#60/source-map/synthesized-field/element_2",
+      "@id": "amf://id#59/source-map/synthesized-field/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#style",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#60/source-map/synthesized-field/element_0",
+      "@id": "amf://id#59/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#explode",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#60/source-map/synthesized-field/element_1",
+      "@id": "amf://id#59/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#required",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#60/source-map/lexical/element_6",
+      "@id": "amf://id#59/source-map/lexical/element_6",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/shapes#schema",
       "http://a.ml/vocabularies/document-source-maps#value": "[(110,8)-(112,0)]"
     },
     {
-      "@id": "amf://id#60/source-map/lexical/element_4",
+      "@id": "amf://id#59/source-map/lexical/element_4",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(107,8)-(108,0)]"
     },
     {
-      "@id": "amf://id#60/source-map/lexical/element_2",
+      "@id": "amf://id#59/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#paramName",
       "http://a.ml/vocabularies/document-source-maps#value": "[(107,8)-(108,0)]"
     },
     {
-      "@id": "amf://id#60/source-map/lexical/element_0",
+      "@id": "amf://id#59/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#examples",
       "http://a.ml/vocabularies/document-source-maps#value": "[(112,8)-(114,0)]"
     },
     {
-      "@id": "amf://id#60/source-map/lexical/element_1",
+      "@id": "amf://id#59/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#binding",
       "http://a.ml/vocabularies/document-source-maps#value": "[(109,8)-(110,0)]"
     },
     {
-      "@id": "amf://id#60/source-map/lexical/element_3",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#60",
+      "@id": "amf://id#59/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#59",
       "http://a.ml/vocabularies/document-source-maps#value": "[(107,8)-(114,0)]"
     },
     {
-      "@id": "amf://id#60/source-map/lexical/element_5",
+      "@id": "amf://id#59/source-map/lexical/element_5",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(108,8)-(109,0)]"
     },
@@ -2211,26 +2211,26 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(130,12)-(136,25)]"
     },
     {
-      "@id": "amf://id#56/source-map",
+      "@id": "amf://id#55/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
         {
-          "@id": "amf://id#56/source-map/type-property-lexical-info/element_0"
+          "@id": "amf://id#55/source-map/type-property-lexical-info/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#56/source-map/lexical/element_1"
+          "@id": "amf://id#55/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#56/source-map/lexical/element_0"
+          "@id": "amf://id#55/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#58",
+      "@id": "amf://id#57",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -2245,87 +2245,87 @@
       "http://a.ml/vocabularies/core#name": "scalar_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#58/source-map"
+          "@id": "amf://id#57/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#57/source-map",
+      "@id": "amf://id#56/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#57/source-map/synthesized-field/element_1"
+          "@id": "amf://id#56/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "amf://id#57/source-map/synthesized-field/element_0"
+          "@id": "amf://id#56/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#57/source-map/lexical/element_0"
+          "@id": "amf://id#56/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#55/source-map/synthesized-field/element_2",
+      "@id": "amf://id#54/source-map/synthesized-field/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#explode",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#55/source-map/synthesized-field/element_0",
+      "@id": "amf://id#54/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#binding",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#55/source-map/synthesized-field/element_1",
+      "@id": "amf://id#54/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#style",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#55/source-map/lexical/element_3",
+      "@id": "amf://id#54/source-map/lexical/element_3",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/shapes#schema",
       "http://a.ml/vocabularies/document-source-maps#value": "[(125,14)-(127,0)]"
     },
     {
-      "@id": "amf://id#55/source-map/lexical/element_1",
+      "@id": "amf://id#54/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(124,14)-(125,0)]"
     },
     {
-      "@id": "amf://id#55/source-map/lexical/element_0",
+      "@id": "amf://id#54/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#examples",
       "http://a.ml/vocabularies/document-source-maps#value": "[(127,14)-(129,0)]"
     },
     {
-      "@id": "amf://id#55/source-map/lexical/element_2",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#55",
+      "@id": "amf://id#54/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#54",
       "http://a.ml/vocabularies/document-source-maps#value": "[(123,12)-(129,0)]"
     },
     {
-      "@id": "amf://id#50/source-map/auto-generated-name/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#50",
+      "@id": "amf://id#49/source-map/auto-generated-name/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#49",
       "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
-      "@id": "amf://id#50/source-map/lexical/element_2",
+      "@id": "amf://id#49/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "[(55,10)-(56,0)]"
     },
     {
-      "@id": "amf://id#50/source-map/lexical/element_0",
+      "@id": "amf://id#49/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(50,8)-(51,0)]"
     },
     {
-      "@id": "amf://id#50/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#50",
+      "@id": "amf://id#49/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#49",
       "http://a.ml/vocabularies/document-source-maps#value": "[(54,8)-(56,0)]"
     },
     {
-      "@id": "amf://id#50/source-map/type-property-lexical-info/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#50",
+      "@id": "amf://id#49/source-map/type-property-lexical-info/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#49",
       "http://a.ml/vocabularies/document-source-maps#value": "[(55,10)-(55,14)]"
     },
     {
@@ -2761,138 +2761,138 @@
       "http://a.ml/vocabularies/document-source-maps#value": "amf://id#1"
     },
     {
-      "@id": "amf://id#48/source-map/auto-generated-name/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#48",
+      "@id": "amf://id#47/source-map/auto-generated-name/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#47",
       "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
-      "@id": "amf://id#48/source-map/lexical/element_2",
+      "@id": "amf://id#47/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "[(60,10)-(61,0)]"
     },
     {
-      "@id": "amf://id#48/source-map/lexical/element_0",
+      "@id": "amf://id#47/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(56,8)-(57,0)]"
     },
     {
-      "@id": "amf://id#48/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#48",
+      "@id": "amf://id#47/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#47",
       "http://a.ml/vocabularies/document-source-maps#value": "[(59,8)-(61,0)]"
     },
     {
-      "@id": "amf://id#48/source-map/type-property-lexical-info/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#48",
+      "@id": "amf://id#47/source-map/type-property-lexical-info/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#47",
       "http://a.ml/vocabularies/document-source-maps#value": "[(60,10)-(60,14)]"
     },
     {
-      "@id": "amf://id#44/source-map/type-property-lexical-info/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#44",
+      "@id": "amf://id#43/source-map/type-property-lexical-info/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#43",
       "http://a.ml/vocabularies/document-source-maps#value": "[(88,16)-(88,20)]"
     },
     {
-      "@id": "amf://id#44/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#44",
+      "@id": "amf://id#43/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#43",
       "http://a.ml/vocabularies/document-source-maps#value": "[(87,14)-(89,0)]"
     },
     {
-      "@id": "amf://id#44/source-map/lexical/element_0",
+      "@id": "amf://id#43/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "[(88,16)-(89,0)]"
     },
     {
-      "@id": "amf://id#68",
+      "@id": "amf://id#67",
       "@type": [
         "http://a.ml/vocabularies/data#Object",
         "http://a.ml/vocabularies/data#Node",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/data#id": {
-        "@id": "amf://id#69"
+        "@id": "amf://id#68"
       },
       "http://a.ml/vocabularies/core#name": "object_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#68/source-map"
+          "@id": "amf://id#67/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#67/source-map",
+      "@id": "amf://id#66/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#67/source-map/synthesized-field/element_1"
+          "@id": "amf://id#66/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "amf://id#67/source-map/synthesized-field/element_0"
+          "@id": "amf://id#66/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#67/source-map/lexical/element_0"
+          "@id": "amf://id#66/source-map/lexical/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#tracked-element": [
         {
-          "@id": "amf://id#67/source-map/tracked-element/element_0"
+          "@id": "amf://id#66/source-map/tracked-element/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#66/source-map/auto-generated-name/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#66",
+      "@id": "amf://id#65/source-map/auto-generated-name/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#65",
       "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
-      "@id": "amf://id#66/source-map/lexical/element_2",
+      "@id": "amf://id#65/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "[(104,10)-(105,0)]"
     },
     {
-      "@id": "amf://id#66/source-map/lexical/element_0",
+      "@id": "amf://id#65/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(99,8)-(100,0)]"
     },
     {
-      "@id": "amf://id#66/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#66",
+      "@id": "amf://id#65/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#65",
       "http://a.ml/vocabularies/document-source-maps#value": "[(103,8)-(105,0)]"
     },
     {
-      "@id": "amf://id#66/source-map/type-property-lexical-info/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#66",
+      "@id": "amf://id#65/source-map/type-property-lexical-info/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#65",
       "http://a.ml/vocabularies/document-source-maps#value": "[(104,10)-(104,14)]"
     },
     {
-      "@id": "amf://id#61/source-map/auto-generated-name/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#61",
+      "@id": "amf://id#60/source-map/auto-generated-name/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#60",
       "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
-      "@id": "amf://id#61/source-map/lexical/element_2",
+      "@id": "amf://id#60/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "[(111,10)-(112,0)]"
     },
     {
-      "@id": "amf://id#61/source-map/lexical/element_0",
+      "@id": "amf://id#60/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(107,8)-(108,0)]"
     },
     {
-      "@id": "amf://id#61/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#61",
+      "@id": "amf://id#60/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#60",
       "http://a.ml/vocabularies/document-source-maps#value": "[(110,8)-(112,0)]"
     },
     {
-      "@id": "amf://id#61/source-map/type-property-lexical-info/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#61",
+      "@id": "amf://id#60/source-map/type-property-lexical-info/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#60",
       "http://a.ml/vocabularies/document-source-maps#value": "[(111,10)-(111,14)]"
     },
     {
-      "@id": "amf://id#64",
+      "@id": "amf://id#63",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -2907,91 +2907,91 @@
       "http://a.ml/vocabularies/core#name": "name",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#64/source-map"
+          "@id": "amf://id#63/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#63/source-map",
+      "@id": "amf://id#62/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#63/source-map/synthesized-field/element_0"
+          "@id": "amf://id#62/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#63/source-map/lexical/element_1"
+          "@id": "amf://id#62/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#63/source-map/lexical/element_0"
+          "@id": "amf://id#62/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#62/source-map/synthesized-field/element_1",
+      "@id": "amf://id#61/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#strict",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#62/source-map/synthesized-field/element_0",
+      "@id": "amf://id#61/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#raw",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#62/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#62",
+      "@id": "amf://id#61/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#61",
       "http://a.ml/vocabularies/document-source-maps#value": "[(112,16)-(114,0)]"
     },
     {
-      "@id": "amf://id#56/source-map/type-property-lexical-info/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#56",
+      "@id": "amf://id#55/source-map/type-property-lexical-info/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#55",
       "http://a.ml/vocabularies/document-source-maps#value": "[(126,16)-(126,20)]"
     },
     {
-      "@id": "amf://id#56/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#56",
+      "@id": "amf://id#55/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#55",
       "http://a.ml/vocabularies/document-source-maps#value": "[(125,14)-(127,0)]"
     },
     {
-      "@id": "amf://id#56/source-map/lexical/element_0",
+      "@id": "amf://id#55/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "[(126,16)-(127,0)]"
     },
     {
-      "@id": "amf://id#58/source-map",
+      "@id": "amf://id#57/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#58/source-map/synthesized-field/element_1"
+          "@id": "amf://id#57/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "amf://id#58/source-map/synthesized-field/element_0"
+          "@id": "amf://id#57/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#58/source-map/lexical/element_0"
+          "@id": "amf://id#57/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#57/source-map/synthesized-field/element_1",
+      "@id": "amf://id#56/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#strict",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#57/source-map/synthesized-field/element_0",
+      "@id": "amf://id#56/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#raw",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#57/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#57",
+      "@id": "amf://id#56/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#56",
       "http://a.ml/vocabularies/document-source-maps#value": "[(128,16)-(128,22)]"
     },
     {
@@ -3494,7 +3494,7 @@
       "http://a.ml/vocabularies/document-source-maps#value": "amf://id#30"
     },
     {
-      "@id": "amf://id#69",
+      "@id": "amf://id#68",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -3509,96 +3509,96 @@
       "http://a.ml/vocabularies/core#name": "id",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#69/source-map"
+          "@id": "amf://id#68/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#68/source-map",
+      "@id": "amf://id#67/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#68/source-map/synthesized-field/element_0"
+          "@id": "amf://id#67/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#68/source-map/lexical/element_1"
+          "@id": "amf://id#67/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#68/source-map/lexical/element_0"
+          "@id": "amf://id#67/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#67/source-map/synthesized-field/element_1",
+      "@id": "amf://id#66/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#strict",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#67/source-map/synthesized-field/element_0",
+      "@id": "amf://id#66/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#raw",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#67/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#67",
+      "@id": "amf://id#66/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#66",
       "http://a.ml/vocabularies/document-source-maps#value": "[(105,16)-(107,0)]"
     },
     {
-      "@id": "amf://id#67/source-map/tracked-element/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#67",
-      "http://a.ml/vocabularies/document-source-maps#value": "amf://id#65"
+      "@id": "amf://id#66/source-map/tracked-element/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#66",
+      "http://a.ml/vocabularies/document-source-maps#value": "amf://id#64"
     },
     {
-      "@id": "amf://id#64/source-map",
+      "@id": "amf://id#63/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#64/source-map/synthesized-field/element_1"
+          "@id": "amf://id#63/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "amf://id#64/source-map/synthesized-field/element_0"
+          "@id": "amf://id#63/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#64/source-map/lexical/element_0"
+          "@id": "amf://id#63/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#63/source-map/synthesized-field/element_0",
+      "@id": "amf://id#62/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#63/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#63",
+      "@id": "amf://id#62/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#62",
       "http://a.ml/vocabularies/document-source-maps#value": "[(113,0)-(114,0)]"
     },
     {
-      "@id": "amf://id#63/source-map/lexical/element_0",
+      "@id": "amf://id#62/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(113,10)-(114,0)]"
     },
     {
-      "@id": "amf://id#58/source-map/synthesized-field/element_1",
+      "@id": "amf://id#57/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#58/source-map/synthesized-field/element_0",
+      "@id": "amf://id#57/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#58/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#58",
+      "@id": "amf://id#57/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#57",
       "http://a.ml/vocabularies/document-source-maps#value": "[(128,16)-(128,22)]"
     },
     {
@@ -3920,52 +3920,52 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(136,20)-(136,25)]"
     },
     {
-      "@id": "amf://id#69/source-map",
+      "@id": "amf://id#68/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#69/source-map/synthesized-field/element_1"
+          "@id": "amf://id#68/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "amf://id#69/source-map/synthesized-field/element_0"
+          "@id": "amf://id#68/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#69/source-map/lexical/element_0"
+          "@id": "amf://id#68/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#68/source-map/synthesized-field/element_0",
+      "@id": "amf://id#67/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#68/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#68",
+      "@id": "amf://id#67/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#67",
       "http://a.ml/vocabularies/document-source-maps#value": "[(106,0)-(107,0)]"
     },
     {
-      "@id": "amf://id#68/source-map/lexical/element_0",
+      "@id": "amf://id#67/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#id",
       "http://a.ml/vocabularies/document-source-maps#value": "[(106,10)-(107,0)]"
     },
     {
-      "@id": "amf://id#64/source-map/synthesized-field/element_1",
+      "@id": "amf://id#63/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#64/source-map/synthesized-field/element_0",
+      "@id": "amf://id#63/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#64/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#64",
+      "@id": "amf://id#63/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#63",
       "http://a.ml/vocabularies/document-source-maps#value": "[(113,16)-(113,17)]"
     },
     {
@@ -4096,18 +4096,18 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(136,24)-(136,25)]"
     },
     {
-      "@id": "amf://id#69/source-map/synthesized-field/element_1",
+      "@id": "amf://id#68/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#69/source-map/synthesized-field/element_0",
+      "@id": "amf://id#68/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#69/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#69",
+      "@id": "amf://id#68/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#68",
       "http://a.ml/vocabularies/document-source-maps#value": "[(106,14)-(106,16)]"
     },
     {
@@ -4169,14 +4169,14 @@
         "http://a.ml/vocabularies/document#Unit"
       ],
       "http://a.ml/vocabularies/document#encodes": {
-        "@id": "amf://id#36"
+        "@id": "amf://id#35"
       },
       "http://a.ml/vocabularies/document#root": true,
       "http://a.ml/vocabularies/document#processingData": {
         "@id": "amf://id#34"
       },
       "http://a.ml/vocabularies/document#sourceInformation": {
-        "@id": "amf://id#35"
+        "@id": "amf://id/BaseUnitSourceInformation"
       }
     }
   ]

--- a/test/data/production/best-practices/negative9.yaml.report.jsonld
+++ b/test/data/production/best-practices/negative9.yaml.report.jsonld
@@ -96,30 +96,30 @@
           "reportSchema:ReportNode",
           "shacl:ValidationReport"
         ],
-        "conforms": true,
+        "conforms": false,
         "profileName": "Anypoint Best Practices",
         "result": [
           {
-            "@id": "warning_0",
+            "@id": "violation_0",
             "@type": [
               "reportSchema:ValidationResultNode",
               "shacl:ValidationResult"
             ],
-            "focusNode": "amf://id#52",
+            "focusNode": "amf://id#51",
             "location": {
-              "@id": "warning_0_location",
+              "@id": "violation_0_location",
               "@type": [
                 "lexicalSchema:LocationNode",
                 "lexical:Location"
               ],
               "range": {
-                "@id": "warning_0_location_range",
+                "@id": "violation_0_location_range",
                 "@type": [
                   "lexicalSchema:RangeNode",
                   "lexical:Range"
                 ],
                 "end": {
-                  "@id": "warning_0_location_range_end",
+                  "@id": "violation_0_location_range_end",
                   "@type": [
                     "lexicalSchema:PositionNode",
                     "lexical:Position"
@@ -128,7 +128,7 @@
                   "line": 136
                 },
                 "start": {
-                  "@id": "warning_0_location_range_start",
+                  "@id": "violation_0_location_range_start",
                   "@type": [
                     "lexicalSchema:PositionNode",
                     "lexical:Position"
@@ -140,30 +140,30 @@
               "uri": "file://./test/data/production/best-practices/negative9.yaml"
             },
             "resultMessage": "These response codes [200,204,304,400,401,403,404,405,406,408,410,412,415,429,500,502,503,504,509,510,511,550,598,\n599]should be used as standard for GET operations, the use of not defined return codes is discouraged and should\nonly be done in exceptional circumstances.\n",
-            "resultSeverity": "http://www.w3.org/ns/shacl#Warning",
+            "resultSeverity": "http://www.w3.org/ns/shacl#Violation",
             "sourceShapeName": "standard-get-status-codes",
             "trace": [
               {
-                "@id": "warning_0_0",
+                "@id": "violation_0_0",
                 "@type": [
                   "reportSchema:TraceMessageNode",
                   "validation:TraceMessage"
                 ],
                 "component": "in",
                 "location": {
-                  "@id": "warning_0_0_location",
+                  "@id": "violation_0_0_location",
                   "@type": [
                     "lexicalSchema:LocationNode",
                     "lexical:Location"
                   ],
                   "range": {
-                    "@id": "warning_0_0_location_range",
+                    "@id": "violation_0_0_location_range",
                     "@type": [
                       "lexicalSchema:RangeNode",
                       "lexical:Range"
                     ],
                     "end": {
-                      "@id": "warning_0_0_location_range_end",
+                      "@id": "violation_0_0_location_range_end",
                       "@type": [
                         "lexicalSchema:PositionNode",
                         "lexical:Position"
@@ -172,7 +172,7 @@
                       "line": 136
                     },
                     "start": {
-                      "@id": "warning_0_0_location_range_start",
+                      "@id": "violation_0_0_location_range_start",
                       "@type": [
                         "lexicalSchema:PositionNode",
                         "lexical:Position"
@@ -185,7 +185,7 @@
                 },
                 "resultPath": "http://a.ml/vocabularies/apiContract#returns / http://a.ml/vocabularies/apiContract#statusCode",
                 "traceValue": {
-                  "@id": "warning_0_0_traceValue",
+                  "@id": "violation_0_0_traceValue",
                   "@type": [
                     "reportSchema:TraceValueNode",
                     "validation:TraceValue"
@@ -196,26 +196,26 @@
                 }
               },
               {
-                "@id": "warning_0_1",
+                "@id": "violation_0_1",
                 "@type": [
                   "reportSchema:TraceMessageNode",
                   "validation:TraceMessage"
                 ],
                 "component": "pattern",
                 "location": {
-                  "@id": "warning_0_1_location",
+                  "@id": "violation_0_1_location",
                   "@type": [
                     "lexicalSchema:LocationNode",
                     "lexical:Location"
                   ],
                   "range": {
-                    "@id": "warning_0_1_location_range",
+                    "@id": "violation_0_1_location_range",
                     "@type": [
                       "lexicalSchema:RangeNode",
                       "lexical:Range"
                     ],
                     "end": {
-                      "@id": "warning_0_1_location_range_end",
+                      "@id": "violation_0_1_location_range_end",
                       "@type": [
                         "lexicalSchema:PositionNode",
                         "lexical:Position"
@@ -224,7 +224,7 @@
                       "line": 136
                     },
                     "start": {
-                      "@id": "warning_0_1_location_range_start",
+                      "@id": "violation_0_1_location_range_start",
                       "@type": [
                         "lexicalSchema:PositionNode",
                         "lexical:Position"
@@ -237,7 +237,7 @@
                 },
                 "resultPath": "http://a.ml/vocabularies/apiContract#method",
                 "traceValue": {
-                  "@id": "warning_0_1_traceValue",
+                  "@id": "violation_0_1_traceValue",
                   "@type": [
                     "reportSchema:TraceValueNode",
                     "validation:TraceValue"

--- a/test/data/production/best-practices/positive1.yaml.jsonld
+++ b/test/data/production/best-practices/positive1.yaml.jsonld
@@ -5,19 +5,12 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
     {
       "@id": "amf://id#35",
-      "@type": [
-        "http://a.ml/vocabularies/document#BaseUnitSourceInformation"
-      ],
-      "http://a.ml/vocabularies/document#rootLocation": "file://./test/data/production/best-practices/positive1.yaml"
-    },
-    {
-      "@id": "amf://id#36",
       "@type": [
         "http://a.ml/vocabularies/apiContract#WebAPI",
         "http://a.ml/vocabularies/apiContract#API",
@@ -28,31 +21,38 @@
       "http://a.ml/vocabularies/core#description": "the awesome API",
       "http://a.ml/vocabularies/apiContract#server": [
         {
-          "@id": "amf://id#37"
+          "@id": "amf://id#36"
         }
       ],
       "http://a.ml/vocabularies/core#version": "1.0",
       "http://a.ml/vocabularies/core#documentation": [
         {
-          "@id": "amf://id#38"
+          "@id": "amf://id#37"
         }
       ],
       "http://a.ml/vocabularies/apiContract#endpoint": [
         {
-          "@id": "amf://id#39"
+          "@id": "amf://id#38"
         },
         {
-          "@id": "amf://id#51"
+          "@id": "amf://id#50"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#36/source-map"
+          "@id": "amf://id#35/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#37",
+      "@id": "amf://id/BaseUnitSourceInformation",
+      "@type": [
+        "http://a.ml/vocabularies/document#BaseUnitSourceInformation"
+      ],
+      "http://a.ml/vocabularies/document#rootLocation": "file://./test/data/production/best-practices/positive1.yaml"
+    },
+    {
+      "@id": "amf://id#36",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Server",
         "http://a.ml/vocabularies/document#DomainElement"
@@ -61,12 +61,12 @@
       "http://a.ml/vocabularies/core#description": "production environment",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#37/source-map"
+          "@id": "amf://id#36/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#38",
+      "@id": "amf://id#37",
       "@type": [
         "http://a.ml/vocabularies/core#CreativeWork",
         "http://a.ml/vocabularies/document#DomainElement"
@@ -79,12 +79,12 @@
       "http://a.ml/vocabularies/core#description": "",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#38/source-map"
+          "@id": "amf://id#37/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#39",
+      "@id": "amf://id#38",
       "@type": [
         "http://a.ml/vocabularies/apiContract#EndPoint",
         "http://a.ml/vocabularies/document#DomainElement"
@@ -93,22 +93,22 @@
       "http://a.ml/vocabularies/core#description": "path description",
       "http://a.ml/vocabularies/apiContract#supportedOperation": [
         {
-          "@id": "amf://id#40"
+          "@id": "amf://id#39"
         }
       ],
       "http://a.ml/vocabularies/apiContract#server": [
         {
-          "@id": "amf://id#37"
+          "@id": "amf://id#36"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#39/source-map"
+          "@id": "amf://id#38/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#51",
+      "@id": "amf://id#50",
       "@type": [
         "http://a.ml/vocabularies/apiContract#EndPoint",
         "http://a.ml/vocabularies/document#DomainElement"
@@ -117,17 +117,43 @@
       "http://a.ml/vocabularies/core#description": "path description",
       "http://a.ml/vocabularies/apiContract#supportedOperation": [
         {
-          "@id": "amf://id#52"
+          "@id": "amf://id#51"
         }
       ],
       "http://a.ml/vocabularies/apiContract#server": [
         {
-          "@id": "amf://id#37"
+          "@id": "amf://id#36"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#51/source-map"
+          "@id": "amf://id#50/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "amf://id#35/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "amf://id#35/source-map/lexical/element_5"
+        },
+        {
+          "@id": "amf://id#35/source-map/lexical/element_3"
+        },
+        {
+          "@id": "amf://id#35/source-map/lexical/element_1"
+        },
+        {
+          "@id": "amf://id#35/source-map/lexical/element_0"
+        },
+        {
+          "@id": "amf://id#35/source-map/lexical/element_2"
+        },
+        {
+          "@id": "amf://id#35/source-map/lexical/element_4"
         }
       ]
     },
@@ -138,22 +164,13 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#36/source-map/lexical/element_5"
-        },
-        {
-          "@id": "amf://id#36/source-map/lexical/element_3"
-        },
-        {
-          "@id": "amf://id#36/source-map/lexical/element_1"
+          "@id": "amf://id#36/source-map/lexical/element_2"
         },
         {
           "@id": "amf://id#36/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#36/source-map/lexical/element_2"
-        },
-        {
-          "@id": "amf://id#36/source-map/lexical/element_4"
+          "@id": "amf://id#36/source-map/lexical/element_1"
         }
       ]
     },
@@ -175,26 +192,61 @@
       ]
     },
     {
+      "@id": "amf://id#39",
+      "@type": [
+        "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/apiContract#method": "get",
+      "http://a.ml/vocabularies/core#name": "opid",
+      "http://a.ml/vocabularies/core#description": "op-description",
+      "http://a.ml/vocabularies/apiContract#expects": [
+        {
+          "@id": "amf://id#44"
+        }
+      ],
+      "http://a.ml/vocabularies/apiContract#returns": [
+        {
+          "@id": "amf://id#41"
+        }
+      ],
+      "http://a.ml/vocabularies/apiContract#tag": [
+        {
+          "@id": "amf://id#40"
+        }
+      ],
+      "http://a.ml/vocabularies/apiContract#server": [
+        {
+          "@id": "amf://id#36"
+        }
+      ],
+      "http://a.ml/vocabularies/apiContract#operationId": "opid",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "amf://id#39/source-map"
+        }
+      ]
+    },
+    {
       "@id": "amf://id#38/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#38/source-map/lexical/element_2"
+          "@id": "amf://id#38/source-map/lexical/element_1"
         },
         {
           "@id": "amf://id#38/source-map/lexical/element_0"
-        },
-        {
-          "@id": "amf://id#38/source-map/lexical/element_1"
         }
       ]
     },
     {
-      "@id": "amf://id#40",
+      "@id": "amf://id#51",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -202,170 +254,121 @@
       "http://a.ml/vocabularies/core#description": "op-description",
       "http://a.ml/vocabularies/apiContract#expects": [
         {
-          "@id": "amf://id#45"
+          "@id": "amf://id#58"
         }
       ],
       "http://a.ml/vocabularies/apiContract#returns": [
-        {
-          "@id": "amf://id#42"
-        }
-      ],
-      "http://a.ml/vocabularies/apiContract#tag": [
-        {
-          "@id": "amf://id#41"
-        }
-      ],
-      "http://a.ml/vocabularies/apiContract#server": [
-        {
-          "@id": "amf://id#37"
-        }
-      ],
-      "http://a.ml/vocabularies/apiContract#operationId": "opid",
-      "http://a.ml/vocabularies/document-source-maps#sources": [
-        {
-          "@id": "amf://id#40/source-map"
-        }
-      ]
-    },
-    {
-      "@id": "amf://id#39/source-map",
-      "@type": [
-        "http://a.ml/vocabularies/document-source-maps#SourceMap"
-      ],
-      "http://a.ml/vocabularies/document-source-maps#lexical": [
-        {
-          "@id": "amf://id#39/source-map/lexical/element_1"
-        },
-        {
-          "@id": "amf://id#39/source-map/lexical/element_0"
-        }
-      ]
-    },
-    {
-      "@id": "amf://id#52",
-      "@type": [
-        "http://a.ml/vocabularies/apiContract#Operation",
-        "http://a.ml/vocabularies/document#DomainElement"
-      ],
-      "http://a.ml/vocabularies/apiContract#method": "get",
-      "http://a.ml/vocabularies/core#name": "opid",
-      "http://a.ml/vocabularies/core#description": "op-description",
-      "http://a.ml/vocabularies/apiContract#expects": [
-        {
-          "@id": "amf://id#59"
-        }
-      ],
-      "http://a.ml/vocabularies/apiContract#returns": [
-        {
-          "@id": "amf://id#54"
-        }
-      ],
-      "http://a.ml/vocabularies/apiContract#tag": [
         {
           "@id": "amf://id#53"
         }
       ],
+      "http://a.ml/vocabularies/apiContract#tag": [
+        {
+          "@id": "amf://id#52"
+        }
+      ],
       "http://a.ml/vocabularies/apiContract#server": [
         {
-          "@id": "amf://id#37"
+          "@id": "amf://id#36"
         }
       ],
       "http://a.ml/vocabularies/apiContract#operationId": "opid",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#52/source-map"
+          "@id": "amf://id#51/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#51/source-map",
+      "@id": "amf://id#50/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#51/source-map/lexical/element_1"
+          "@id": "amf://id#50/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#51/source-map/lexical/element_0"
+          "@id": "amf://id#50/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#36/source-map/lexical/element_5",
+      "@id": "amf://id#35/source-map/lexical/element_5",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#version",
       "http://a.ml/vocabularies/document-source-maps#value": "[(4,2)-(5,0)]"
     },
     {
-      "@id": "amf://id#36/source-map/lexical/element_3",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#36",
+      "@id": "amf://id#35/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#35",
       "http://a.ml/vocabularies/document-source-maps#value": "[(1,0)-(136,25)]"
     },
     {
-      "@id": "amf://id#36/source-map/lexical/element_1",
+      "@id": "amf://id#35/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#server",
       "http://a.ml/vocabularies/document-source-maps#value": "[(6,0)-(9,0)]"
     },
     {
-      "@id": "amf://id#36/source-map/lexical/element_0",
+      "@id": "amf://id#35/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#endpoint",
       "http://a.ml/vocabularies/document-source-maps#value": "[(46,0)-(136,25)]"
     },
     {
-      "@id": "amf://id#36/source-map/lexical/element_2",
+      "@id": "amf://id#35/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(3,2)-(4,0)]"
     },
     {
-      "@id": "amf://id#36/source-map/lexical/element_4",
+      "@id": "amf://id#35/source-map/lexical/element_4",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(5,2)-(6,0)]"
     },
     {
-      "@id": "amf://id#37/source-map/lexical/element_2",
+      "@id": "amf://id#36/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#urlTemplate",
       "http://a.ml/vocabularies/document-source-maps#value": "[(7,4)-(8,0)]"
     },
     {
-      "@id": "amf://id#37/source-map/lexical/element_0",
+      "@id": "amf://id#36/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(8,4)-(9,0)]"
     },
     {
-      "@id": "amf://id#37/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#37",
+      "@id": "amf://id#36/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#36",
       "http://a.ml/vocabularies/document-source-maps#value": "[(7,4)-(9,0)]"
     },
     {
-      "@id": "amf://id#38/source-map/lexical/element_2",
+      "@id": "amf://id#37/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#url",
       "http://a.ml/vocabularies/document-source-maps#value": "[(11,2)-(13,0)]"
     },
     {
-      "@id": "amf://id#38/source-map/lexical/element_0",
+      "@id": "amf://id#37/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(10,2)-(11,0)]"
     },
     {
-      "@id": "amf://id#38/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#38",
+      "@id": "amf://id#37/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#37",
       "http://a.ml/vocabularies/document-source-maps#value": "[(10,0)-(13,0)]"
     },
     {
-      "@id": "amf://id#45",
+      "@id": "amf://id#44",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#parameter": [
         {
-          "@id": "amf://id#46"
+          "@id": "amf://id#45"
         }
       ],
       "http://a.ml/vocabularies/apiContract#uriParameter": [
         {
-          "@id": "amf://id#49"
+          "@id": "amf://id#48"
         }
       ],
       "http://a.ml/vocabularies/core#name": "requestBody",
@@ -376,19 +379,20 @@
       ],
       "http://a.ml/vocabularies/apiContract#header": [
         {
-          "@id": "amf://id#47"
+          "@id": "amf://id#46"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#45/source-map"
+          "@id": "amf://id#44/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#42",
+      "@id": "amf://id#41",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -402,22 +406,9 @@
       ],
       "http://a.ml/vocabularies/apiContract#header": [
         {
-          "@id": "amf://id#43"
+          "@id": "amf://id#42"
         }
       ],
-      "http://a.ml/vocabularies/document-source-maps#sources": [
-        {
-          "@id": "amf://id#42/source-map"
-        }
-      ]
-    },
-    {
-      "@id": "amf://id#41",
-      "@type": [
-        "http://a.ml/vocabularies/apiContract#Tag",
-        "http://a.ml/vocabularies/document#DomainElement"
-      ],
-      "http://a.ml/vocabularies/core#name": "Invoice Items",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
           "@id": "amf://id#41/source-map"
@@ -425,66 +416,78 @@
       ]
     },
     {
-      "@id": "amf://id#40/source-map",
+      "@id": "amf://id#40",
+      "@type": [
+        "http://a.ml/vocabularies/apiContract#Tag",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/core#name": "Invoice Items",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "amf://id#40/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "amf://id#39/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#40/source-map/lexical/element_6"
+          "@id": "amf://id#39/source-map/lexical/element_5"
         },
         {
-          "@id": "amf://id#40/source-map/lexical/element_4"
+          "@id": "amf://id#39/source-map/lexical/element_3"
         },
         {
-          "@id": "amf://id#40/source-map/lexical/element_2"
+          "@id": "amf://id#39/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#40/source-map/lexical/element_0"
+          "@id": "amf://id#39/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#40/source-map/lexical/element_1"
+          "@id": "amf://id#39/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#40/source-map/lexical/element_3"
-        },
-        {
-          "@id": "amf://id#40/source-map/lexical/element_5"
+          "@id": "amf://id#39/source-map/lexical/element_4"
         }
       ]
     },
     {
-      "@id": "amf://id#39/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#39",
+      "@id": "amf://id#38/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#38",
       "http://a.ml/vocabularies/document-source-maps#value": "[(47,2)-(96,0)]"
     },
     {
-      "@id": "amf://id#39/source-map/lexical/element_0",
+      "@id": "amf://id#38/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(48,4)-(49,0)]"
     },
     {
-      "@id": "amf://id#59",
+      "@id": "amf://id#58",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#uriParameter": [
         {
-          "@id": "amf://id#65"
+          "@id": "amf://id#64"
         }
       ],
       "http://a.ml/vocabularies/apiContract#header": [
         {
-          "@id": "amf://id#60"
+          "@id": "amf://id#59"
         }
       ]
     },
     {
-      "@id": "amf://id#54",
+      "@id": "amf://id#53",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -498,22 +501,9 @@
       ],
       "http://a.ml/vocabularies/apiContract#header": [
         {
-          "@id": "amf://id#55"
+          "@id": "amf://id#54"
         }
       ],
-      "http://a.ml/vocabularies/document-source-maps#sources": [
-        {
-          "@id": "amf://id#54/source-map"
-        }
-      ]
-    },
-    {
-      "@id": "amf://id#53",
-      "@type": [
-        "http://a.ml/vocabularies/apiContract#Tag",
-        "http://a.ml/vocabularies/document#DomainElement"
-      ],
-      "http://a.ml/vocabularies/core#name": "Invoice Items",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
           "@id": "amf://id#53/source-map"
@@ -521,45 +511,59 @@
       ]
     },
     {
-      "@id": "amf://id#52/source-map",
+      "@id": "amf://id#52",
+      "@type": [
+        "http://a.ml/vocabularies/apiContract#Tag",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/core#name": "Invoice Items",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "amf://id#52/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "amf://id#51/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#52/source-map/lexical/element_5"
+          "@id": "amf://id#51/source-map/lexical/element_5"
         },
         {
-          "@id": "amf://id#52/source-map/lexical/element_3"
+          "@id": "amf://id#51/source-map/lexical/element_3"
         },
         {
-          "@id": "amf://id#52/source-map/lexical/element_1"
+          "@id": "amf://id#51/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#52/source-map/lexical/element_0"
+          "@id": "amf://id#51/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#52/source-map/lexical/element_2"
+          "@id": "amf://id#51/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#52/source-map/lexical/element_4"
+          "@id": "amf://id#51/source-map/lexical/element_4"
         }
       ]
     },
     {
-      "@id": "amf://id#51/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#51",
+      "@id": "amf://id#50/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#50",
       "http://a.ml/vocabularies/document-source-maps#value": "[(96,2)-(136,25)]"
     },
     {
-      "@id": "amf://id#51/source-map/lexical/element_0",
+      "@id": "amf://id#50/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(97,4)-(98,0)]"
     },
     {
-      "@id": "amf://id#46",
+      "@id": "amf://id#45",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "other",
@@ -573,14 +577,15 @@
       "http://a.ml/vocabularies/apiContract#binding": "query",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#46/source-map"
+          "@id": "amf://id#45/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#49",
+      "@id": "amf://id#48",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -591,11 +596,11 @@
       "http://a.ml/vocabularies/apiContract#explode": false,
       "http://a.ml/vocabularies/apiContract#binding": "path",
       "http://a.ml/vocabularies/shapes#schema": {
-        "@id": "amf://id#50"
+        "@id": "amf://id#49"
       },
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#49/source-map"
+          "@id": "amf://id#48/source-map"
         }
       ]
     },
@@ -603,6 +608,7 @@
       "@id": "amf://id#23",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -616,9 +622,10 @@
       ]
     },
     {
-      "@id": "amf://id#47",
+      "@id": "amf://id#46",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "accept",
@@ -629,25 +636,22 @@
       "http://a.ml/vocabularies/apiContract#explode": false,
       "http://a.ml/vocabularies/apiContract#binding": "header",
       "http://a.ml/vocabularies/shapes#schema": {
-        "@id": "amf://id#48"
+        "@id": "amf://id#47"
       },
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#47/source-map"
+          "@id": "amf://id#46/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#45/source-map",
+      "@id": "amf://id#44/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#45/source-map/lexical/element_1"
-        },
-        {
-          "@id": "amf://id#45/source-map/lexical/element_0"
+          "@id": "amf://id#44/source-map/lexical/element_0"
         }
       ]
     },
@@ -655,6 +659,7 @@
       "@id": "amf://id#19",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -668,9 +673,10 @@
       ]
     },
     {
-      "@id": "amf://id#43",
+      "@id": "amf://id#42",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "content-type",
@@ -679,34 +685,11 @@
       "http://a.ml/vocabularies/apiContract#explode": false,
       "http://a.ml/vocabularies/apiContract#binding": "header",
       "http://a.ml/vocabularies/shapes#schema": {
-        "@id": "amf://id#44"
+        "@id": "amf://id#43"
       },
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#43/source-map"
-        }
-      ]
-    },
-    {
-      "@id": "amf://id#42/source-map",
-      "@type": [
-        "http://a.ml/vocabularies/document-source-maps#SourceMap"
-      ],
-      "http://a.ml/vocabularies/document-source-maps#lexical": [
-        {
-          "@id": "amf://id#42/source-map/lexical/element_4"
-        },
-        {
-          "@id": "amf://id#42/source-map/lexical/element_2"
-        },
-        {
-          "@id": "amf://id#42/source-map/lexical/element_0"
-        },
-        {
-          "@id": "amf://id#42/source-map/lexical/element_1"
-        },
-        {
-          "@id": "amf://id#42/source-map/lexical/element_3"
+          "@id": "amf://id#42/source-map"
         }
       ]
     },
@@ -717,49 +700,68 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
+          "@id": "amf://id#41/source-map/lexical/element_4"
+        },
+        {
+          "@id": "amf://id#41/source-map/lexical/element_2"
+        },
+        {
           "@id": "amf://id#41/source-map/lexical/element_0"
+        },
+        {
+          "@id": "amf://id#41/source-map/lexical/element_1"
+        },
+        {
+          "@id": "amf://id#41/source-map/lexical/element_3"
         }
       ]
     },
     {
-      "@id": "amf://id#40/source-map/lexical/element_6",
+      "@id": "amf://id#40/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "amf://id#40/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "amf://id#39/source-map/lexical/element_5",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#tag",
       "http://a.ml/vocabularies/document-source-maps#value": "[(67,6)-(69,0)]"
     },
     {
-      "@id": "amf://id#40/source-map/lexical/element_4",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(66,6)-(67,0)]"
+      "@id": "amf://id#39/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#39",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(64,4)-(96,0)]"
     },
     {
-      "@id": "amf://id#40/source-map/lexical/element_2",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(65,6)-(66,0)]"
-    },
-    {
-      "@id": "amf://id#40/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#operationId",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(66,6)-(67,0)]"
-    },
-    {
-      "@id": "amf://id#40/source-map/lexical/element_1",
+      "@id": "amf://id#39/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#returns",
       "http://a.ml/vocabularies/document-source-maps#value": "[(81,6)-(96,0)]"
     },
     {
-      "@id": "amf://id#40/source-map/lexical/element_3",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#40",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(64,4)-(96,0)]"
+      "@id": "amf://id#39/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#operationId",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(66,6)-(67,0)]"
     },
     {
-      "@id": "amf://id#40/source-map/lexical/element_5",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#expects",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(69,6)-(81,0)]"
+      "@id": "amf://id#39/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(66,6)-(67,0)]"
     },
     {
-      "@id": "amf://id#65",
+      "@id": "amf://id#39/source-map/lexical/element_4",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(65,6)-(66,0)]"
+    },
+    {
+      "@id": "amf://id#64",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -770,18 +772,19 @@
       "http://a.ml/vocabularies/apiContract#explode": false,
       "http://a.ml/vocabularies/apiContract#binding": "path",
       "http://a.ml/vocabularies/shapes#schema": {
-        "@id": "amf://id#66"
+        "@id": "amf://id#65"
       },
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#65/source-map"
+          "@id": "amf://id#64/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#60",
+      "@id": "amf://id#59",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "accept",
@@ -792,16 +795,16 @@
       "http://a.ml/vocabularies/apiContract#explode": false,
       "http://a.ml/vocabularies/apiContract#binding": "header",
       "http://a.ml/vocabularies/shapes#schema": {
-        "@id": "amf://id#61"
+        "@id": "amf://id#60"
       },
       "http://a.ml/vocabularies/apiContract#examples": [
         {
-          "@id": "amf://id#62"
+          "@id": "amf://id#61"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#60/source-map"
+          "@id": "amf://id#59/source-map"
         }
       ]
     },
@@ -809,6 +812,7 @@
       "@id": "amf://id#30",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -822,9 +826,10 @@
       ]
     },
     {
-      "@id": "amf://id#55",
+      "@id": "amf://id#54",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "content-type",
@@ -833,39 +838,16 @@
       "http://a.ml/vocabularies/apiContract#explode": false,
       "http://a.ml/vocabularies/apiContract#binding": "header",
       "http://a.ml/vocabularies/shapes#schema": {
-        "@id": "amf://id#56"
+        "@id": "amf://id#55"
       },
       "http://a.ml/vocabularies/apiContract#examples": [
         {
-          "@id": "amf://id#57"
+          "@id": "amf://id#56"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#55/source-map"
-        }
-      ]
-    },
-    {
-      "@id": "amf://id#54/source-map",
-      "@type": [
-        "http://a.ml/vocabularies/document-source-maps#SourceMap"
-      ],
-      "http://a.ml/vocabularies/document-source-maps#lexical": [
-        {
-          "@id": "amf://id#54/source-map/lexical/element_4"
-        },
-        {
-          "@id": "amf://id#54/source-map/lexical/element_2"
-        },
-        {
-          "@id": "amf://id#54/source-map/lexical/element_0"
-        },
-        {
-          "@id": "amf://id#54/source-map/lexical/element_1"
-        },
-        {
-          "@id": "amf://id#54/source-map/lexical/element_3"
+          "@id": "amf://id#54/source-map"
         }
       ]
     },
@@ -876,76 +858,99 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
+          "@id": "amf://id#53/source-map/lexical/element_4"
+        },
+        {
+          "@id": "amf://id#53/source-map/lexical/element_2"
+        },
+        {
           "@id": "amf://id#53/source-map/lexical/element_0"
+        },
+        {
+          "@id": "amf://id#53/source-map/lexical/element_1"
+        },
+        {
+          "@id": "amf://id#53/source-map/lexical/element_3"
         }
       ]
     },
     {
-      "@id": "amf://id#52/source-map/lexical/element_5",
+      "@id": "amf://id#52/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "amf://id#52/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "amf://id#51/source-map/lexical/element_5",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#tag",
       "http://a.ml/vocabularies/document-source-maps#value": "[(117,6)-(119,0)]"
     },
     {
-      "@id": "amf://id#52/source-map/lexical/element_3",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#52",
+      "@id": "amf://id#51/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#51",
       "http://a.ml/vocabularies/document-source-maps#value": "[(114,4)-(136,25)]"
     },
     {
-      "@id": "amf://id#52/source-map/lexical/element_1",
+      "@id": "amf://id#51/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#returns",
       "http://a.ml/vocabularies/document-source-maps#value": "[(119,6)-(136,25)]"
     },
     {
-      "@id": "amf://id#52/source-map/lexical/element_0",
+      "@id": "amf://id#51/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#operationId",
       "http://a.ml/vocabularies/document-source-maps#value": "[(116,6)-(117,0)]"
     },
     {
-      "@id": "amf://id#52/source-map/lexical/element_2",
+      "@id": "amf://id#51/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(116,6)-(117,0)]"
     },
     {
-      "@id": "amf://id#52/source-map/lexical/element_4",
+      "@id": "amf://id#51/source-map/lexical/element_4",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(115,6)-(116,0)]"
     },
     {
-      "@id": "amf://id#46/source-map",
+      "@id": "amf://id#45/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#46/source-map/synthesized-field/element_2"
+          "@id": "amf://id#45/source-map/synthesized-field/element_2"
         },
         {
-          "@id": "amf://id#46/source-map/synthesized-field/element_0"
+          "@id": "amf://id#45/source-map/synthesized-field/element_0"
         },
         {
-          "@id": "amf://id#46/source-map/synthesized-field/element_1"
+          "@id": "amf://id#45/source-map/synthesized-field/element_1"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#46/source-map/lexical/element_4"
+          "@id": "amf://id#45/source-map/lexical/element_4"
         },
         {
-          "@id": "amf://id#46/source-map/lexical/element_2"
+          "@id": "amf://id#45/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#46/source-map/lexical/element_0"
+          "@id": "amf://id#45/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#46/source-map/lexical/element_1"
+          "@id": "amf://id#45/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#46/source-map/lexical/element_3"
+          "@id": "amf://id#45/source-map/lexical/element_3"
         }
       ]
     },
     {
-      "@id": "amf://id#50",
+      "@id": "amf://id#49",
       "@type": [
         "http://a.ml/vocabularies/shapes#ScalarShape",
         "http://a.ml/vocabularies/shapes#AnyShape",
@@ -961,44 +966,44 @@
       "http://www.w3.org/ns/shacl#name": "id",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#50/source-map"
+          "@id": "amf://id#49/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#49/source-map",
+      "@id": "amf://id#48/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#49/source-map/synthesized-field/element_1"
+          "@id": "amf://id#48/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "amf://id#49/source-map/synthesized-field/element_0"
+          "@id": "amf://id#48/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#49/source-map/lexical/element_6"
+          "@id": "amf://id#48/source-map/lexical/element_6"
         },
         {
-          "@id": "amf://id#49/source-map/lexical/element_4"
+          "@id": "amf://id#48/source-map/lexical/element_4"
         },
         {
-          "@id": "amf://id#49/source-map/lexical/element_2"
+          "@id": "amf://id#48/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#49/source-map/lexical/element_0"
+          "@id": "amf://id#48/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#49/source-map/lexical/element_1"
+          "@id": "amf://id#48/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#49/source-map/lexical/element_3"
+          "@id": "amf://id#48/source-map/lexical/element_3"
         },
         {
-          "@id": "amf://id#49/source-map/lexical/element_5"
+          "@id": "amf://id#48/source-map/lexical/element_5"
         }
       ]
     },
@@ -1070,7 +1075,7 @@
       ]
     },
     {
-      "@id": "amf://id#48",
+      "@id": "amf://id#47",
       "@type": [
         "http://a.ml/vocabularies/shapes#ScalarShape",
         "http://a.ml/vocabularies/shapes#AnyShape",
@@ -1086,54 +1091,49 @@
       "http://www.w3.org/ns/shacl#name": "accept",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#48/source-map"
+          "@id": "amf://id#47/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#47/source-map",
+      "@id": "amf://id#46/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#47/source-map/synthesized-field/element_2"
+          "@id": "amf://id#46/source-map/synthesized-field/element_2"
         },
         {
-          "@id": "amf://id#47/source-map/synthesized-field/element_0"
+          "@id": "amf://id#46/source-map/synthesized-field/element_0"
         },
         {
-          "@id": "amf://id#47/source-map/synthesized-field/element_1"
+          "@id": "amf://id#46/source-map/synthesized-field/element_1"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#47/source-map/lexical/element_5"
+          "@id": "amf://id#46/source-map/lexical/element_5"
         },
         {
-          "@id": "amf://id#47/source-map/lexical/element_3"
+          "@id": "amf://id#46/source-map/lexical/element_3"
         },
         {
-          "@id": "amf://id#47/source-map/lexical/element_1"
+          "@id": "amf://id#46/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#47/source-map/lexical/element_0"
+          "@id": "amf://id#46/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#47/source-map/lexical/element_2"
+          "@id": "amf://id#46/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#47/source-map/lexical/element_4"
+          "@id": "amf://id#46/source-map/lexical/element_4"
         }
       ]
     },
     {
-      "@id": "amf://id#45/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#45",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(69,6)-(81,0)]"
-    },
-    {
-      "@id": "amf://id#45/source-map/lexical/element_0",
+      "@id": "amf://id#44/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(69,6)-(69,17)]"
     },
@@ -1155,7 +1155,7 @@
       ]
     },
     {
-      "@id": "amf://id#44",
+      "@id": "amf://id#43",
       "@type": [
         "http://a.ml/vocabularies/shapes#ScalarShape",
         "http://a.ml/vocabularies/shapes#AnyShape",
@@ -1171,70 +1171,70 @@
       "http://www.w3.org/ns/shacl#name": "schema",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#44/source-map"
+          "@id": "amf://id#43/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#43/source-map",
+      "@id": "amf://id#42/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#43/source-map/synthesized-field/element_2"
+          "@id": "amf://id#42/source-map/synthesized-field/element_2"
         },
         {
-          "@id": "amf://id#43/source-map/synthesized-field/element_0"
+          "@id": "amf://id#42/source-map/synthesized-field/element_0"
         },
         {
-          "@id": "amf://id#43/source-map/synthesized-field/element_1"
+          "@id": "amf://id#42/source-map/synthesized-field/element_1"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#43/source-map/lexical/element_2"
+          "@id": "amf://id#42/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#43/source-map/lexical/element_0"
+          "@id": "amf://id#42/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#43/source-map/lexical/element_1"
+          "@id": "amf://id#42/source-map/lexical/element_1"
         }
       ]
     },
     {
-      "@id": "amf://id#42/source-map/lexical/element_4",
+      "@id": "amf://id#41/source-map/lexical/element_4",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#payload",
       "http://a.ml/vocabularies/document-source-maps#value": "[(89,10)-(96,0)]"
     },
     {
-      "@id": "amf://id#42/source-map/lexical/element_2",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#42",
+      "@id": "amf://id#41/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#41",
       "http://a.ml/vocabularies/document-source-maps#value": "[(82,8)-(96,0)]"
     },
     {
-      "@id": "amf://id#42/source-map/lexical/element_0",
+      "@id": "amf://id#41/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#header",
       "http://a.ml/vocabularies/document-source-maps#value": "[(84,10)-(89,0)]"
     },
     {
-      "@id": "amf://id#42/source-map/lexical/element_1",
+      "@id": "amf://id#41/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(83,10)-(84,0)]"
     },
     {
-      "@id": "amf://id#42/source-map/lexical/element_3",
+      "@id": "amf://id#41/source-map/lexical/element_3",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(82,8)-(82,13)]"
     },
     {
-      "@id": "amf://id#41/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#41",
+      "@id": "amf://id#40/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#40",
       "http://a.ml/vocabularies/document-source-maps#value": "[(68,10)-(68,23)]"
     },
     {
-      "@id": "amf://id#66",
+      "@id": "amf://id#65",
       "@type": [
         "http://a.ml/vocabularies/shapes#ScalarShape",
         "http://a.ml/vocabularies/shapes#AnyShape",
@@ -1250,54 +1250,54 @@
       "http://www.w3.org/ns/shacl#name": "id",
       "http://a.ml/vocabularies/apiContract#examples": [
         {
-          "@id": "amf://id#67"
+          "@id": "amf://id#66"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#66/source-map"
+          "@id": "amf://id#65/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#65/source-map",
+      "@id": "amf://id#64/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#65/source-map/synthesized-field/element_1"
+          "@id": "amf://id#64/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "amf://id#65/source-map/synthesized-field/element_0"
+          "@id": "amf://id#64/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#65/source-map/lexical/element_6"
+          "@id": "amf://id#64/source-map/lexical/element_6"
         },
         {
-          "@id": "amf://id#65/source-map/lexical/element_4"
+          "@id": "amf://id#64/source-map/lexical/element_4"
         },
         {
-          "@id": "amf://id#65/source-map/lexical/element_2"
+          "@id": "amf://id#64/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#65/source-map/lexical/element_0"
+          "@id": "amf://id#64/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#65/source-map/lexical/element_1"
+          "@id": "amf://id#64/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#65/source-map/lexical/element_3"
+          "@id": "amf://id#64/source-map/lexical/element_3"
         },
         {
-          "@id": "amf://id#65/source-map/lexical/element_5"
+          "@id": "amf://id#64/source-map/lexical/element_5"
         }
       ]
     },
     {
-      "@id": "amf://id#61",
+      "@id": "amf://id#60",
       "@type": [
         "http://a.ml/vocabularies/shapes#ScalarShape",
         "http://a.ml/vocabularies/shapes#AnyShape",
@@ -1313,64 +1313,64 @@
       "http://www.w3.org/ns/shacl#name": "accept",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#61/source-map"
+          "@id": "amf://id#60/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#62",
+      "@id": "amf://id#61",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Example",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/document#strict": true,
       "http://a.ml/vocabularies/document#structuredValue": {
-        "@id": "amf://id#63"
+        "@id": "amf://id#62"
       },
       "http://a.ml/vocabularies/document#raw": "name: a",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#62/source-map"
+          "@id": "amf://id#61/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#60/source-map",
+      "@id": "amf://id#59/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#60/source-map/synthesized-field/element_2"
+          "@id": "amf://id#59/source-map/synthesized-field/element_2"
         },
         {
-          "@id": "amf://id#60/source-map/synthesized-field/element_0"
+          "@id": "amf://id#59/source-map/synthesized-field/element_0"
         },
         {
-          "@id": "amf://id#60/source-map/synthesized-field/element_1"
+          "@id": "amf://id#59/source-map/synthesized-field/element_1"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#60/source-map/lexical/element_6"
+          "@id": "amf://id#59/source-map/lexical/element_6"
         },
         {
-          "@id": "amf://id#60/source-map/lexical/element_4"
+          "@id": "amf://id#59/source-map/lexical/element_4"
         },
         {
-          "@id": "amf://id#60/source-map/lexical/element_2"
+          "@id": "amf://id#59/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#60/source-map/lexical/element_0"
+          "@id": "amf://id#59/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#60/source-map/lexical/element_1"
+          "@id": "amf://id#59/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#60/source-map/lexical/element_3"
+          "@id": "amf://id#59/source-map/lexical/element_3"
         },
         {
-          "@id": "amf://id#60/source-map/lexical/element_5"
+          "@id": "amf://id#59/source-map/lexical/element_5"
         }
       ]
     },
@@ -1392,7 +1392,7 @@
       ]
     },
     {
-      "@id": "amf://id#56",
+      "@id": "amf://id#55",
       "@type": [
         "http://a.ml/vocabularies/shapes#ScalarShape",
         "http://a.ml/vocabularies/shapes#AnyShape",
@@ -1408,197 +1408,197 @@
       "http://www.w3.org/ns/shacl#name": "schema",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#56/source-map"
+          "@id": "amf://id#55/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#57",
+      "@id": "amf://id#56",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Example",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/document#strict": true,
       "http://a.ml/vocabularies/document#structuredValue": {
-        "@id": "amf://id#58"
+        "@id": "amf://id#57"
       },
       "http://a.ml/vocabularies/document#raw": "teapot",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#57/source-map"
+          "@id": "amf://id#56/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#55/source-map",
+      "@id": "amf://id#54/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#55/source-map/synthesized-field/element_2"
+          "@id": "amf://id#54/source-map/synthesized-field/element_2"
         },
         {
-          "@id": "amf://id#55/source-map/synthesized-field/element_0"
+          "@id": "amf://id#54/source-map/synthesized-field/element_0"
         },
         {
-          "@id": "amf://id#55/source-map/synthesized-field/element_1"
+          "@id": "amf://id#54/source-map/synthesized-field/element_1"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#55/source-map/lexical/element_3"
+          "@id": "amf://id#54/source-map/lexical/element_3"
         },
         {
-          "@id": "amf://id#55/source-map/lexical/element_1"
+          "@id": "amf://id#54/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#55/source-map/lexical/element_0"
+          "@id": "amf://id#54/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#55/source-map/lexical/element_2"
+          "@id": "amf://id#54/source-map/lexical/element_2"
         }
       ]
     },
     {
-      "@id": "amf://id#54/source-map/lexical/element_4",
+      "@id": "amf://id#53/source-map/lexical/element_4",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#payload",
       "http://a.ml/vocabularies/document-source-maps#value": "[(129,10)-(136,25)]"
     },
     {
-      "@id": "amf://id#54/source-map/lexical/element_2",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#54",
+      "@id": "amf://id#53/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#53",
       "http://a.ml/vocabularies/document-source-maps#value": "[(120,8)-(136,25)]"
     },
     {
-      "@id": "amf://id#54/source-map/lexical/element_0",
+      "@id": "amf://id#53/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#header",
       "http://a.ml/vocabularies/document-source-maps#value": "[(122,10)-(129,0)]"
     },
     {
-      "@id": "amf://id#54/source-map/lexical/element_1",
+      "@id": "amf://id#53/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(121,10)-(122,0)]"
     },
     {
-      "@id": "amf://id#54/source-map/lexical/element_3",
+      "@id": "amf://id#53/source-map/lexical/element_3",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(120,8)-(120,13)]"
     },
     {
-      "@id": "amf://id#53/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#53",
+      "@id": "amf://id#52/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#52",
       "http://a.ml/vocabularies/document-source-maps#value": "[(118,10)-(118,23)]"
     },
     {
-      "@id": "amf://id#46/source-map/synthesized-field/element_2",
+      "@id": "amf://id#45/source-map/synthesized-field/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#style",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#46/source-map/synthesized-field/element_0",
+      "@id": "amf://id#45/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#explode",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#46/source-map/synthesized-field/element_1",
+      "@id": "amf://id#45/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#required",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#46/source-map/lexical/element_4",
+      "@id": "amf://id#45/source-map/lexical/element_4",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(63,8)-(64,0)]"
     },
     {
-      "@id": "amf://id#46/source-map/lexical/element_2",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#46",
+      "@id": "amf://id#45/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#45",
       "http://a.ml/vocabularies/document-source-maps#value": "[(61,8)-(64,0)]"
     },
     {
-      "@id": "amf://id#46/source-map/lexical/element_0",
+      "@id": "amf://id#45/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#binding",
       "http://a.ml/vocabularies/document-source-maps#value": "[(62,8)-(63,0)]"
     },
     {
-      "@id": "amf://id#46/source-map/lexical/element_1",
+      "@id": "amf://id#45/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#paramName",
       "http://a.ml/vocabularies/document-source-maps#value": "[(61,8)-(62,0)]"
     },
     {
-      "@id": "amf://id#46/source-map/lexical/element_3",
+      "@id": "amf://id#45/source-map/lexical/element_3",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(61,8)-(62,0)]"
     },
     {
-      "@id": "amf://id#50/source-map",
+      "@id": "amf://id#49/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#auto-generated-name": [
         {
-          "@id": "amf://id#50/source-map/auto-generated-name/element_0"
+          "@id": "amf://id#49/source-map/auto-generated-name/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#50/source-map/lexical/element_2"
+          "@id": "amf://id#49/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#50/source-map/lexical/element_0"
+          "@id": "amf://id#49/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#50/source-map/lexical/element_1"
+          "@id": "amf://id#49/source-map/lexical/element_1"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
         {
-          "@id": "amf://id#50/source-map/type-property-lexical-info/element_0"
+          "@id": "amf://id#49/source-map/type-property-lexical-info/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#49/source-map/synthesized-field/element_1",
+      "@id": "amf://id#48/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#style",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#49/source-map/synthesized-field/element_0",
+      "@id": "amf://id#48/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#explode",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#49/source-map/lexical/element_6",
+      "@id": "amf://id#48/source-map/lexical/element_6",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#binding",
       "http://a.ml/vocabularies/document-source-maps#value": "[(51,8)-(52,0)]"
     },
     {
-      "@id": "amf://id#49/source-map/lexical/element_4",
+      "@id": "amf://id#48/source-map/lexical/element_4",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(50,8)-(51,0)]"
     },
     {
-      "@id": "amf://id#49/source-map/lexical/element_2",
+      "@id": "amf://id#48/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#paramName",
       "http://a.ml/vocabularies/document-source-maps#value": "[(50,8)-(51,0)]"
     },
     {
-      "@id": "amf://id#49/source-map/lexical/element_0",
+      "@id": "amf://id#48/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/shapes#schema",
       "http://a.ml/vocabularies/document-source-maps#value": "[(54,8)-(56,0)]"
     },
     {
-      "@id": "amf://id#49/source-map/lexical/element_1",
+      "@id": "amf://id#48/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#required",
       "http://a.ml/vocabularies/document-source-maps#value": "[(52,8)-(53,0)]"
     },
     {
-      "@id": "amf://id#49/source-map/lexical/element_3",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#49",
+      "@id": "amf://id#48/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#48",
       "http://a.ml/vocabularies/document-source-maps#value": "[(50,8)-(56,0)]"
     },
     {
-      "@id": "amf://id#49/source-map/lexical/element_5",
+      "@id": "amf://id#48/source-map/lexical/element_5",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(53,8)-(54,0)]"
     },
@@ -1858,74 +1858,74 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(71,10)-(81,0)]"
     },
     {
-      "@id": "amf://id#48/source-map",
+      "@id": "amf://id#47/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#auto-generated-name": [
         {
-          "@id": "amf://id#48/source-map/auto-generated-name/element_0"
+          "@id": "amf://id#47/source-map/auto-generated-name/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#48/source-map/lexical/element_2"
+          "@id": "amf://id#47/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#48/source-map/lexical/element_0"
+          "@id": "amf://id#47/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#48/source-map/lexical/element_1"
+          "@id": "amf://id#47/source-map/lexical/element_1"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
         {
-          "@id": "amf://id#48/source-map/type-property-lexical-info/element_0"
+          "@id": "amf://id#47/source-map/type-property-lexical-info/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#47/source-map/synthesized-field/element_2",
+      "@id": "amf://id#46/source-map/synthesized-field/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#style",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#47/source-map/synthesized-field/element_0",
+      "@id": "amf://id#46/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#explode",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#47/source-map/synthesized-field/element_1",
+      "@id": "amf://id#46/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#required",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#47/source-map/lexical/element_5",
+      "@id": "amf://id#46/source-map/lexical/element_5",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#binding",
       "http://a.ml/vocabularies/document-source-maps#value": "[(57,8)-(58,0)]"
     },
     {
-      "@id": "amf://id#47/source-map/lexical/element_3",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#47",
+      "@id": "amf://id#46/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#46",
       "http://a.ml/vocabularies/document-source-maps#value": "[(56,8)-(61,0)]"
     },
     {
-      "@id": "amf://id#47/source-map/lexical/element_1",
+      "@id": "amf://id#46/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(58,8)-(59,0)]"
     },
     {
-      "@id": "amf://id#47/source-map/lexical/element_0",
+      "@id": "amf://id#46/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/shapes#schema",
       "http://a.ml/vocabularies/document-source-maps#value": "[(59,8)-(61,0)]"
     },
     {
-      "@id": "amf://id#47/source-map/lexical/element_2",
+      "@id": "amf://id#46/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(56,8)-(57,0)]"
     },
     {
-      "@id": "amf://id#47/source-map/lexical/element_4",
+      "@id": "amf://id#46/source-map/lexical/element_4",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#paramName",
       "http://a.ml/vocabularies/document-source-maps#value": "[(56,8)-(57,0)]"
     },
@@ -1945,253 +1945,253 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(90,12)-(96,0)]"
     },
     {
-      "@id": "amf://id#44/source-map",
+      "@id": "amf://id#43/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
         {
-          "@id": "amf://id#44/source-map/type-property-lexical-info/element_0"
+          "@id": "amf://id#43/source-map/type-property-lexical-info/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#44/source-map/lexical/element_1"
+          "@id": "amf://id#43/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#44/source-map/lexical/element_0"
+          "@id": "amf://id#43/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#43/source-map/synthesized-field/element_2",
+      "@id": "amf://id#42/source-map/synthesized-field/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#explode",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#43/source-map/synthesized-field/element_0",
+      "@id": "amf://id#42/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#binding",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#43/source-map/synthesized-field/element_1",
+      "@id": "amf://id#42/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#style",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#43/source-map/lexical/element_2",
+      "@id": "amf://id#42/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(86,14)-(87,0)]"
     },
     {
-      "@id": "amf://id#43/source-map/lexical/element_0",
+      "@id": "amf://id#42/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/shapes#schema",
       "http://a.ml/vocabularies/document-source-maps#value": "[(87,14)-(89,0)]"
     },
     {
-      "@id": "amf://id#43/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#43",
+      "@id": "amf://id#42/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#42",
       "http://a.ml/vocabularies/document-source-maps#value": "[(85,12)-(89,0)]"
     },
     {
-      "@id": "amf://id#67",
+      "@id": "amf://id#66",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Example",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/document#strict": true,
       "http://a.ml/vocabularies/document#structuredValue": {
-        "@id": "amf://id#68"
+        "@id": "amf://id#67"
       },
       "http://a.ml/vocabularies/document#raw": "id: 34",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#67/source-map"
+          "@id": "amf://id#66/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#66/source-map",
+      "@id": "amf://id#65/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#auto-generated-name": [
         {
-          "@id": "amf://id#66/source-map/auto-generated-name/element_0"
+          "@id": "amf://id#65/source-map/auto-generated-name/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#66/source-map/lexical/element_2"
+          "@id": "amf://id#65/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#66/source-map/lexical/element_0"
+          "@id": "amf://id#65/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#66/source-map/lexical/element_1"
+          "@id": "amf://id#65/source-map/lexical/element_1"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
         {
-          "@id": "amf://id#66/source-map/type-property-lexical-info/element_0"
+          "@id": "amf://id#65/source-map/type-property-lexical-info/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#65/source-map/synthesized-field/element_1",
+      "@id": "amf://id#64/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#style",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#65/source-map/synthesized-field/element_0",
+      "@id": "amf://id#64/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#explode",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#65/source-map/lexical/element_6",
+      "@id": "amf://id#64/source-map/lexical/element_6",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#binding",
       "http://a.ml/vocabularies/document-source-maps#value": "[(100,8)-(101,0)]"
     },
     {
-      "@id": "amf://id#65/source-map/lexical/element_4",
+      "@id": "amf://id#64/source-map/lexical/element_4",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(99,8)-(100,0)]"
     },
     {
-      "@id": "amf://id#65/source-map/lexical/element_2",
+      "@id": "amf://id#64/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#paramName",
       "http://a.ml/vocabularies/document-source-maps#value": "[(99,8)-(100,0)]"
     },
     {
-      "@id": "amf://id#65/source-map/lexical/element_0",
+      "@id": "amf://id#64/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/shapes#schema",
       "http://a.ml/vocabularies/document-source-maps#value": "[(103,8)-(105,0)]"
     },
     {
-      "@id": "amf://id#65/source-map/lexical/element_1",
+      "@id": "amf://id#64/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#required",
       "http://a.ml/vocabularies/document-source-maps#value": "[(101,8)-(102,0)]"
     },
     {
-      "@id": "amf://id#65/source-map/lexical/element_3",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#65",
+      "@id": "amf://id#64/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#64",
       "http://a.ml/vocabularies/document-source-maps#value": "[(99,8)-(107,0)]"
     },
     {
-      "@id": "amf://id#65/source-map/lexical/element_5",
+      "@id": "amf://id#64/source-map/lexical/element_5",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(102,8)-(103,0)]"
     },
     {
-      "@id": "amf://id#61/source-map",
+      "@id": "amf://id#60/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#auto-generated-name": [
         {
-          "@id": "amf://id#61/source-map/auto-generated-name/element_0"
+          "@id": "amf://id#60/source-map/auto-generated-name/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#61/source-map/lexical/element_2"
+          "@id": "amf://id#60/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#61/source-map/lexical/element_0"
+          "@id": "amf://id#60/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#61/source-map/lexical/element_1"
+          "@id": "amf://id#60/source-map/lexical/element_1"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
         {
-          "@id": "amf://id#61/source-map/type-property-lexical-info/element_0"
+          "@id": "amf://id#60/source-map/type-property-lexical-info/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#63",
+      "@id": "amf://id#62",
       "@type": [
         "http://a.ml/vocabularies/data#Object",
         "http://a.ml/vocabularies/data#Node",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/data#name": {
-        "@id": "amf://id#64"
+        "@id": "amf://id#63"
       },
       "http://a.ml/vocabularies/core#name": "object_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#63/source-map"
+          "@id": "amf://id#62/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#62/source-map",
+      "@id": "amf://id#61/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#62/source-map/synthesized-field/element_1"
+          "@id": "amf://id#61/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "amf://id#62/source-map/synthesized-field/element_0"
+          "@id": "amf://id#61/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#62/source-map/lexical/element_0"
+          "@id": "amf://id#61/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#60/source-map/synthesized-field/element_2",
+      "@id": "amf://id#59/source-map/synthesized-field/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#style",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#60/source-map/synthesized-field/element_0",
+      "@id": "amf://id#59/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#explode",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#60/source-map/synthesized-field/element_1",
+      "@id": "amf://id#59/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#required",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#60/source-map/lexical/element_6",
+      "@id": "amf://id#59/source-map/lexical/element_6",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/shapes#schema",
       "http://a.ml/vocabularies/document-source-maps#value": "[(110,8)-(112,0)]"
     },
     {
-      "@id": "amf://id#60/source-map/lexical/element_4",
+      "@id": "amf://id#59/source-map/lexical/element_4",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(107,8)-(108,0)]"
     },
     {
-      "@id": "amf://id#60/source-map/lexical/element_2",
+      "@id": "amf://id#59/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#paramName",
       "http://a.ml/vocabularies/document-source-maps#value": "[(107,8)-(108,0)]"
     },
     {
-      "@id": "amf://id#60/source-map/lexical/element_0",
+      "@id": "amf://id#59/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#examples",
       "http://a.ml/vocabularies/document-source-maps#value": "[(112,8)-(114,0)]"
     },
     {
-      "@id": "amf://id#60/source-map/lexical/element_1",
+      "@id": "amf://id#59/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#binding",
       "http://a.ml/vocabularies/document-source-maps#value": "[(109,8)-(110,0)]"
     },
     {
-      "@id": "amf://id#60/source-map/lexical/element_3",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#60",
+      "@id": "amf://id#59/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#59",
       "http://a.ml/vocabularies/document-source-maps#value": "[(107,8)-(114,0)]"
     },
     {
-      "@id": "amf://id#60/source-map/lexical/element_5",
+      "@id": "amf://id#59/source-map/lexical/element_5",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(108,8)-(109,0)]"
     },
@@ -2211,26 +2211,26 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(130,12)-(136,25)]"
     },
     {
-      "@id": "amf://id#56/source-map",
+      "@id": "amf://id#55/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
         {
-          "@id": "amf://id#56/source-map/type-property-lexical-info/element_0"
+          "@id": "amf://id#55/source-map/type-property-lexical-info/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#56/source-map/lexical/element_1"
+          "@id": "amf://id#55/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#56/source-map/lexical/element_0"
+          "@id": "amf://id#55/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#58",
+      "@id": "amf://id#57",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -2245,87 +2245,87 @@
       "http://a.ml/vocabularies/core#name": "scalar_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#58/source-map"
+          "@id": "amf://id#57/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#57/source-map",
+      "@id": "amf://id#56/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#57/source-map/synthesized-field/element_1"
+          "@id": "amf://id#56/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "amf://id#57/source-map/synthesized-field/element_0"
+          "@id": "amf://id#56/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#57/source-map/lexical/element_0"
+          "@id": "amf://id#56/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#55/source-map/synthesized-field/element_2",
+      "@id": "amf://id#54/source-map/synthesized-field/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#explode",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#55/source-map/synthesized-field/element_0",
+      "@id": "amf://id#54/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#binding",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#55/source-map/synthesized-field/element_1",
+      "@id": "amf://id#54/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#style",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#55/source-map/lexical/element_3",
+      "@id": "amf://id#54/source-map/lexical/element_3",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/shapes#schema",
       "http://a.ml/vocabularies/document-source-maps#value": "[(125,14)-(127,0)]"
     },
     {
-      "@id": "amf://id#55/source-map/lexical/element_1",
+      "@id": "amf://id#54/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
       "http://a.ml/vocabularies/document-source-maps#value": "[(124,14)-(125,0)]"
     },
     {
-      "@id": "amf://id#55/source-map/lexical/element_0",
+      "@id": "amf://id#54/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#examples",
       "http://a.ml/vocabularies/document-source-maps#value": "[(127,14)-(129,0)]"
     },
     {
-      "@id": "amf://id#55/source-map/lexical/element_2",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#55",
+      "@id": "amf://id#54/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#54",
       "http://a.ml/vocabularies/document-source-maps#value": "[(123,12)-(129,0)]"
     },
     {
-      "@id": "amf://id#50/source-map/auto-generated-name/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#50",
+      "@id": "amf://id#49/source-map/auto-generated-name/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#49",
       "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
-      "@id": "amf://id#50/source-map/lexical/element_2",
+      "@id": "amf://id#49/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "[(55,10)-(56,0)]"
     },
     {
-      "@id": "amf://id#50/source-map/lexical/element_0",
+      "@id": "amf://id#49/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(50,8)-(51,0)]"
     },
     {
-      "@id": "amf://id#50/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#50",
+      "@id": "amf://id#49/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#49",
       "http://a.ml/vocabularies/document-source-maps#value": "[(54,8)-(56,0)]"
     },
     {
-      "@id": "amf://id#50/source-map/type-property-lexical-info/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#50",
+      "@id": "amf://id#49/source-map/type-property-lexical-info/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#49",
       "http://a.ml/vocabularies/document-source-maps#value": "[(55,10)-(55,14)]"
     },
     {
@@ -2761,138 +2761,138 @@
       "http://a.ml/vocabularies/document-source-maps#value": "amf://id#1"
     },
     {
-      "@id": "amf://id#48/source-map/auto-generated-name/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#48",
+      "@id": "amf://id#47/source-map/auto-generated-name/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#47",
       "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
-      "@id": "amf://id#48/source-map/lexical/element_2",
+      "@id": "amf://id#47/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "[(60,10)-(61,0)]"
     },
     {
-      "@id": "amf://id#48/source-map/lexical/element_0",
+      "@id": "amf://id#47/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(56,8)-(57,0)]"
     },
     {
-      "@id": "amf://id#48/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#48",
+      "@id": "amf://id#47/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#47",
       "http://a.ml/vocabularies/document-source-maps#value": "[(59,8)-(61,0)]"
     },
     {
-      "@id": "amf://id#48/source-map/type-property-lexical-info/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#48",
+      "@id": "amf://id#47/source-map/type-property-lexical-info/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#47",
       "http://a.ml/vocabularies/document-source-maps#value": "[(60,10)-(60,14)]"
     },
     {
-      "@id": "amf://id#44/source-map/type-property-lexical-info/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#44",
+      "@id": "amf://id#43/source-map/type-property-lexical-info/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#43",
       "http://a.ml/vocabularies/document-source-maps#value": "[(88,16)-(88,20)]"
     },
     {
-      "@id": "amf://id#44/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#44",
+      "@id": "amf://id#43/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#43",
       "http://a.ml/vocabularies/document-source-maps#value": "[(87,14)-(89,0)]"
     },
     {
-      "@id": "amf://id#44/source-map/lexical/element_0",
+      "@id": "amf://id#43/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "[(88,16)-(89,0)]"
     },
     {
-      "@id": "amf://id#68",
+      "@id": "amf://id#67",
       "@type": [
         "http://a.ml/vocabularies/data#Object",
         "http://a.ml/vocabularies/data#Node",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/data#id": {
-        "@id": "amf://id#69"
+        "@id": "amf://id#68"
       },
       "http://a.ml/vocabularies/core#name": "object_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#68/source-map"
+          "@id": "amf://id#67/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#67/source-map",
+      "@id": "amf://id#66/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#67/source-map/synthesized-field/element_1"
+          "@id": "amf://id#66/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "amf://id#67/source-map/synthesized-field/element_0"
+          "@id": "amf://id#66/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#67/source-map/lexical/element_0"
+          "@id": "amf://id#66/source-map/lexical/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#tracked-element": [
         {
-          "@id": "amf://id#67/source-map/tracked-element/element_0"
+          "@id": "amf://id#66/source-map/tracked-element/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#66/source-map/auto-generated-name/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#66",
+      "@id": "amf://id#65/source-map/auto-generated-name/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#65",
       "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
-      "@id": "amf://id#66/source-map/lexical/element_2",
+      "@id": "amf://id#65/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "[(104,10)-(105,0)]"
     },
     {
-      "@id": "amf://id#66/source-map/lexical/element_0",
+      "@id": "amf://id#65/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(99,8)-(100,0)]"
     },
     {
-      "@id": "amf://id#66/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#66",
+      "@id": "amf://id#65/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#65",
       "http://a.ml/vocabularies/document-source-maps#value": "[(103,8)-(105,0)]"
     },
     {
-      "@id": "amf://id#66/source-map/type-property-lexical-info/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#66",
+      "@id": "amf://id#65/source-map/type-property-lexical-info/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#65",
       "http://a.ml/vocabularies/document-source-maps#value": "[(104,10)-(104,14)]"
     },
     {
-      "@id": "amf://id#61/source-map/auto-generated-name/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#61",
+      "@id": "amf://id#60/source-map/auto-generated-name/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#60",
       "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
-      "@id": "amf://id#61/source-map/lexical/element_2",
+      "@id": "amf://id#60/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "[(111,10)-(112,0)]"
     },
     {
-      "@id": "amf://id#61/source-map/lexical/element_0",
+      "@id": "amf://id#60/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(107,8)-(108,0)]"
     },
     {
-      "@id": "amf://id#61/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#61",
+      "@id": "amf://id#60/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#60",
       "http://a.ml/vocabularies/document-source-maps#value": "[(110,8)-(112,0)]"
     },
     {
-      "@id": "amf://id#61/source-map/type-property-lexical-info/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#61",
+      "@id": "amf://id#60/source-map/type-property-lexical-info/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#60",
       "http://a.ml/vocabularies/document-source-maps#value": "[(111,10)-(111,14)]"
     },
     {
-      "@id": "amf://id#64",
+      "@id": "amf://id#63",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -2907,91 +2907,91 @@
       "http://a.ml/vocabularies/core#name": "name",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#64/source-map"
+          "@id": "amf://id#63/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#63/source-map",
+      "@id": "amf://id#62/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#63/source-map/synthesized-field/element_0"
+          "@id": "amf://id#62/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#63/source-map/lexical/element_1"
+          "@id": "amf://id#62/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#63/source-map/lexical/element_0"
+          "@id": "amf://id#62/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#62/source-map/synthesized-field/element_1",
+      "@id": "amf://id#61/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#strict",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#62/source-map/synthesized-field/element_0",
+      "@id": "amf://id#61/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#raw",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#62/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#62",
+      "@id": "amf://id#61/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#61",
       "http://a.ml/vocabularies/document-source-maps#value": "[(112,16)-(114,0)]"
     },
     {
-      "@id": "amf://id#56/source-map/type-property-lexical-info/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#56",
+      "@id": "amf://id#55/source-map/type-property-lexical-info/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#55",
       "http://a.ml/vocabularies/document-source-maps#value": "[(126,16)-(126,20)]"
     },
     {
-      "@id": "amf://id#56/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#56",
+      "@id": "amf://id#55/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#55",
       "http://a.ml/vocabularies/document-source-maps#value": "[(125,14)-(127,0)]"
     },
     {
-      "@id": "amf://id#56/source-map/lexical/element_0",
+      "@id": "amf://id#55/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "[(126,16)-(127,0)]"
     },
     {
-      "@id": "amf://id#58/source-map",
+      "@id": "amf://id#57/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#58/source-map/synthesized-field/element_1"
+          "@id": "amf://id#57/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "amf://id#58/source-map/synthesized-field/element_0"
+          "@id": "amf://id#57/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#58/source-map/lexical/element_0"
+          "@id": "amf://id#57/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#57/source-map/synthesized-field/element_1",
+      "@id": "amf://id#56/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#strict",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#57/source-map/synthesized-field/element_0",
+      "@id": "amf://id#56/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#raw",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#57/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#57",
+      "@id": "amf://id#56/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#56",
       "http://a.ml/vocabularies/document-source-maps#value": "[(128,16)-(128,22)]"
     },
     {
@@ -3494,7 +3494,7 @@
       "http://a.ml/vocabularies/document-source-maps#value": "amf://id#30"
     },
     {
-      "@id": "amf://id#69",
+      "@id": "amf://id#68",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -3509,96 +3509,96 @@
       "http://a.ml/vocabularies/core#name": "id",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#69/source-map"
+          "@id": "amf://id#68/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#68/source-map",
+      "@id": "amf://id#67/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#68/source-map/synthesized-field/element_0"
+          "@id": "amf://id#67/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#68/source-map/lexical/element_1"
+          "@id": "amf://id#67/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#68/source-map/lexical/element_0"
+          "@id": "amf://id#67/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#67/source-map/synthesized-field/element_1",
+      "@id": "amf://id#66/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#strict",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#67/source-map/synthesized-field/element_0",
+      "@id": "amf://id#66/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#raw",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#67/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#67",
+      "@id": "amf://id#66/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#66",
       "http://a.ml/vocabularies/document-source-maps#value": "[(105,16)-(107,0)]"
     },
     {
-      "@id": "amf://id#67/source-map/tracked-element/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#67",
-      "http://a.ml/vocabularies/document-source-maps#value": "amf://id#65"
+      "@id": "amf://id#66/source-map/tracked-element/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#66",
+      "http://a.ml/vocabularies/document-source-maps#value": "amf://id#64"
     },
     {
-      "@id": "amf://id#64/source-map",
+      "@id": "amf://id#63/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#64/source-map/synthesized-field/element_1"
+          "@id": "amf://id#63/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "amf://id#64/source-map/synthesized-field/element_0"
+          "@id": "amf://id#63/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#64/source-map/lexical/element_0"
+          "@id": "amf://id#63/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#63/source-map/synthesized-field/element_0",
+      "@id": "amf://id#62/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#63/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#63",
+      "@id": "amf://id#62/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#62",
       "http://a.ml/vocabularies/document-source-maps#value": "[(113,0)-(114,0)]"
     },
     {
-      "@id": "amf://id#63/source-map/lexical/element_0",
+      "@id": "amf://id#62/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(113,10)-(114,0)]"
     },
     {
-      "@id": "amf://id#58/source-map/synthesized-field/element_1",
+      "@id": "amf://id#57/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#58/source-map/synthesized-field/element_0",
+      "@id": "amf://id#57/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#58/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#58",
+      "@id": "amf://id#57/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#57",
       "http://a.ml/vocabularies/document-source-maps#value": "[(128,16)-(128,22)]"
     },
     {
@@ -3920,52 +3920,52 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(136,20)-(136,25)]"
     },
     {
-      "@id": "amf://id#69/source-map",
+      "@id": "amf://id#68/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#69/source-map/synthesized-field/element_1"
+          "@id": "amf://id#68/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "amf://id#69/source-map/synthesized-field/element_0"
+          "@id": "amf://id#68/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#69/source-map/lexical/element_0"
+          "@id": "amf://id#68/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#68/source-map/synthesized-field/element_0",
+      "@id": "amf://id#67/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#68/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#68",
+      "@id": "amf://id#67/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#67",
       "http://a.ml/vocabularies/document-source-maps#value": "[(106,0)-(107,0)]"
     },
     {
-      "@id": "amf://id#68/source-map/lexical/element_0",
+      "@id": "amf://id#67/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#id",
       "http://a.ml/vocabularies/document-source-maps#value": "[(106,10)-(107,0)]"
     },
     {
-      "@id": "amf://id#64/source-map/synthesized-field/element_1",
+      "@id": "amf://id#63/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#64/source-map/synthesized-field/element_0",
+      "@id": "amf://id#63/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#64/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#64",
+      "@id": "amf://id#63/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#63",
       "http://a.ml/vocabularies/document-source-maps#value": "[(113,16)-(113,17)]"
     },
     {
@@ -4096,18 +4096,18 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(136,24)-(136,25)]"
     },
     {
-      "@id": "amf://id#69/source-map/synthesized-field/element_1",
+      "@id": "amf://id#68/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#69/source-map/synthesized-field/element_0",
+      "@id": "amf://id#68/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#69/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#69",
+      "@id": "amf://id#68/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#68",
       "http://a.ml/vocabularies/document-source-maps#value": "[(106,14)-(106,16)]"
     },
     {
@@ -4169,14 +4169,14 @@
         "http://a.ml/vocabularies/document#Unit"
       ],
       "http://a.ml/vocabularies/document#encodes": {
-        "@id": "amf://id#36"
+        "@id": "amf://id#35"
       },
       "http://a.ml/vocabularies/document#root": true,
       "http://a.ml/vocabularies/document#processingData": {
         "@id": "amf://id#34"
       },
       "http://a.ml/vocabularies/document#sourceInformation": {
-        "@id": "amf://id#35"
+        "@id": "amf://id/BaseUnitSourceInformation"
       }
     }
   ]

--- a/test/data/production/best-practices/positive2.raml.jsonld
+++ b/test/data/production/best-practices/positive2.raml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
@@ -153,6 +153,7 @@
       "@id": "amf://id#11",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -245,6 +246,7 @@
       "@id": "amf://id#12",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -271,6 +273,7 @@
       "@id": "amf://id#19",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -332,6 +335,7 @@
       "@id": "amf://id#13",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "filter",
@@ -352,6 +356,7 @@
       "@id": "amf://id#15",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "order",
@@ -372,6 +377,7 @@
       "@id": "amf://id#17",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "callerId",
@@ -406,6 +412,7 @@
       "@id": "amf://id#22",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -422,6 +429,7 @@
       "@id": "amf://id#20",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "content-type",

--- a/test/data/production/best-practices/positive3.yaml.jsonld
+++ b/test/data/production/best-practices/positive3.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -168,6 +168,7 @@
       "@id": "amf://id#6",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -273,6 +274,7 @@
       "@id": "amf://id#8",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -345,6 +347,7 @@
       "@id": "amf://id#11",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -361,6 +364,7 @@
       "@id": "amf://id#9",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "content-type",

--- a/test/data/production/best-practices/positive4.raml.jsonld
+++ b/test/data/production/best-practices/positive4.raml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/test/data/production/best-practices/profile.yaml
+++ b/test/data/production/best-practices/profile.yaml
@@ -14,8 +14,6 @@ violation:
   - provide-examples
   - api-must-have-title
   - operations-must-have-identifiers
-
-warning:
   - api-must-have-description
   - api-must-have-documentation
   - operations-must-have-descriptions

--- a/test/data/production/datagraph/negative1.yaml.jsonld
+++ b/test/data/production/datagraph/negative1.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -149,6 +149,7 @@
       "@id": "amf://id#11",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -196,6 +197,7 @@
       "@id": "amf://id#19",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -283,6 +285,7 @@
       "@id": "amf://id#15",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -296,6 +299,7 @@
       "@id": "amf://id#13",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -361,6 +365,7 @@
       "@id": "amf://id#24",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -374,6 +379,7 @@
       "@id": "amf://id#21",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -439,6 +445,7 @@
       "@id": "amf://id#16",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -461,6 +468,7 @@
       "@id": "amf://id#14",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -538,6 +546,7 @@
       "@id": "amf://id#25",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -560,6 +569,7 @@
       "@id": "amf://id#22",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/datagraph/negative10.yaml.jsonld
+++ b/test/data/production/datagraph/negative10.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -123,6 +123,7 @@
       "@id": "amf://id#13",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -215,6 +216,7 @@
       "@id": "amf://id#19",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -228,6 +230,7 @@
       "@id": "amf://id#15",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -310,6 +313,7 @@
       "@id": "amf://id#20",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -332,6 +336,7 @@
       "@id": "amf://id#16",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/datagraph/negative11.yaml.jsonld
+++ b/test/data/production/datagraph/negative11.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -123,6 +123,7 @@
       "@id": "amf://id#17",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -215,6 +216,7 @@
       "@id": "amf://id#23",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -228,6 +230,7 @@
       "@id": "amf://id#19",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -310,6 +313,7 @@
       "@id": "amf://id#24",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -332,6 +336,7 @@
       "@id": "amf://id#20",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/datagraph/negative12.yaml.jsonld
+++ b/test/data/production/datagraph/negative12.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -123,6 +123,7 @@
       "@id": "amf://id#13",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -215,6 +216,7 @@
       "@id": "amf://id#19",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -233,6 +235,7 @@
       "@id": "amf://id#15",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -315,6 +318,7 @@
       "@id": "amf://id#20",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "args",
@@ -339,6 +343,7 @@
       "@id": "amf://id#26",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -361,6 +366,7 @@
       "@id": "amf://id#16",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/datagraph/negative13.yaml.jsonld
+++ b/test/data/production/datagraph/negative13.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -123,6 +123,7 @@
       "@id": "amf://id#13",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -215,6 +216,7 @@
       "@id": "amf://id#19",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -228,6 +230,7 @@
       "@id": "amf://id#15",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -310,6 +313,7 @@
       "@id": "amf://id#20",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -332,6 +336,7 @@
       "@id": "amf://id#16",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/datagraph/negative2.yaml.jsonld
+++ b/test/data/production/datagraph/negative2.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -123,6 +123,7 @@
       "@id": "amf://id#10",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -210,6 +211,7 @@
       "@id": "amf://id#18",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -223,6 +225,7 @@
       "@id": "amf://id#12",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -288,6 +291,7 @@
       "@id": "amf://id#19",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -310,6 +314,7 @@
       "@id": "amf://id#13",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/datagraph/negative3.yaml.jsonld
+++ b/test/data/production/datagraph/negative3.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -149,6 +149,7 @@
       "@id": "amf://id#14",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -196,6 +197,7 @@
       "@id": "amf://id#22",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -283,6 +285,7 @@
       "@id": "amf://id#18",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -296,6 +299,7 @@
       "@id": "amf://id#16",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -361,6 +365,7 @@
       "@id": "amf://id#30",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -374,6 +379,7 @@
       "@id": "amf://id#24",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -439,6 +445,7 @@
       "@id": "amf://id#19",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -461,6 +468,7 @@
       "@id": "amf://id#17",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -538,6 +546,7 @@
       "@id": "amf://id#31",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -560,6 +569,7 @@
       "@id": "amf://id#25",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/yaml",

--- a/test/data/production/datagraph/negative3.yaml.report.jsonld
+++ b/test/data/production/datagraph/negative3.yaml.report.jsonld
@@ -105,7 +105,7 @@
               "reportSchema:ValidationResultNode",
               "shacl:ValidationResult"
             ],
-            "focusNode": "amf://id#22",
+            "focusNode": "amf://id#7",
             "location": {
               "@id": "violation_0_location",
               "@type": [
@@ -124,8 +124,8 @@
                     "lexicalSchema:PositionNode",
                     "lexical:Position"
                   ],
-                  "column": 20,
-                  "line": 72
+                  "column": 0,
+                  "line": 31
                 },
                 "start": {
                   "@id": "violation_0_location_range_start",
@@ -134,14 +134,14 @@
                     "lexical:Position"
                   ],
                   "column": 4,
-                  "line": 60
+                  "line": 23
                 }
               },
               "uri": "file://./test/data/production/datagraph/negative3.yaml"
             },
-            "resultMessage": "Only JSON payloads are supported at the moment in DataGraph. This is the preferred media type format.\n",
+            "resultMessage": "Open schemas with a set of variable properties cannot be pre-processed to generated the federated schema.\nConsider if possible to define a closed schema with a finite set of proeprties described statically in the API spec.\nIf you are working on OAS or AsyncAPI, object schemas are open by default and must be explicilty closed using `additionalProperties: false`.\n",
             "resultSeverity": "http://www.w3.org/ns/shacl#Violation",
-            "sourceShapeName": "not-json-response",
+            "sourceShapeName": "open-schemas-ignored",
             "trace": [
               {
                 "@id": "violation_0_0",
@@ -149,7 +149,7 @@
                   "reportSchema:TraceMessageNode",
                   "validation:TraceMessage"
                 ],
-                "component": "atLeast",
+                "component": "in",
                 "location": {
                   "@id": "violation_0_0_location",
                   "@type": [
@@ -168,208 +168,11 @@
                         "lexicalSchema:PositionNode",
                         "lexical:Position"
                       ],
-                      "column": 20,
-                      "line": 72
-                    },
-                    "start": {
-                      "@id": "violation_0_0_location_range_start",
-                      "@type": [
-                        "lexicalSchema:PositionNode",
-                        "lexical:Position"
-                      ],
-                      "column": 4,
-                      "line": 60
-                    }
-                  },
-                  "uri": "file://./test/data/production/datagraph/negative3.yaml"
-                },
-                "resultPath": "http://a.ml/vocabularies/apiContract#returns / http://a.ml/vocabularies/apiContract#payload",
-                "traceValue": {
-                  "@id": "violation_0_0_traceValue",
-                  "@type": [
-                    "reportSchema:TraceValueNode",
-                    "validation:TraceValue"
-                  ],
-                  "cardinality": 1,
-                  "failedNodes": 1,
-                  "negated": false,
-                  "subResult": [
-                    {
-                      "@id": "violation_0_0_traceValue_0",
-                      "@type": [
-                        "reportSchema:ValidationResultNode",
-                        "shacl:ValidationResult"
-                      ],
-                      "focusNode": "amf://id#25",
-                      "location": {
-                        "@id": "violation_0_0_traceValue_0_location",
-                        "@type": [
-                          "lexicalSchema:LocationNode",
-                          "lexical:Location"
-                        ],
-                        "range": {
-                          "@id": "violation_0_0_traceValue_0_location_range",
-                          "@type": [
-                            "lexicalSchema:RangeNode",
-                            "lexical:Range"
-                          ],
-                          "end": {
-                            "@id": "violation_0_0_traceValue_0_location_range_end",
-                            "@type": [
-                              "lexicalSchema:PositionNode",
-                              "lexical:Position"
-                            ],
-                            "column": 20,
-                            "line": 72
-                          },
-                          "start": {
-                            "@id": "violation_0_0_traceValue_0_location_range_start",
-                            "@type": [
-                              "lexicalSchema:PositionNode",
-                              "lexical:Position"
-                            ],
-                            "column": 12,
-                            "line": 69
-                          }
-                        },
-                        "uri": "file://./test/data/production/datagraph/negative3.yaml"
-                      },
-                      "resultMessage": "error in nested nodes under http://a.ml/vocabularies/apiContract#returns / http://a.ml/vocabularies/apiContract#payload",
-                      "sourceShapeName": "nested",
-                      "trace": [
-                        {
-                          "@id": "violation_0_0_traceValue_0_0",
-                          "@type": [
-                            "reportSchema:TraceMessageNode",
-                            "validation:TraceMessage"
-                          ],
-                          "component": "pattern",
-                          "location": {
-                            "@id": "violation_0_0_traceValue_0_0_location",
-                            "@type": [
-                              "lexicalSchema:LocationNode",
-                              "lexical:Location"
-                            ],
-                            "range": {
-                              "@id": "violation_0_0_traceValue_0_0_location_range",
-                              "@type": [
-                                "lexicalSchema:RangeNode",
-                                "lexical:Range"
-                              ],
-                              "end": {
-                                "@id": "violation_0_0_traceValue_0_0_location_range_end",
-                                "@type": [
-                                  "lexicalSchema:PositionNode",
-                                  "lexical:Position"
-                                ],
-                                "column": 20,
-                                "line": 72
-                              },
-                              "start": {
-                                "@id": "violation_0_0_traceValue_0_0_location_range_start",
-                                "@type": [
-                                  "lexicalSchema:PositionNode",
-                                  "lexical:Position"
-                                ],
-                                "column": 12,
-                                "line": 69
-                              }
-                            },
-                            "uri": "file://./test/data/production/datagraph/negative3.yaml"
-                          },
-                          "resultPath": "http://a.ml/vocabularies/core#mediaType",
-                          "traceValue": {
-                            "@id": "violation_0_0_traceValue_0_0_traceValue",
-                            "@type": [
-                              "reportSchema:TraceValueNode",
-                              "validation:TraceValue"
-                            ],
-                            "argument": "application/yaml",
-                            "negated": false
-                          }
-                        }
-                      ]
-                    }
-                  ],
-                  "successfulNodes": 0
-                }
-              }
-            ]
-          },
-          {
-            "@id": "violation_1",
-            "@type": [
-              "reportSchema:ValidationResultNode",
-              "shacl:ValidationResult"
-            ],
-            "focusNode": "amf://id#7",
-            "location": {
-              "@id": "violation_1_location",
-              "@type": [
-                "lexicalSchema:LocationNode",
-                "lexical:Location"
-              ],
-              "range": {
-                "@id": "violation_1_location_range",
-                "@type": [
-                  "lexicalSchema:RangeNode",
-                  "lexical:Range"
-                ],
-                "end": {
-                  "@id": "violation_1_location_range_end",
-                  "@type": [
-                    "lexicalSchema:PositionNode",
-                    "lexical:Position"
-                  ],
-                  "column": 0,
-                  "line": 31
-                },
-                "start": {
-                  "@id": "violation_1_location_range_start",
-                  "@type": [
-                    "lexicalSchema:PositionNode",
-                    "lexical:Position"
-                  ],
-                  "column": 4,
-                  "line": 23
-                }
-              },
-              "uri": "file://./test/data/production/datagraph/negative3.yaml"
-            },
-            "resultMessage": "Open schemas with a set of variable properties cannot be pre-processed to generated the federated schema.\nConsider if possible to define a closed schema with a finite set of proeprties described statically in the API spec.\nIf you are working on OAS or AsyncAPI, object schemas are open by default and must be explicilty closed using `additionalProperties: false`.\n",
-            "resultSeverity": "http://www.w3.org/ns/shacl#Violation",
-            "sourceShapeName": "open-schemas-ignored",
-            "trace": [
-              {
-                "@id": "violation_1_0",
-                "@type": [
-                  "reportSchema:TraceMessageNode",
-                  "validation:TraceMessage"
-                ],
-                "component": "in",
-                "location": {
-                  "@id": "violation_1_0_location",
-                  "@type": [
-                    "lexicalSchema:LocationNode",
-                    "lexical:Location"
-                  ],
-                  "range": {
-                    "@id": "violation_1_0_location_range",
-                    "@type": [
-                      "lexicalSchema:RangeNode",
-                      "lexical:Range"
-                    ],
-                    "end": {
-                      "@id": "violation_1_0_location_range_end",
-                      "@type": [
-                        "lexicalSchema:PositionNode",
-                        "lexical:Position"
-                      ],
                       "column": 0,
                       "line": 31
                     },
                     "start": {
-                      "@id": "violation_1_0_location_range_start",
+                      "@id": "violation_0_0_location_range_start",
                       "@type": [
                         "lexicalSchema:PositionNode",
                         "lexical:Position"
@@ -382,7 +185,7 @@
                 },
                 "resultPath": "http://www.w3.org/ns/shacl#closed",
                 "traceValue": {
-                  "@id": "violation_1_0_traceValue",
+                  "@id": "violation_0_0_traceValue",
                   "@type": [
                     "reportSchema:TraceValueNode",
                     "validation:TraceValue"

--- a/test/data/production/datagraph/negative4.yaml.jsonld
+++ b/test/data/production/datagraph/negative4.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -149,6 +149,7 @@
       "@id": "amf://id#20",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -201,6 +202,7 @@
       "@id": "amf://id#34",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -293,6 +295,7 @@
       "@id": "amf://id#30",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -306,6 +309,7 @@
       "@id": "amf://id#22",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -388,6 +392,7 @@
       "@id": "amf://id#43",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -401,6 +406,7 @@
       "@id": "amf://id#36",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -469,6 +475,7 @@
       "@id": "amf://id#31",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -491,6 +498,7 @@
       "@id": "amf://id#23",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -598,6 +606,7 @@
       "@id": "amf://id#44",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -620,6 +629,7 @@
       "@id": "amf://id#37",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/yaml",
@@ -638,6 +648,7 @@
       "@id": "amf://id#42",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/datagraph/negative5.yaml.jsonld
+++ b/test/data/production/datagraph/negative5.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -149,6 +149,7 @@
       "@id": "amf://id#17",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -201,6 +202,7 @@
       "@id": "amf://id#29",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -293,6 +295,7 @@
       "@id": "amf://id#23",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -311,6 +314,7 @@
       "@id": "amf://id#19",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -393,6 +397,7 @@
       "@id": "amf://id#38",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -406,6 +411,7 @@
       "@id": "amf://id#31",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -474,6 +480,7 @@
       "@id": "amf://id#24",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "createdAt",
@@ -498,6 +505,7 @@
       "@id": "amf://id#26",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -520,6 +528,7 @@
       "@id": "amf://id#20",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -624,6 +633,7 @@
       "@id": "amf://id#39",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -646,6 +656,7 @@
       "@id": "amf://id#32",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/yaml",
@@ -664,6 +675,7 @@
       "@id": "amf://id#37",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/datagraph/negative6.yaml.jsonld
+++ b/test/data/production/datagraph/negative6.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -149,6 +149,7 @@
       "@id": "amf://id#17",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -201,6 +202,7 @@
       "@id": "amf://id#29",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -293,6 +295,7 @@
       "@id": "amf://id#23",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -311,6 +314,7 @@
       "@id": "amf://id#19",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -393,6 +397,7 @@
       "@id": "amf://id#38",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -406,6 +411,7 @@
       "@id": "amf://id#31",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -474,6 +480,7 @@
       "@id": "amf://id#24",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "createdAt",
@@ -498,6 +505,7 @@
       "@id": "amf://id#26",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -519,6 +527,7 @@
       "@id": "amf://id#20",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -623,6 +632,7 @@
       "@id": "amf://id#39",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "uuid",
@@ -645,6 +655,7 @@
       "@id": "amf://id#32",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/yaml",
@@ -663,6 +674,7 @@
       "@id": "amf://id#37",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/datagraph/negative7.yaml.jsonld
+++ b/test/data/production/datagraph/negative7.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -149,6 +149,7 @@
       "@id": "amf://id#17",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -201,6 +202,7 @@
       "@id": "amf://id#29",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -293,6 +295,7 @@
       "@id": "amf://id#23",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -311,6 +314,7 @@
       "@id": "amf://id#19",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -393,6 +397,7 @@
       "@id": "amf://id#38",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -406,6 +411,7 @@
       "@id": "amf://id#31",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -474,6 +480,7 @@
       "@id": "amf://id#24",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "createdAt",
@@ -498,6 +505,7 @@
       "@id": "amf://id#26",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -520,6 +528,7 @@
       "@id": "amf://id#20",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -624,6 +633,7 @@
       "@id": "amf://id#39",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "uuid",
@@ -646,6 +656,7 @@
       "@id": "amf://id#32",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/yaml",
@@ -664,6 +675,7 @@
       "@id": "amf://id#37",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/datagraph/negative8.yaml.jsonld
+++ b/test/data/production/datagraph/negative8.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -123,6 +123,7 @@
       "@id": "amf://id#23",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -215,6 +216,7 @@
       "@id": "amf://id#29",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -228,6 +230,7 @@
       "@id": "amf://id#25",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -310,6 +313,7 @@
       "@id": "amf://id#30",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -332,6 +336,7 @@
       "@id": "amf://id#26",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/datagraph/negative9.yaml.jsonld
+++ b/test/data/production/datagraph/negative9.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -123,6 +123,7 @@
       "@id": "amf://id#17",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -215,6 +216,7 @@
       "@id": "amf://id#23",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -228,6 +230,7 @@
       "@id": "amf://id#19",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -310,6 +313,7 @@
       "@id": "amf://id#24",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -332,6 +336,7 @@
       "@id": "amf://id#20",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/datagraph/positive1.yaml.jsonld
+++ b/test/data/production/datagraph/positive1.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -149,6 +149,7 @@
       "@id": "amf://id#15",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -196,6 +197,7 @@
       "@id": "amf://id#23",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -283,6 +285,7 @@
       "@id": "amf://id#19",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -296,6 +299,7 @@
       "@id": "amf://id#17",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -361,6 +365,7 @@
       "@id": "amf://id#27",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -374,6 +379,7 @@
       "@id": "amf://id#25",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -439,6 +445,7 @@
       "@id": "amf://id#20",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -461,6 +468,7 @@
       "@id": "amf://id#18",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -538,6 +546,7 @@
       "@id": "amf://id#28",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -560,6 +569,7 @@
       "@id": "amf://id#26",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/datagraph/positive12.yaml.jsonld
+++ b/test/data/production/datagraph/positive12.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -123,6 +123,7 @@
       "@id": "amf://id#13",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -215,6 +216,7 @@
       "@id": "amf://id#19",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -233,6 +235,7 @@
       "@id": "amf://id#15",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -315,6 +318,7 @@
       "@id": "amf://id#20",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "args",
@@ -339,6 +343,7 @@
       "@id": "amf://id#23",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -361,6 +366,7 @@
       "@id": "amf://id#16",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/datagraph/positive2.yaml.jsonld
+++ b/test/data/production/datagraph/positive2.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -149,6 +149,7 @@
       "@id": "amf://id#15",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -196,6 +197,7 @@
       "@id": "amf://id#23",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -283,6 +285,7 @@
       "@id": "amf://id#19",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -296,6 +299,7 @@
       "@id": "amf://id#17",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -361,6 +365,7 @@
       "@id": "amf://id#32",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -374,6 +379,7 @@
       "@id": "amf://id#25",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -442,6 +448,7 @@
       "@id": "amf://id#20",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -464,6 +471,7 @@
       "@id": "amf://id#18",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -541,6 +549,7 @@
       "@id": "amf://id#33",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -563,6 +572,7 @@
       "@id": "amf://id#26",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/yaml",
@@ -581,6 +591,7 @@
       "@id": "amf://id#31",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/datagraph/positive3.yaml.jsonld
+++ b/test/data/production/datagraph/positive3.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -149,6 +149,7 @@
       "@id": "amf://id#15",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -196,6 +197,7 @@
       "@id": "amf://id#23",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -283,6 +285,7 @@
       "@id": "amf://id#19",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -296,6 +299,7 @@
       "@id": "amf://id#17",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -361,6 +365,7 @@
       "@id": "amf://id#32",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -374,6 +379,7 @@
       "@id": "amf://id#25",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -442,6 +448,7 @@
       "@id": "amf://id#20",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -464,6 +471,7 @@
       "@id": "amf://id#18",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -541,6 +549,7 @@
       "@id": "amf://id#33",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -563,6 +572,7 @@
       "@id": "amf://id#26",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/yaml",
@@ -581,6 +591,7 @@
       "@id": "amf://id#31",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/datagraph/positive4.yaml.jsonld
+++ b/test/data/production/datagraph/positive4.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -149,6 +149,7 @@
       "@id": "amf://id#17",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -201,6 +202,7 @@
       "@id": "amf://id#27",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -293,6 +295,7 @@
       "@id": "amf://id#23",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -306,6 +309,7 @@
       "@id": "amf://id#19",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -388,6 +392,7 @@
       "@id": "amf://id#36",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -401,6 +406,7 @@
       "@id": "amf://id#29",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -469,6 +475,7 @@
       "@id": "amf://id#24",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -491,6 +498,7 @@
       "@id": "amf://id#20",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -595,6 +603,7 @@
       "@id": "amf://id#37",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -617,6 +626,7 @@
       "@id": "amf://id#30",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/yaml",
@@ -635,6 +645,7 @@
       "@id": "amf://id#35",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/datagraph/positive5.yaml.jsonld
+++ b/test/data/production/datagraph/positive5.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -149,6 +149,7 @@
       "@id": "amf://id#17",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -201,6 +202,7 @@
       "@id": "amf://id#29",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -293,6 +295,7 @@
       "@id": "amf://id#23",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -311,6 +314,7 @@
       "@id": "amf://id#19",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -393,6 +397,7 @@
       "@id": "amf://id#38",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -406,6 +411,7 @@
       "@id": "amf://id#31",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -474,6 +480,7 @@
       "@id": "amf://id#24",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "createdAt",
@@ -498,6 +505,7 @@
       "@id": "amf://id#26",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -520,6 +528,7 @@
       "@id": "amf://id#20",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -624,6 +633,7 @@
       "@id": "amf://id#39",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "uuid",
@@ -646,6 +656,7 @@
       "@id": "amf://id#32",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/yaml",
@@ -664,6 +675,7 @@
       "@id": "amf://id#37",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/datagraph/positive9.yaml.jsonld
+++ b/test/data/production/datagraph/positive9.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -123,6 +123,7 @@
       "@id": "amf://id#17",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -215,6 +216,7 @@
       "@id": "amf://id#23",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -228,6 +230,7 @@
       "@id": "amf://id#19",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -310,6 +313,7 @@
       "@id": "amf://id#24",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -332,6 +336,7 @@
       "@id": "amf://id#20",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/datagraph/profile.yaml
+++ b/test/data/production/datagraph/profile.yaml
@@ -3,21 +3,21 @@
 profile: Anypoint Datagraph Best Practices
 
 violation:
-  - not-anonymous-types
-  - missing-return-type
+#  - not-anonymous-types
+#  - missing-return-type
   - not-json-response
-  - no-2xx-response
-  - only-http-basic-security-supported
-  - potential-key-parameters
-  - missing-type-description
-  - missing-property-description
-  - missing-parameter-description
-  - request-response-antipattern
-  - heterogeneous-union
-  - nil-union-antipattern
-  - unsupported-response-schema-shapes
-  - non-scalar-url-parameters
-  - open-schemas-ignored
+#  - no-2xx-response
+#  - only-http-basic-security-supported
+#  - potential-key-parameters
+#  - missing-type-description
+#  - missing-property-description
+#  - missing-parameter-description
+#  - request-response-antipattern
+#  - heterogeneous-union
+#  - nil-union-antipattern
+#  - unsupported-response-schema-shapes
+#  - non-scalar-url-parameters
+#  - open-schemas-ignored
 
 validations:
 
@@ -64,16 +64,23 @@ validations:
     message: |
       Only JSON payloads are supported at the moment in DataGraph. This is the preferred media type format.
     targetClass: apiContract.Operation
-    propertyConstraints:
-      apiContract.method:
-        pattern: "get"
-      apiContract.returns / apiContract.payload:
-        atLeast:
-          count: 1
-          validation:
-            propertyConstraints:
-               core.mediaType:
-                pattern: "application/json"
+    if:
+      propertyConstraints:
+        apiContract.method:
+          pattern: "get"
+    then:
+      or:
+        - propertyConstraints:
+            core.mediaType:
+              pattern: "application/json"
+        - propertyConstraints:
+            apiContract.returns / apiContract.payload:
+              atLeast:
+                count: 1
+                validation:
+                  propertyConstraints:
+                     core.mediaType:
+                      pattern: "application/json"
 
   no-2xx-response:
     message: |

--- a/test/data/production/datagraph/profile.yaml
+++ b/test/data/production/datagraph/profile.yaml
@@ -3,21 +3,21 @@
 profile: Anypoint Datagraph Best Practices
 
 violation:
-#  - not-anonymous-types
-#  - missing-return-type
+  - not-anonymous-types
+  - missing-return-type
   - not-json-response
-#  - no-2xx-response
-#  - only-http-basic-security-supported
-#  - potential-key-parameters
-#  - missing-type-description
-#  - missing-property-description
-#  - missing-parameter-description
-#  - request-response-antipattern
-#  - heterogeneous-union
-#  - nil-union-antipattern
-#  - unsupported-response-schema-shapes
-#  - non-scalar-url-parameters
-#  - open-schemas-ignored
+  - no-2xx-response
+  - only-http-basic-security-supported
+  - potential-key-parameters
+  - missing-type-description
+  - missing-property-description
+  - missing-parameter-description
+  - request-response-antipattern
+  - heterogeneous-union
+  - nil-union-antipattern
+  - unsupported-response-schema-shapes
+  - non-scalar-url-parameters
+  - open-schemas-ignored
 
 validations:
 

--- a/test/data/production/datagraph/profile.yaml
+++ b/test/data/production/datagraph/profile.yaml
@@ -64,16 +64,23 @@ validations:
     message: |
       Only JSON payloads are supported at the moment in DataGraph. This is the preferred media type format.
     targetClass: apiContract.Operation
-    propertyConstraints:
-      apiContract.method:
-        pattern: "get"
-      apiContract.returns / apiContract.payload:
-        atLeast:
-          count: 1
-          validation:
-            propertyConstraints:
-               core.mediaType:
-                pattern: "application/json"
+    if:
+      propertyConstraints:
+        apiContract.method:
+          pattern: "get"
+    then:
+      or:
+        - propertyConstraints:
+            core.mediaType:
+              pattern: "application/json"
+        - propertyConstraints:
+            apiContract.returns / apiContract.payload:
+              atLeast:
+                count: 1
+                validation:
+                  propertyConstraints:
+                     core.mediaType:
+                      pattern: "application/json"
 
   no-2xx-response:
     message: |

--- a/test/data/production/json-api/negative1.yaml.jsonld
+++ b/test/data/production/json-api/negative1.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -123,6 +123,7 @@
       "@id": "amf://id#16",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -216,6 +217,7 @@
       "@id": "amf://id#29",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -229,6 +231,7 @@
       "@id": "amf://id#18",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -250,6 +253,7 @@
       "@id": "amf://id#20",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -271,6 +275,7 @@
       "@id": "amf://id#22",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -336,6 +341,7 @@
       "@id": "amf://id#30",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -358,6 +364,7 @@
       "@id": "amf://id#19",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/vnd.api+json",
@@ -394,6 +401,7 @@
       "@id": "amf://id#21",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/vnd.api+json",
@@ -430,6 +438,7 @@
       "@id": "amf://id#23",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/vnd.api+json",

--- a/test/data/production/json-api/negative10.yaml.jsonld
+++ b/test/data/production/json-api/negative10.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -123,6 +123,7 @@
       "@id": "amf://id#23",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -216,6 +217,7 @@
       "@id": "amf://id#31",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -229,6 +231,7 @@
       "@id": "amf://id#25",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -250,6 +253,7 @@
       "@id": "amf://id#27",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -271,6 +275,7 @@
       "@id": "amf://id#29",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -336,6 +341,7 @@
       "@id": "amf://id#32",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -358,6 +364,7 @@
       "@id": "amf://id#26",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/vnd.api+json",
@@ -394,6 +401,7 @@
       "@id": "amf://id#28",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/vnd.api+json",
@@ -430,6 +438,7 @@
       "@id": "amf://id#30",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/vnd.api+json",

--- a/test/data/production/json-api/negative11.yaml.jsonld
+++ b/test/data/production/json-api/negative11.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -123,6 +123,7 @@
       "@id": "amf://id#27",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -216,6 +217,7 @@
       "@id": "amf://id#35",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -240,6 +242,7 @@
       "@id": "amf://id#29",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -261,6 +264,7 @@
       "@id": "amf://id#31",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -282,6 +286,7 @@
       "@id": "amf://id#33",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -319,25 +324,22 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#27/source-map/lexical/element_6"
-        },
-        {
-          "@id": "amf://id#27/source-map/lexical/element_4"
-        },
-        {
-          "@id": "amf://id#27/source-map/lexical/element_2"
-        },
-        {
-          "@id": "amf://id#27/source-map/lexical/element_0"
-        },
-        {
-          "@id": "amf://id#27/source-map/lexical/element_1"
+          "@id": "amf://id#27/source-map/lexical/element_5"
         },
         {
           "@id": "amf://id#27/source-map/lexical/element_3"
         },
         {
-          "@id": "amf://id#27/source-map/lexical/element_5"
+          "@id": "amf://id#27/source-map/lexical/element_1"
+        },
+        {
+          "@id": "amf://id#27/source-map/lexical/element_0"
+        },
+        {
+          "@id": "amf://id#27/source-map/lexical/element_2"
+        },
+        {
+          "@id": "amf://id#27/source-map/lexical/element_4"
         }
       ]
     },
@@ -350,6 +352,7 @@
       "@id": "amf://id#42",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -372,6 +375,7 @@
       "@id": "amf://id#36",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/vnd.api+json",
@@ -391,9 +395,6 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#35/source-map/lexical/element_1"
-        },
-        {
           "@id": "amf://id#35/source-map/lexical/element_0"
         }
       ]
@@ -402,6 +403,7 @@
       "@id": "amf://id#30",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/vnd.api+json",
@@ -438,6 +440,7 @@
       "@id": "amf://id#32",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/vnd.api+json",
@@ -474,6 +477,7 @@
       "@id": "amf://id#34",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/vnd.api+json",
@@ -518,29 +522,9 @@
       ]
     },
     {
-      "@id": "amf://id#27/source-map/lexical/element_6",
+      "@id": "amf://id#27/source-map/lexical/element_5",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#tag",
       "http://a.ml/vocabularies/document-source-maps#value": "[(47,6)-(49,0)]"
-    },
-    {
-      "@id": "amf://id#27/source-map/lexical/element_4",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(46,6)-(47,0)]"
-    },
-    {
-      "@id": "amf://id#27/source-map/lexical/element_2",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(45,6)-(46,0)]"
-    },
-    {
-      "@id": "amf://id#27/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#operationId",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(46,6)-(47,0)]"
-    },
-    {
-      "@id": "amf://id#27/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#returns",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(60,6)-(79,0)]"
     },
     {
       "@id": "amf://id#27/source-map/lexical/element_3",
@@ -548,9 +532,24 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(44,4)-(79,0)]"
     },
     {
-      "@id": "amf://id#27/source-map/lexical/element_5",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#expects",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(49,6)-(60,0)]"
+      "@id": "amf://id#27/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#returns",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(60,6)-(79,0)]"
+    },
+    {
+      "@id": "amf://id#27/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#operationId",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(46,6)-(47,0)]"
+    },
+    {
+      "@id": "amf://id#27/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(46,6)-(47,0)]"
+    },
+    {
+      "@id": "amf://id#27/source-map/lexical/element_4",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(45,6)-(46,0)]"
     },
     {
       "@id": "amf://id#43",
@@ -648,11 +647,6 @@
           "@id": "amf://id#36/source-map/lexical/element_1"
         }
       ]
-    },
-    {
-      "@id": "amf://id#35/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#35",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(49,6)-(60,0)]"
     },
     {
       "@id": "amf://id#35/source-map/lexical/element_0",

--- a/test/data/production/json-api/negative2.yaml.jsonld
+++ b/test/data/production/json-api/negative2.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -123,6 +123,7 @@
       "@id": "amf://id#16",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -216,6 +217,7 @@
       "@id": "amf://id#25",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -229,6 +231,7 @@
       "@id": "amf://id#18",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -250,6 +253,7 @@
       "@id": "amf://id#20",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -271,6 +275,7 @@
       "@id": "amf://id#22",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -336,6 +341,7 @@
       "@id": "amf://id#26",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -358,6 +364,7 @@
       "@id": "amf://id#19",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/vnd.api+json",
@@ -394,6 +401,7 @@
       "@id": "amf://id#21",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/vnd.api+json",
@@ -430,6 +438,7 @@
       "@id": "amf://id#23",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/vnd.api+json",

--- a/test/data/production/json-api/negative2b.yaml.jsonld
+++ b/test/data/production/json-api/negative2b.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -123,6 +123,7 @@
       "@id": "amf://id#16",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -216,6 +217,7 @@
       "@id": "amf://id#25",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -240,6 +242,7 @@
       "@id": "amf://id#18",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -261,6 +264,7 @@
       "@id": "amf://id#20",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -282,6 +286,7 @@
       "@id": "amf://id#22",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -319,25 +324,22 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#16/source-map/lexical/element_6"
-        },
-        {
-          "@id": "amf://id#16/source-map/lexical/element_4"
-        },
-        {
-          "@id": "amf://id#16/source-map/lexical/element_2"
-        },
-        {
-          "@id": "amf://id#16/source-map/lexical/element_0"
-        },
-        {
-          "@id": "amf://id#16/source-map/lexical/element_1"
+          "@id": "amf://id#16/source-map/lexical/element_5"
         },
         {
           "@id": "amf://id#16/source-map/lexical/element_3"
         },
         {
-          "@id": "amf://id#16/source-map/lexical/element_5"
+          "@id": "amf://id#16/source-map/lexical/element_1"
+        },
+        {
+          "@id": "amf://id#16/source-map/lexical/element_0"
+        },
+        {
+          "@id": "amf://id#16/source-map/lexical/element_2"
+        },
+        {
+          "@id": "amf://id#16/source-map/lexical/element_4"
         }
       ]
     },
@@ -350,6 +352,7 @@
       "@id": "amf://id#28",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -372,6 +375,7 @@
       "@id": "amf://id#26",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/vnd.api+json",
@@ -391,9 +395,6 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#25/source-map/lexical/element_1"
-        },
-        {
           "@id": "amf://id#25/source-map/lexical/element_0"
         }
       ]
@@ -402,6 +403,7 @@
       "@id": "amf://id#19",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/vnd.api+json",
@@ -438,6 +440,7 @@
       "@id": "amf://id#21",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/vnd.api+json",
@@ -474,6 +477,7 @@
       "@id": "amf://id#23",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/vnd.api+json",
@@ -518,29 +522,9 @@
       ]
     },
     {
-      "@id": "amf://id#16/source-map/lexical/element_6",
+      "@id": "amf://id#16/source-map/lexical/element_5",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#tag",
       "http://a.ml/vocabularies/document-source-maps#value": "[(34,6)-(36,0)]"
-    },
-    {
-      "@id": "amf://id#16/source-map/lexical/element_4",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(33,6)-(34,0)]"
-    },
-    {
-      "@id": "amf://id#16/source-map/lexical/element_2",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(32,6)-(33,0)]"
-    },
-    {
-      "@id": "amf://id#16/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#operationId",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(33,6)-(34,0)]"
-    },
-    {
-      "@id": "amf://id#16/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#returns",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(36,6)-(56,0)]"
     },
     {
       "@id": "amf://id#16/source-map/lexical/element_3",
@@ -548,9 +532,24 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(31,4)-(60,26)]"
     },
     {
-      "@id": "amf://id#16/source-map/lexical/element_5",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#expects",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(56,6)-(60,26)]"
+      "@id": "amf://id#16/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#returns",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(36,6)-(56,0)]"
+    },
+    {
+      "@id": "amf://id#16/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#operationId",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(33,6)-(34,0)]"
+    },
+    {
+      "@id": "amf://id#16/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(33,6)-(34,0)]"
+    },
+    {
+      "@id": "amf://id#16/source-map/lexical/element_4",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(32,6)-(33,0)]"
     },
     {
       "@id": "amf://id#29",
@@ -647,11 +646,6 @@
           "@id": "amf://id#26/source-map/lexical/element_1"
         }
       ]
-    },
-    {
-      "@id": "amf://id#25/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#25",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(56,6)-(60,26)]"
     },
     {
       "@id": "amf://id#25/source-map/lexical/element_0",

--- a/test/data/production/json-api/negative3.yaml.jsonld
+++ b/test/data/production/json-api/negative3.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -123,6 +123,7 @@
       "@id": "amf://id#16",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -216,6 +217,7 @@
       "@id": "amf://id#31",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -240,6 +242,7 @@
       "@id": "amf://id#18",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -261,6 +264,7 @@
       "@id": "amf://id#20",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -282,6 +286,7 @@
       "@id": "amf://id#22",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -319,25 +324,22 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#16/source-map/lexical/element_6"
-        },
-        {
-          "@id": "amf://id#16/source-map/lexical/element_4"
-        },
-        {
-          "@id": "amf://id#16/source-map/lexical/element_2"
-        },
-        {
-          "@id": "amf://id#16/source-map/lexical/element_0"
-        },
-        {
-          "@id": "amf://id#16/source-map/lexical/element_1"
+          "@id": "amf://id#16/source-map/lexical/element_5"
         },
         {
           "@id": "amf://id#16/source-map/lexical/element_3"
         },
         {
-          "@id": "amf://id#16/source-map/lexical/element_5"
+          "@id": "amf://id#16/source-map/lexical/element_1"
+        },
+        {
+          "@id": "amf://id#16/source-map/lexical/element_0"
+        },
+        {
+          "@id": "amf://id#16/source-map/lexical/element_2"
+        },
+        {
+          "@id": "amf://id#16/source-map/lexical/element_4"
         }
       ]
     },
@@ -350,6 +352,7 @@
       "@id": "amf://id#40",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -372,6 +375,7 @@
       "@id": "amf://id#32",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -391,9 +395,6 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#31/source-map/lexical/element_1"
-        },
-        {
           "@id": "amf://id#31/source-map/lexical/element_0"
         }
       ]
@@ -402,6 +403,7 @@
       "@id": "amf://id#19",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/vnd.api+json",
@@ -438,6 +440,7 @@
       "@id": "amf://id#21",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/vnd.api+json",
@@ -474,6 +477,7 @@
       "@id": "amf://id#23",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/vnd.api+json",
@@ -518,29 +522,9 @@
       ]
     },
     {
-      "@id": "amf://id#16/source-map/lexical/element_6",
+      "@id": "amf://id#16/source-map/lexical/element_5",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#tag",
       "http://a.ml/vocabularies/document-source-maps#value": "[(34,6)-(36,0)]"
-    },
-    {
-      "@id": "amf://id#16/source-map/lexical/element_4",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(33,6)-(34,0)]"
-    },
-    {
-      "@id": "amf://id#16/source-map/lexical/element_2",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(32,6)-(33,0)]"
-    },
-    {
-      "@id": "amf://id#16/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#operationId",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(33,6)-(34,0)]"
-    },
-    {
-      "@id": "amf://id#16/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#returns",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(36,6)-(63,0)]"
     },
     {
       "@id": "amf://id#16/source-map/lexical/element_3",
@@ -548,9 +532,24 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(31,4)-(75,34)]"
     },
     {
-      "@id": "amf://id#16/source-map/lexical/element_5",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#expects",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(63,6)-(75,34)]"
+      "@id": "amf://id#16/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#returns",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(36,6)-(63,0)]"
+    },
+    {
+      "@id": "amf://id#16/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#operationId",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(33,6)-(34,0)]"
+    },
+    {
+      "@id": "amf://id#16/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(33,6)-(34,0)]"
+    },
+    {
+      "@id": "amf://id#16/source-map/lexical/element_4",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(32,6)-(33,0)]"
     },
     {
       "@id": "amf://id#41",
@@ -648,11 +647,6 @@
           "@id": "amf://id#32/source-map/lexical/element_1"
         }
       ]
-    },
-    {
-      "@id": "amf://id#31/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#31",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(63,6)-(75,34)]"
     },
     {
       "@id": "amf://id#31/source-map/lexical/element_0",

--- a/test/data/production/json-api/negative3.yaml.report.jsonld
+++ b/test/data/production/json-api/negative3.yaml.report.jsonld
@@ -106,39 +106,6 @@
               "shacl:ValidationResult"
             ],
             "focusNode": "amf://id#31",
-            "location": {
-              "@id": "violation_0_location",
-              "@type": [
-                "lexicalSchema:LocationNode",
-                "lexical:Location"
-              ],
-              "range": {
-                "@id": "violation_0_location_range",
-                "@type": [
-                  "lexicalSchema:RangeNode",
-                  "lexical:Range"
-                ],
-                "end": {
-                  "@id": "violation_0_location_range_end",
-                  "@type": [
-                    "lexicalSchema:PositionNode",
-                    "lexical:Position"
-                  ],
-                  "column": 34,
-                  "line": 75
-                },
-                "start": {
-                  "@id": "violation_0_location_range_start",
-                  "@type": [
-                    "lexicalSchema:PositionNode",
-                    "lexical:Position"
-                  ],
-                  "column": 6,
-                  "line": 63
-                }
-              },
-              "uri": "file://./test/data/production/json-api/negative3.yaml"
-            },
             "resultMessage": "Clients MUST send all JSON:API data in request documents with the header Content-Type: application/vnd.api+json\nwithout any media type parameters.\nClients that include the JSON:API media type in their Accept header MUST specify the media type there at least once\nwithout any media type parameters.\nClients MUST ignore any parameters for the application/vnd.api+json media type received in the Content-Type header\nof response documents.\n",
             "resultSeverity": "http://www.w3.org/ns/shacl#Violation",
             "sourceShapeName": "json-api-media-type-request",
@@ -150,39 +117,6 @@
                   "validation:TraceMessage"
                 ],
                 "component": "in",
-                "location": {
-                  "@id": "violation_0_0_location",
-                  "@type": [
-                    "lexicalSchema:LocationNode",
-                    "lexical:Location"
-                  ],
-                  "range": {
-                    "@id": "violation_0_0_location_range",
-                    "@type": [
-                      "lexicalSchema:RangeNode",
-                      "lexical:Range"
-                    ],
-                    "end": {
-                      "@id": "violation_0_0_location_range_end",
-                      "@type": [
-                        "lexicalSchema:PositionNode",
-                        "lexical:Position"
-                      ],
-                      "column": 34,
-                      "line": 75
-                    },
-                    "start": {
-                      "@id": "violation_0_0_location_range_start",
-                      "@type": [
-                        "lexicalSchema:PositionNode",
-                        "lexical:Position"
-                      ],
-                      "column": 6,
-                      "line": 63
-                    }
-                  },
-                  "uri": "file://./test/data/production/json-api/negative3.yaml"
-                },
                 "resultPath": "http://a.ml/vocabularies/apiContract#payload / http://a.ml/vocabularies/core#mediaType",
                 "traceValue": {
                   "@id": "violation_0_0_traceValue",

--- a/test/data/production/json-api/negative3b.yaml.jsonld
+++ b/test/data/production/json-api/negative3b.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -123,6 +123,7 @@
       "@id": "amf://id#16",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -216,6 +217,7 @@
       "@id": "amf://id#31",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -240,6 +242,7 @@
       "@id": "amf://id#18",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -261,6 +264,7 @@
       "@id": "amf://id#20",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -282,6 +286,7 @@
       "@id": "amf://id#22",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -319,25 +324,22 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#16/source-map/lexical/element_6"
-        },
-        {
-          "@id": "amf://id#16/source-map/lexical/element_4"
-        },
-        {
-          "@id": "amf://id#16/source-map/lexical/element_2"
-        },
-        {
-          "@id": "amf://id#16/source-map/lexical/element_0"
-        },
-        {
-          "@id": "amf://id#16/source-map/lexical/element_1"
+          "@id": "amf://id#16/source-map/lexical/element_5"
         },
         {
           "@id": "amf://id#16/source-map/lexical/element_3"
         },
         {
-          "@id": "amf://id#16/source-map/lexical/element_5"
+          "@id": "amf://id#16/source-map/lexical/element_1"
+        },
+        {
+          "@id": "amf://id#16/source-map/lexical/element_0"
+        },
+        {
+          "@id": "amf://id#16/source-map/lexical/element_2"
+        },
+        {
+          "@id": "amf://id#16/source-map/lexical/element_4"
         }
       ]
     },
@@ -350,6 +352,7 @@
       "@id": "amf://id#40",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -372,6 +375,7 @@
       "@id": "amf://id#32",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/vnd.api+json",
@@ -391,9 +395,6 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#31/source-map/lexical/element_1"
-        },
-        {
           "@id": "amf://id#31/source-map/lexical/element_0"
         }
       ]
@@ -402,6 +403,7 @@
       "@id": "amf://id#19",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/vnd.api+json",
@@ -438,6 +440,7 @@
       "@id": "amf://id#21",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/vnd.api+json",
@@ -474,6 +477,7 @@
       "@id": "amf://id#23",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -518,29 +522,9 @@
       ]
     },
     {
-      "@id": "amf://id#16/source-map/lexical/element_6",
+      "@id": "amf://id#16/source-map/lexical/element_5",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#tag",
       "http://a.ml/vocabularies/document-source-maps#value": "[(35,6)-(37,0)]"
-    },
-    {
-      "@id": "amf://id#16/source-map/lexical/element_4",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(34,6)-(35,0)]"
-    },
-    {
-      "@id": "amf://id#16/source-map/lexical/element_2",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(33,6)-(34,0)]"
-    },
-    {
-      "@id": "amf://id#16/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#operationId",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(34,6)-(35,0)]"
-    },
-    {
-      "@id": "amf://id#16/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#returns",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(37,6)-(64,0)]"
     },
     {
       "@id": "amf://id#16/source-map/lexical/element_3",
@@ -548,9 +532,24 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(32,4)-(76,34)]"
     },
     {
-      "@id": "amf://id#16/source-map/lexical/element_5",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#expects",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(64,6)-(76,34)]"
+      "@id": "amf://id#16/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#returns",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(37,6)-(64,0)]"
+    },
+    {
+      "@id": "amf://id#16/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#operationId",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(34,6)-(35,0)]"
+    },
+    {
+      "@id": "amf://id#16/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(34,6)-(35,0)]"
+    },
+    {
+      "@id": "amf://id#16/source-map/lexical/element_4",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(33,6)-(34,0)]"
     },
     {
       "@id": "amf://id#41",
@@ -648,11 +647,6 @@
           "@id": "amf://id#32/source-map/lexical/element_1"
         }
       ]
-    },
-    {
-      "@id": "amf://id#31/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#31",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(64,6)-(76,34)]"
     },
     {
       "@id": "amf://id#31/source-map/lexical/element_0",

--- a/test/data/production/json-api/negative4.yaml.jsonld
+++ b/test/data/production/json-api/negative4.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -123,6 +123,7 @@
       "@id": "amf://id#16",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -213,6 +214,7 @@
       "@id": "amf://id#22",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -226,6 +228,7 @@
       "@id": "amf://id#18",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -247,6 +250,7 @@
       "@id": "amf://id#20",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -312,6 +316,7 @@
       "@id": "amf://id#23",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -334,6 +339,7 @@
       "@id": "amf://id#19",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/vnd.api+json",
@@ -370,6 +376,7 @@
       "@id": "amf://id#21",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/vnd.api+json",

--- a/test/data/production/json-api/negative4b.yaml.jsonld
+++ b/test/data/production/json-api/negative4b.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -123,6 +123,7 @@
       "@id": "amf://id#16",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -213,6 +214,7 @@
       "@id": "amf://id#22",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -226,6 +228,7 @@
       "@id": "amf://id#18",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -247,6 +250,7 @@
       "@id": "amf://id#20",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -312,6 +316,7 @@
       "@id": "amf://id#23",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -334,6 +339,7 @@
       "@id": "amf://id#19",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/vnd.api+json",
@@ -370,6 +376,7 @@
       "@id": "amf://id#21",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/vnd.api+json",

--- a/test/data/production/json-api/negative5.yaml.jsonld
+++ b/test/data/production/json-api/negative5.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -123,6 +123,7 @@
       "@id": "amf://id#16",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -216,6 +217,7 @@
       "@id": "amf://id#29",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -229,6 +231,7 @@
       "@id": "amf://id#18",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -250,6 +253,7 @@
       "@id": "amf://id#20",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -271,6 +275,7 @@
       "@id": "amf://id#22",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -336,6 +341,7 @@
       "@id": "amf://id#30",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -358,6 +364,7 @@
       "@id": "amf://id#19",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/vnd.api+json",
@@ -394,6 +401,7 @@
       "@id": "amf://id#21",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/vnd.api+json",
@@ -430,6 +438,7 @@
       "@id": "amf://id#23",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/vnd.api+json",

--- a/test/data/production/json-api/negative6.yaml.jsonld
+++ b/test/data/production/json-api/negative6.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -123,6 +123,7 @@
       "@id": "amf://id#17",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -216,6 +217,7 @@
       "@id": "amf://id#25",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -229,6 +231,7 @@
       "@id": "amf://id#19",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -250,6 +253,7 @@
       "@id": "amf://id#21",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -271,6 +275,7 @@
       "@id": "amf://id#23",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -336,6 +341,7 @@
       "@id": "amf://id#26",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -358,6 +364,7 @@
       "@id": "amf://id#20",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/vnd.api+json",
@@ -394,6 +401,7 @@
       "@id": "amf://id#22",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/vnd.api+json",
@@ -430,6 +438,7 @@
       "@id": "amf://id#24",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/vnd.api+json",

--- a/test/data/production/json-api/negative7.yaml.jsonld
+++ b/test/data/production/json-api/negative7.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -123,6 +123,7 @@
       "@id": "amf://id#16",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -216,6 +217,7 @@
       "@id": "amf://id#29",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -229,6 +231,7 @@
       "@id": "amf://id#18",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -250,6 +253,7 @@
       "@id": "amf://id#20",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -271,6 +275,7 @@
       "@id": "amf://id#22",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -336,6 +341,7 @@
       "@id": "amf://id#30",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -358,6 +364,7 @@
       "@id": "amf://id#19",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/vnd.api+json",
@@ -394,6 +401,7 @@
       "@id": "amf://id#21",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/vnd.api+json",
@@ -430,6 +438,7 @@
       "@id": "amf://id#23",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/vnd.api+json",

--- a/test/data/production/json-api/negative8.yaml.jsonld
+++ b/test/data/production/json-api/negative8.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -123,6 +123,7 @@
       "@id": "amf://id#27",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -216,6 +217,7 @@
       "@id": "amf://id#35",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -229,6 +231,7 @@
       "@id": "amf://id#29",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -250,6 +253,7 @@
       "@id": "amf://id#31",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -271,6 +275,7 @@
       "@id": "amf://id#33",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -336,6 +341,7 @@
       "@id": "amf://id#36",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -358,6 +364,7 @@
       "@id": "amf://id#30",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/vnd.api+json",
@@ -394,6 +401,7 @@
       "@id": "amf://id#32",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/vnd.api+json",
@@ -430,6 +438,7 @@
       "@id": "amf://id#34",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/vnd.api+json",

--- a/test/data/production/json-api/negative9.yaml.jsonld
+++ b/test/data/production/json-api/negative9.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -123,6 +123,7 @@
       "@id": "amf://id#21",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -216,6 +217,7 @@
       "@id": "amf://id#29",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -229,6 +231,7 @@
       "@id": "amf://id#23",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -250,6 +253,7 @@
       "@id": "amf://id#25",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -271,6 +275,7 @@
       "@id": "amf://id#27",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -336,6 +341,7 @@
       "@id": "amf://id#30",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -358,6 +364,7 @@
       "@id": "amf://id#24",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/vnd.api+json",
@@ -394,6 +401,7 @@
       "@id": "amf://id#26",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/vnd.api+json",
@@ -430,6 +438,7 @@
       "@id": "amf://id#28",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/vnd.api+json",

--- a/test/data/production/json-api/positive1.yaml.jsonld
+++ b/test/data/production/json-api/positive1.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -123,6 +123,7 @@
       "@id": "amf://id#25",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -216,6 +217,7 @@
       "@id": "amf://id#33",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -229,6 +231,7 @@
       "@id": "amf://id#27",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -250,6 +253,7 @@
       "@id": "amf://id#29",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -271,6 +275,7 @@
       "@id": "amf://id#31",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -336,6 +341,7 @@
       "@id": "amf://id#34",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -358,6 +364,7 @@
       "@id": "amf://id#28",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/vnd.api+json",
@@ -394,6 +401,7 @@
       "@id": "amf://id#30",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/vnd.api+json",
@@ -430,6 +438,7 @@
       "@id": "amf://id#32",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/vnd.api+json",

--- a/test/data/production/json-api/positive10.yaml.jsonld
+++ b/test/data/production/json-api/positive10.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -123,6 +123,7 @@
       "@id": "amf://id#25",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -216,6 +217,7 @@
       "@id": "amf://id#33",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -240,6 +242,7 @@
       "@id": "amf://id#27",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -261,6 +264,7 @@
       "@id": "amf://id#29",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -282,6 +286,7 @@
       "@id": "amf://id#31",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -319,25 +324,22 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#25/source-map/lexical/element_6"
-        },
-        {
-          "@id": "amf://id#25/source-map/lexical/element_4"
-        },
-        {
-          "@id": "amf://id#25/source-map/lexical/element_2"
-        },
-        {
-          "@id": "amf://id#25/source-map/lexical/element_0"
-        },
-        {
-          "@id": "amf://id#25/source-map/lexical/element_1"
+          "@id": "amf://id#25/source-map/lexical/element_5"
         },
         {
           "@id": "amf://id#25/source-map/lexical/element_3"
         },
         {
-          "@id": "amf://id#25/source-map/lexical/element_5"
+          "@id": "amf://id#25/source-map/lexical/element_1"
+        },
+        {
+          "@id": "amf://id#25/source-map/lexical/element_0"
+        },
+        {
+          "@id": "amf://id#25/source-map/lexical/element_2"
+        },
+        {
+          "@id": "amf://id#25/source-map/lexical/element_4"
         }
       ]
     },
@@ -350,6 +352,7 @@
       "@id": "amf://id#40",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -372,6 +375,7 @@
       "@id": "amf://id#34",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/vnd.api+json",
@@ -391,9 +395,6 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#33/source-map/lexical/element_1"
-        },
-        {
           "@id": "amf://id#33/source-map/lexical/element_0"
         }
       ]
@@ -402,6 +403,7 @@
       "@id": "amf://id#28",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/vnd.api+json",
@@ -438,6 +440,7 @@
       "@id": "amf://id#30",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/vnd.api+json",
@@ -474,6 +477,7 @@
       "@id": "amf://id#32",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/vnd.api+json",
@@ -518,29 +522,9 @@
       ]
     },
     {
-      "@id": "amf://id#25/source-map/lexical/element_6",
+      "@id": "amf://id#25/source-map/lexical/element_5",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#tag",
       "http://a.ml/vocabularies/document-source-maps#value": "[(45,6)-(47,0)]"
-    },
-    {
-      "@id": "amf://id#25/source-map/lexical/element_4",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(44,6)-(45,0)]"
-    },
-    {
-      "@id": "amf://id#25/source-map/lexical/element_2",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(43,6)-(44,0)]"
-    },
-    {
-      "@id": "amf://id#25/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#operationId",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(44,6)-(45,0)]"
-    },
-    {
-      "@id": "amf://id#25/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#returns",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(58,6)-(77,0)]"
     },
     {
       "@id": "amf://id#25/source-map/lexical/element_3",
@@ -548,9 +532,24 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(42,4)-(77,0)]"
     },
     {
-      "@id": "amf://id#25/source-map/lexical/element_5",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#expects",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(47,6)-(58,0)]"
+      "@id": "amf://id#25/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#returns",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(58,6)-(77,0)]"
+    },
+    {
+      "@id": "amf://id#25/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#operationId",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(44,6)-(45,0)]"
+    },
+    {
+      "@id": "amf://id#25/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(44,6)-(45,0)]"
+    },
+    {
+      "@id": "amf://id#25/source-map/lexical/element_4",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(43,6)-(44,0)]"
     },
     {
       "@id": "amf://id#41",
@@ -648,11 +647,6 @@
           "@id": "amf://id#34/source-map/lexical/element_1"
         }
       ]
-    },
-    {
-      "@id": "amf://id#33/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#33",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(47,6)-(58,0)]"
     },
     {
       "@id": "amf://id#33/source-map/lexical/element_0",

--- a/test/data/production/json-api/positive9.yaml.jsonld
+++ b/test/data/production/json-api/positive9.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -123,6 +123,7 @@
       "@id": "amf://id#21",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -216,6 +217,7 @@
       "@id": "amf://id#29",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -229,6 +231,7 @@
       "@id": "amf://id#23",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -250,6 +253,7 @@
       "@id": "amf://id#25",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -271,6 +275,7 @@
       "@id": "amf://id#27",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -336,6 +341,7 @@
       "@id": "amf://id#30",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -358,6 +364,7 @@
       "@id": "amf://id#24",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/vnd.api+json",
@@ -394,6 +401,7 @@
       "@id": "amf://id#26",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/vnd.api+json",
@@ -430,6 +438,7 @@
       "@id": "amf://id#28",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/vnd.api+json",

--- a/test/data/production/owasp/negative1.yaml.jsonld
+++ b/test/data/production/owasp/negative1.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -123,6 +123,7 @@
       "@id": "amf://id#5",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -213,6 +214,7 @@
       "@id": "amf://id#13",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -229,6 +231,7 @@
       "@id": "amf://id#7",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -250,6 +253,7 @@
       "@id": "amf://id#10",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -315,6 +319,7 @@
       "@id": "amf://id#14",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "itemId",
@@ -337,6 +342,7 @@
       "@id": "amf://id#16",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -359,6 +365,7 @@
       "@id": "amf://id#8",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -395,6 +402,7 @@
       "@id": "amf://id#11",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/owasp/negative2.yaml.jsonld
+++ b/test/data/production/owasp/negative2.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -123,6 +123,7 @@
       "@id": "amf://id#5",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -201,6 +202,7 @@
       "@id": "amf://id#6",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -217,6 +219,7 @@
       "@id": "amf://id#7",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -277,6 +280,7 @@
       "@id": "amf://id#8",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/owasp/negative3.yaml.jsonld
+++ b/test/data/production/owasp/negative3.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -126,6 +126,7 @@
       "@id": "amf://id#5",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -157,6 +158,7 @@
       "@id": "amf://id#10",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "head",
@@ -231,6 +233,7 @@
       "@id": "amf://id#7",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -291,6 +294,7 @@
       "@id": "amf://id#11",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -330,6 +334,7 @@
       "@id": "amf://id#8",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -407,6 +412,7 @@
       "@id": "amf://id#12",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/owasp/negative4.yaml.jsonld
+++ b/test/data/production/owasp/negative4.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -126,6 +126,7 @@
       "@id": "amf://id#5",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -160,6 +161,7 @@
       "@id": "amf://id#13",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "head",
@@ -234,6 +236,7 @@
       "@id": "amf://id#7",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -255,6 +258,7 @@
       "@id": "amf://id#10",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -314,6 +318,7 @@
       "@id": "amf://id#14",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -353,6 +358,7 @@
       "@id": "amf://id#8",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -389,6 +395,7 @@
       "@id": "amf://id#11",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -463,6 +470,7 @@
       "@id": "amf://id#15",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/owasp/negative5.yaml.jsonld
+++ b/test/data/production/owasp/negative5.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -123,6 +123,7 @@
       "@id": "amf://id#5",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -213,6 +214,7 @@
       "@id": "amf://id#13",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -231,6 +233,7 @@
       "@id": "amf://id#7",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -252,6 +255,7 @@
       "@id": "amf://id#10",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -317,6 +321,7 @@
       "@id": "amf://id#14",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "itemId",
@@ -341,6 +346,7 @@
       "@id": "amf://id#16",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -363,6 +369,7 @@
       "@id": "amf://id#8",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -399,6 +406,7 @@
       "@id": "amf://id#11",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/owasp/negative6.yaml.jsonld
+++ b/test/data/production/owasp/negative6.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -79,6 +79,7 @@
       "@id": "amf://id#4",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -139,6 +140,7 @@
       "@id": "amf://id#6",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -160,6 +162,7 @@
       "@id": "amf://id#9",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -225,6 +228,7 @@
       "@id": "amf://id#7",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -261,6 +265,7 @@
       "@id": "amf://id#10",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/owasp/negative6b.yaml.jsonld
+++ b/test/data/production/owasp/negative6b.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -119,6 +119,7 @@
       "@id": "amf://id#5",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -199,6 +200,7 @@
       "@id": "amf://id#7",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -220,6 +222,7 @@
       "@id": "amf://id#10",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -285,6 +288,7 @@
       "@id": "amf://id#8",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -321,6 +325,7 @@
       "@id": "amf://id#11",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/owasp/negative7.yaml.jsonld
+++ b/test/data/production/owasp/negative7.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -119,6 +119,7 @@
       "@id": "amf://id#5",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -199,6 +200,7 @@
       "@id": "amf://id#7",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -220,6 +222,7 @@
       "@id": "amf://id#10",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -285,6 +288,7 @@
       "@id": "amf://id#8",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -321,6 +325,7 @@
       "@id": "amf://id#11",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/owasp/negative8.yaml.jsonld
+++ b/test/data/production/owasp/negative8.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -160,6 +160,7 @@
       "@id": "amf://id#6",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -263,6 +264,7 @@
       "@id": "amf://id#8",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -284,6 +286,7 @@
       "@id": "amf://id#11",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -349,6 +352,7 @@
       "@id": "amf://id#9",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -385,6 +389,7 @@
       "@id": "amf://id#12",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/owasp/negative9.yaml.jsonld
+++ b/test/data/production/owasp/negative9.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -160,6 +160,7 @@
       "@id": "amf://id#8",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -263,6 +264,7 @@
       "@id": "amf://id#10",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -284,6 +286,7 @@
       "@id": "amf://id#13",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -349,6 +352,7 @@
       "@id": "amf://id#11",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -385,6 +389,7 @@
       "@id": "amf://id#14",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/owasp/negative9b.yaml.jsonld
+++ b/test/data/production/owasp/negative9b.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -189,6 +189,7 @@
       "@id": "amf://id#8",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -237,6 +238,7 @@
       "@id": "amf://id#17",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -345,6 +347,7 @@
       "@id": "amf://id#10",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -366,6 +369,7 @@
       "@id": "amf://id#13",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -431,6 +435,7 @@
       "@id": "amf://id#19",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -452,6 +457,7 @@
       "@id": "amf://id#22",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -534,6 +540,7 @@
       "@id": "amf://id#11",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -570,6 +577,7 @@
       "@id": "amf://id#14",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -647,6 +655,7 @@
       "@id": "amf://id#20",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -683,6 +692,7 @@
       "@id": "amf://id#23",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/owasp/positive1.yaml.jsonld
+++ b/test/data/production/owasp/positive1.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -123,6 +123,7 @@
       "@id": "amf://id#7",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -206,6 +207,7 @@
       "@id": "amf://id#8",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -227,6 +229,7 @@
       "@id": "amf://id#11",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -287,6 +290,7 @@
       "@id": "amf://id#9",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -323,6 +327,7 @@
       "@id": "amf://id#12",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/owasp/positive2.yaml.jsonld
+++ b/test/data/production/owasp/positive2.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -123,6 +123,7 @@
       "@id": "amf://id#7",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -218,6 +219,7 @@
       "@id": "amf://id#17",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -234,6 +236,7 @@
       "@id": "amf://id#9",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -255,6 +258,7 @@
       "@id": "amf://id#12",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -337,6 +341,7 @@
       "@id": "amf://id#18",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "itemId",
@@ -359,6 +364,7 @@
       "@id": "amf://id#20",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -381,6 +387,7 @@
       "@id": "amf://id#10",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -417,6 +424,7 @@
       "@id": "amf://id#13",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/owasp/positive3.yaml.jsonld
+++ b/test/data/production/owasp/positive3.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -126,6 +126,7 @@
       "@id": "amf://id#7",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -165,6 +166,7 @@
       "@id": "amf://id#17",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "head",
@@ -244,6 +246,7 @@
       "@id": "amf://id#9",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -265,6 +268,7 @@
       "@id": "amf://id#12",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -341,6 +345,7 @@
       "@id": "amf://id#18",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -380,6 +385,7 @@
       "@id": "amf://id#10",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -416,6 +422,7 @@
       "@id": "amf://id#13",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -517,6 +524,7 @@
       "@id": "amf://id#19",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/owasp/positive4.yaml.jsonld
+++ b/test/data/production/owasp/positive4.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -126,6 +126,7 @@
       "@id": "amf://id#7",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -165,6 +166,7 @@
       "@id": "amf://id#17",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "head",
@@ -244,6 +246,7 @@
       "@id": "amf://id#9",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -265,6 +268,7 @@
       "@id": "amf://id#12",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -341,6 +345,7 @@
       "@id": "amf://id#18",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -380,6 +385,7 @@
       "@id": "amf://id#10",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -416,6 +422,7 @@
       "@id": "amf://id#13",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -517,6 +524,7 @@
       "@id": "amf://id#19",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/owasp/positive5.yaml.jsonld
+++ b/test/data/production/owasp/positive5.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -123,6 +123,7 @@
       "@id": "amf://id#7",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -218,6 +219,7 @@
       "@id": "amf://id#17",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -239,6 +241,7 @@
       "@id": "amf://id#9",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -260,6 +263,7 @@
       "@id": "amf://id#12",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -342,6 +346,7 @@
       "@id": "amf://id#18",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "itemId",
@@ -366,6 +371,7 @@
       "@id": "amf://id#20",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "limit",
@@ -390,6 +396,7 @@
       "@id": "amf://id#22",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -412,6 +419,7 @@
       "@id": "amf://id#10",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -448,6 +456,7 @@
       "@id": "amf://id#13",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/owasp/positive6.yaml.jsonld
+++ b/test/data/production/owasp/positive6.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -123,6 +123,7 @@
       "@id": "amf://id#7",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -213,6 +214,7 @@
       "@id": "amf://id#9",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -234,6 +236,7 @@
       "@id": "amf://id#12",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -316,6 +319,7 @@
       "@id": "amf://id#10",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -352,6 +356,7 @@
       "@id": "amf://id#13",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/owasp/positive7.yaml.jsonld
+++ b/test/data/production/owasp/positive7.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -123,6 +123,7 @@
       "@id": "amf://id#7",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -213,6 +214,7 @@
       "@id": "amf://id#9",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -234,6 +236,7 @@
       "@id": "amf://id#12",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -316,6 +319,7 @@
       "@id": "amf://id#10",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -352,6 +356,7 @@
       "@id": "amf://id#13",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/owasp/positive8.yaml.jsonld
+++ b/test/data/production/owasp/positive8.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -160,6 +160,7 @@
       "@id": "amf://id#8",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -268,6 +269,7 @@
       "@id": "amf://id#10",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -289,6 +291,7 @@
       "@id": "amf://id#13",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -371,6 +374,7 @@
       "@id": "amf://id#11",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -407,6 +411,7 @@
       "@id": "amf://id#14",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/owasp/positive9.yaml.jsonld
+++ b/test/data/production/owasp/positive9.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -160,6 +160,7 @@
       "@id": "amf://id#8",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -268,6 +269,7 @@
       "@id": "amf://id#10",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -289,6 +291,7 @@
       "@id": "amf://id#13",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -371,6 +374,7 @@
       "@id": "amf://id#11",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -407,6 +411,7 @@
       "@id": "amf://id#14",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/security/negative1.yaml.jsonld
+++ b/test/data/production/security/negative1.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -123,6 +123,7 @@
       "@id": "amf://id#13",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -210,6 +211,7 @@
       "@id": "amf://id#17",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -228,6 +230,7 @@
       "@id": "amf://id#15",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -293,6 +296,7 @@
       "@id": "amf://id#18",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "args",
@@ -317,6 +321,7 @@
       "@id": "amf://id#21",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -339,6 +344,7 @@
       "@id": "amf://id#16",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/security/negative10.yaml.jsonld
+++ b/test/data/production/security/negative10.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -123,6 +123,7 @@
       "@id": "amf://id#13",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -215,6 +216,7 @@
       "@id": "amf://id#19",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -233,6 +235,7 @@
       "@id": "amf://id#15",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -315,6 +318,7 @@
       "@id": "amf://id#20",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "args",
@@ -339,6 +343,7 @@
       "@id": "amf://id#23",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -361,6 +366,7 @@
       "@id": "amf://id#16",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/security/negative11.yaml.jsonld
+++ b/test/data/production/security/negative11.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -123,6 +123,7 @@
       "@id": "amf://id#13",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -215,6 +216,7 @@
       "@id": "amf://id#19",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -233,6 +235,7 @@
       "@id": "amf://id#15",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -315,6 +318,7 @@
       "@id": "amf://id#20",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "args",
@@ -339,6 +343,7 @@
       "@id": "amf://id#23",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -361,6 +366,7 @@
       "@id": "amf://id#16",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/security/negative12.yaml.jsonld
+++ b/test/data/production/security/negative12.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -79,6 +79,7 @@
       "@id": "amf://id#15",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -151,6 +152,7 @@
       "@id": "amf://id#26",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -169,6 +171,7 @@
       "@id": "amf://id#17",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -268,6 +271,7 @@
       "@id": "amf://id#27",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "args",
@@ -292,6 +296,7 @@
       "@id": "amf://id#30",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -314,6 +319,7 @@
       "@id": "amf://id#18",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/security/negative13.yaml.jsonld
+++ b/test/data/production/security/negative13.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -123,6 +123,7 @@
       "@id": "amf://id#18",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -215,6 +216,7 @@
       "@id": "amf://id#24",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -233,6 +235,7 @@
       "@id": "amf://id#20",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -315,6 +318,7 @@
       "@id": "amf://id#25",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "args",
@@ -339,6 +343,7 @@
       "@id": "amf://id#28",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -361,6 +366,7 @@
       "@id": "amf://id#21",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/security/negative14.yaml.jsonld
+++ b/test/data/production/security/negative14.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -123,6 +123,7 @@
       "@id": "amf://id#15",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -215,6 +216,7 @@
       "@id": "amf://id#21",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -233,6 +235,7 @@
       "@id": "amf://id#17",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -315,6 +318,7 @@
       "@id": "amf://id#22",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "args",
@@ -339,6 +343,7 @@
       "@id": "amf://id#25",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -361,6 +366,7 @@
       "@id": "amf://id#18",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/security/negative15.yaml.jsonld
+++ b/test/data/production/security/negative15.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -197,6 +197,7 @@
       "@id": "amf://id#15",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -325,6 +326,7 @@
       "@id": "amf://id#21",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -343,6 +345,7 @@
       "@id": "amf://id#17",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -425,6 +428,7 @@
       "@id": "amf://id#22",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "args",
@@ -449,6 +453,7 @@
       "@id": "amf://id#25",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -471,6 +476,7 @@
       "@id": "amf://id#18",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/security/negative16.yaml.jsonld
+++ b/test/data/production/security/negative16.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -123,6 +123,7 @@
       "@id": "amf://id#18",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -215,6 +216,7 @@
       "@id": "amf://id#24",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -233,6 +235,7 @@
       "@id": "amf://id#20",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -315,6 +318,7 @@
       "@id": "amf://id#25",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "args",
@@ -339,6 +343,7 @@
       "@id": "amf://id#28",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -361,6 +366,7 @@
       "@id": "amf://id#21",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/security/negative17.yaml.jsonld
+++ b/test/data/production/security/negative17.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -126,6 +126,7 @@
       "@id": "amf://id#10",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -162,6 +163,7 @@
       "@id": "amf://id#22",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "put",
@@ -249,6 +251,7 @@
       "@id": "amf://id#12",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -326,6 +329,7 @@
       "@id": "amf://id#24",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -391,6 +395,7 @@
       "@id": "amf://id#13",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -498,6 +503,7 @@
       "@id": "amf://id#25",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/security/negative2.yaml.jsonld
+++ b/test/data/production/security/negative2.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -123,6 +123,7 @@
       "@id": "amf://id#13",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -210,6 +211,7 @@
       "@id": "amf://id#17",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -228,6 +230,7 @@
       "@id": "amf://id#15",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -293,6 +296,7 @@
       "@id": "amf://id#18",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "args",
@@ -317,6 +321,7 @@
       "@id": "amf://id#21",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -339,6 +344,7 @@
       "@id": "amf://id#16",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/security/negative3.yaml.jsonld
+++ b/test/data/production/security/negative3.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -149,6 +149,7 @@
       "@id": "amf://id#14",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -191,6 +192,7 @@
       "@id": "amf://id#20",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -283,6 +285,7 @@
       "@id": "amf://id#16",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -348,6 +351,7 @@
       "@id": "amf://id#26",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -366,6 +370,7 @@
       "@id": "amf://id#22",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -448,6 +453,7 @@
       "@id": "amf://id#17",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -525,6 +531,7 @@
       "@id": "amf://id#27",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "args",
@@ -549,6 +556,7 @@
       "@id": "amf://id#30",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -571,6 +579,7 @@
       "@id": "amf://id#23",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/security/negative4.yaml.jsonld
+++ b/test/data/production/security/negative4.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -123,6 +123,7 @@
       "@id": "amf://id#10",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -210,6 +211,7 @@
       "@id": "amf://id#12",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],

--- a/test/data/production/security/negative5.yaml.jsonld
+++ b/test/data/production/security/negative5.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -123,6 +123,7 @@
       "@id": "amf://id#10",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -210,6 +211,7 @@
       "@id": "amf://id#12",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],

--- a/test/data/production/security/negative6.yaml.jsonld
+++ b/test/data/production/security/negative6.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -123,6 +123,7 @@
       "@id": "amf://id#10",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -210,6 +211,7 @@
       "@id": "amf://id#12",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],

--- a/test/data/production/security/negative7.yaml.jsonld
+++ b/test/data/production/security/negative7.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -123,6 +123,7 @@
       "@id": "amf://id#11",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -210,6 +211,7 @@
       "@id": "amf://id#13",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -292,6 +294,7 @@
       "@id": "amf://id#14",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/security/negative8.yaml.jsonld
+++ b/test/data/production/security/negative8.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -123,6 +123,7 @@
       "@id": "amf://id#7",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -210,6 +211,7 @@
       "@id": "amf://id#9",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],

--- a/test/data/production/security/negative9.yaml.jsonld
+++ b/test/data/production/security/negative9.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -123,6 +123,7 @@
       "@id": "amf://id#7",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -210,6 +211,7 @@
       "@id": "amf://id#9",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],

--- a/test/data/production/security/positive1.yaml.jsonld
+++ b/test/data/production/security/positive1.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -123,6 +123,7 @@
       "@id": "amf://id#13",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -215,6 +216,7 @@
       "@id": "amf://id#19",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -233,6 +235,7 @@
       "@id": "amf://id#15",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -315,6 +318,7 @@
       "@id": "amf://id#20",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "args",
@@ -339,6 +343,7 @@
       "@id": "amf://id#23",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -361,6 +366,7 @@
       "@id": "amf://id#16",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/security/positive3.yaml.jsonld
+++ b/test/data/production/security/positive3.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -149,6 +149,7 @@
       "@id": "amf://id#14",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -196,6 +197,7 @@
       "@id": "amf://id#22",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -288,6 +290,7 @@
       "@id": "amf://id#16",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -370,6 +373,7 @@
       "@id": "amf://id#28",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -388,6 +392,7 @@
       "@id": "amf://id#24",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -470,6 +475,7 @@
       "@id": "amf://id#17",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -574,6 +580,7 @@
       "@id": "amf://id#29",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "args",
@@ -598,6 +605,7 @@
       "@id": "amf://id#32",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -620,6 +628,7 @@
       "@id": "amf://id#25",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/security/positive4.yaml.jsonld
+++ b/test/data/production/security/positive4.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -123,6 +123,7 @@
       "@id": "amf://id#10",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -210,6 +211,7 @@
       "@id": "amf://id#12",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -292,6 +294,7 @@
       "@id": "amf://id#13",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/spectral/negative1.yaml.jsonld
+++ b/test/data/production/spectral/negative1.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -179,6 +179,7 @@
       "@id": "amf://id#7",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -298,6 +299,7 @@
       "@id": "amf://id#9",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],

--- a/test/data/production/spectral/negative10.yaml.jsonld
+++ b/test/data/production/spectral/negative10.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -157,6 +157,7 @@
       "@id": "amf://id#6",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -259,6 +260,7 @@
       "@id": "amf://id#9",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -272,6 +274,7 @@
       "@id": "amf://id#8",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -332,6 +335,7 @@
       "@id": "amf://id#10",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",

--- a/test/data/production/spectral/negative10.yaml.report.jsonld
+++ b/test/data/production/spectral/negative10.yaml.report.jsonld
@@ -96,30 +96,30 @@
           "reportSchema:ReportNode",
           "shacl:ValidationReport"
         ],
-        "conforms": true,
+        "conforms": false,
         "profileName": "Spectral Base",
         "result": [
           {
-            "@id": "warning_0",
+            "@id": "violation_0",
             "@type": [
               "reportSchema:ValidationResultNode",
               "shacl:ValidationResult"
             ],
             "focusNode": "amf://id#2",
             "location": {
-              "@id": "warning_0_location",
+              "@id": "violation_0_location",
               "@type": [
                 "lexicalSchema:LocationNode",
                 "lexical:Location"
               ],
               "range": {
-                "@id": "warning_0_location_range",
+                "@id": "violation_0_location_range",
                 "@type": [
                   "lexicalSchema:RangeNode",
                   "lexical:Range"
                 ],
                 "end": {
-                  "@id": "warning_0_location_range_end",
+                  "@id": "violation_0_location_range_end",
                   "@type": [
                     "lexicalSchema:PositionNode",
                     "lexical:Position"
@@ -128,7 +128,7 @@
                   "line": 28
                 },
                 "start": {
-                  "@id": "warning_0_location_range_start",
+                  "@id": "violation_0_location_range_start",
                   "@type": [
                     "lexicalSchema:PositionNode",
                     "lexical:Position"
@@ -140,30 +140,30 @@
               "uri": "file://./test/data/production/spectral/negative10.yaml"
             },
             "resultMessage": "OpenAPI object should have non-empty tags array.\nWhy? Well, you can reference tags arbitrarily in operations, and definition is optional...\nDefining tags allows you to add more information like a description.\n",
-            "resultSeverity": "http://www.w3.org/ns/shacl#Warning",
+            "resultSeverity": "http://www.w3.org/ns/shacl#Violation",
             "sourceShapeName": "openapi-tags",
             "trace": [
               {
-                "@id": "warning_0_0",
+                "@id": "violation_0_0",
                 "@type": [
                   "reportSchema:TraceMessageNode",
                   "validation:TraceMessage"
                 ],
                 "component": "minCount",
                 "location": {
-                  "@id": "warning_0_0_location",
+                  "@id": "violation_0_0_location",
                   "@type": [
                     "lexicalSchema:LocationNode",
                     "lexical:Location"
                   ],
                   "range": {
-                    "@id": "warning_0_0_location_range",
+                    "@id": "violation_0_0_location_range",
                     "@type": [
                       "lexicalSchema:RangeNode",
                       "lexical:Range"
                     ],
                     "end": {
-                      "@id": "warning_0_0_location_range_end",
+                      "@id": "violation_0_0_location_range_end",
                       "@type": [
                         "lexicalSchema:PositionNode",
                         "lexical:Position"
@@ -172,7 +172,7 @@
                       "line": 28
                     },
                     "start": {
-                      "@id": "warning_0_0_location_range_start",
+                      "@id": "violation_0_0_location_range_start",
                       "@type": [
                         "lexicalSchema:PositionNode",
                         "lexical:Position"
@@ -185,7 +185,7 @@
                 },
                 "resultPath": "http://a.ml/vocabularies/apiContract#tag",
                 "traceValue": {
-                  "@id": "warning_0_0_traceValue",
+                  "@id": "violation_0_0_traceValue",
                   "@type": [
                     "reportSchema:TraceValueNode",
                     "validation:TraceValue"
@@ -199,26 +199,26 @@
             ]
           },
           {
-            "@id": "warning_1",
+            "@id": "violation_1",
             "@type": [
               "reportSchema:ValidationResultNode",
               "shacl:ValidationResult"
             ],
             "focusNode": "amf://id#2",
             "location": {
-              "@id": "warning_1_location",
+              "@id": "violation_1_location",
               "@type": [
                 "lexicalSchema:LocationNode",
                 "lexical:Location"
               ],
               "range": {
-                "@id": "warning_1_location_range",
+                "@id": "violation_1_location_range",
                 "@type": [
                   "lexicalSchema:RangeNode",
                   "lexical:Range"
                 ],
                 "end": {
-                  "@id": "warning_1_location_range_end",
+                  "@id": "violation_1_location_range_end",
                   "@type": [
                     "lexicalSchema:PositionNode",
                     "lexical:Position"
@@ -227,7 +227,7 @@
                   "line": 28
                 },
                 "start": {
-                  "@id": "warning_1_location_range_start",
+                  "@id": "violation_1_location_range_start",
                   "@type": [
                     "lexicalSchema:PositionNode",
                     "lexical:Position"
@@ -239,30 +239,30 @@
               "uri": "file://./test/data/production/spectral/negative10.yaml"
             },
             "resultMessage": "Operation tags should be defined in global tags.",
-            "resultSeverity": "http://www.w3.org/ns/shacl#Warning",
+            "resultSeverity": "http://www.w3.org/ns/shacl#Violation",
             "sourceShapeName": "operation-tag-defined",
             "trace": [
               {
-                "@id": "warning_1_0",
+                "@id": "violation_1_0",
                 "@type": [
                   "reportSchema:TraceMessageNode",
                   "validation:TraceMessage"
                 ],
                 "component": "rego",
                 "location": {
-                  "@id": "warning_1_0_location",
+                  "@id": "violation_1_0_location",
                   "@type": [
                     "lexicalSchema:LocationNode",
                     "lexical:Location"
                   ],
                   "range": {
-                    "@id": "warning_1_0_location_range",
+                    "@id": "violation_1_0_location_range",
                     "@type": [
                       "lexicalSchema:RangeNode",
                       "lexical:Range"
                     ],
                     "end": {
-                      "@id": "warning_1_0_location_range_end",
+                      "@id": "violation_1_0_location_range_end",
                       "@type": [
                         "lexicalSchema:PositionNode",
                         "lexical:Position"
@@ -271,7 +271,7 @@
                       "line": 25
                     },
                     "start": {
-                      "@id": "warning_1_0_location_range_start",
+                      "@id": "violation_1_0_location_range_start",
                       "@type": [
                         "lexicalSchema:PositionNode",
                         "lexical:Position"
@@ -284,7 +284,7 @@
                 },
                 "resultPath": "",
                 "traceValue": {
-                  "@id": "warning_1_0_traceValue",
+                  "@id": "violation_1_0_traceValue",
                   "@type": [
                     "reportSchema:TraceValueNode",
                     "validation:TraceValue"

--- a/test/data/production/spectral/negative11.yaml.jsonld
+++ b/test/data/production/spectral/negative11.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -179,6 +179,7 @@
       "@id": "amf://id#7",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -306,6 +307,7 @@
       "@id": "amf://id#11",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -319,6 +321,7 @@
       "@id": "amf://id#9",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -335,6 +338,7 @@
       "@id": "amf://id#10",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -410,6 +414,7 @@
       "@id": "amf://id#12",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",

--- a/test/data/production/spectral/negative12.yaml.jsonld
+++ b/test/data/production/spectral/negative12.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -179,6 +179,7 @@
       "@id": "amf://id#7",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -302,6 +303,7 @@
       "@id": "amf://id#10",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -315,6 +317,7 @@
       "@id": "amf://id#9",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -387,6 +390,7 @@
       "@id": "amf://id#11",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",

--- a/test/data/production/spectral/negative12.yaml.report.jsonld
+++ b/test/data/production/spectral/negative12.yaml.report.jsonld
@@ -96,30 +96,30 @@
           "reportSchema:ReportNode",
           "shacl:ValidationReport"
         ],
-        "conforms": true,
+        "conforms": false,
         "profileName": "Spectral Base",
         "result": [
           {
-            "@id": "warning_0",
+            "@id": "violation_0",
             "@type": [
               "reportSchema:ValidationResultNode",
               "shacl:ValidationResult"
             ],
             "focusNode": "amf://id#7",
             "location": {
-              "@id": "warning_0_location",
+              "@id": "violation_0_location",
               "@type": [
                 "lexicalSchema:LocationNode",
                 "lexical:Location"
               ],
               "range": {
-                "@id": "warning_0_location_range",
+                "@id": "violation_0_location_range",
                 "@type": [
                   "lexicalSchema:RangeNode",
                   "lexical:Range"
                 ],
                 "end": {
-                  "@id": "warning_0_location_range_end",
+                  "@id": "violation_0_location_range_end",
                   "@type": [
                     "lexicalSchema:PositionNode",
                     "lexical:Position"
@@ -128,7 +128,7 @@
                   "line": 30
                 },
                 "start": {
-                  "@id": "warning_0_location_range_start",
+                  "@id": "violation_0_location_range_start",
                   "@type": [
                     "lexicalSchema:PositionNode",
                     "lexical:Position"
@@ -140,30 +140,30 @@
               "uri": "file://./test/data/production/spectral/negative12.yaml"
             },
             "resultMessage": "Operation must have a description explaining the operation functionality",
-            "resultSeverity": "http://www.w3.org/ns/shacl#Warning",
+            "resultSeverity": "http://www.w3.org/ns/shacl#Violation",
             "sourceShapeName": "operation-description",
             "trace": [
               {
-                "@id": "warning_0_0",
+                "@id": "violation_0_0",
                 "@type": [
                   "reportSchema:TraceMessageNode",
                   "validation:TraceMessage"
                 ],
                 "component": "minCount",
                 "location": {
-                  "@id": "warning_0_0_location",
+                  "@id": "violation_0_0_location",
                   "@type": [
                     "lexicalSchema:LocationNode",
                     "lexical:Location"
                   ],
                   "range": {
-                    "@id": "warning_0_0_location_range",
+                    "@id": "violation_0_0_location_range",
                     "@type": [
                       "lexicalSchema:RangeNode",
                       "lexical:Range"
                     ],
                     "end": {
-                      "@id": "warning_0_0_location_range_end",
+                      "@id": "violation_0_0_location_range_end",
                       "@type": [
                         "lexicalSchema:PositionNode",
                         "lexical:Position"
@@ -172,7 +172,7 @@
                       "line": 30
                     },
                     "start": {
-                      "@id": "warning_0_0_location_range_start",
+                      "@id": "violation_0_0_location_range_start",
                       "@type": [
                         "lexicalSchema:PositionNode",
                         "lexical:Position"
@@ -185,7 +185,7 @@
                 },
                 "resultPath": "http://a.ml/vocabularies/core#description",
                 "traceValue": {
-                  "@id": "warning_0_0_traceValue",
+                  "@id": "violation_0_0_traceValue",
                   "@type": [
                     "reportSchema:TraceValueNode",
                     "validation:TraceValue"

--- a/test/data/production/spectral/negative13.yaml.jsonld
+++ b/test/data/production/spectral/negative13.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -221,6 +221,7 @@
       "@id": "amf://id#7",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -261,6 +262,7 @@
       "@id": "amf://id#14",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -303,6 +305,7 @@
       "@id": "amf://id#21",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -427,6 +430,7 @@
       "@id": "amf://id#10",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -440,6 +444,7 @@
       "@id": "amf://id#9",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -494,6 +499,7 @@
       "@id": "amf://id#17",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -507,6 +513,7 @@
       "@id": "amf://id#16",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -567,6 +574,7 @@
       "@id": "amf://id#24",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -580,6 +588,7 @@
       "@id": "amf://id#23",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -655,6 +664,7 @@
       "@id": "amf://id#11",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -725,6 +735,7 @@
       "@id": "amf://id#18",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -805,6 +816,7 @@
       "@id": "amf://id#25",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",

--- a/test/data/production/spectral/negative14.yaml.jsonld
+++ b/test/data/production/spectral/negative14.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -203,6 +203,7 @@
       "@id": "amf://id#7",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -229,6 +230,7 @@
       "@id": "amf://id#12",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "delete",
@@ -271,6 +273,7 @@
       "@id": "amf://id#17",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -395,6 +398,7 @@
       "@id": "amf://id#9",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -408,6 +412,7 @@
       "@id": "amf://id#8",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -447,6 +452,7 @@
       "@id": "amf://id#15",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -460,6 +466,7 @@
       "@id": "amf://id#14",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -520,6 +527,7 @@
       "@id": "amf://id#20",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -533,6 +541,7 @@
       "@id": "amf://id#19",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -608,6 +617,7 @@
       "@id": "amf://id#10",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -730,6 +740,7 @@
       "@id": "amf://id#21",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",

--- a/test/data/production/spectral/negative14.yaml.report.jsonld
+++ b/test/data/production/spectral/negative14.yaml.report.jsonld
@@ -96,30 +96,30 @@
           "reportSchema:ReportNode",
           "shacl:ValidationReport"
         ],
-        "conforms": true,
+        "conforms": false,
         "profileName": "Spectral Base",
         "result": [
           {
-            "@id": "warning_0",
+            "@id": "violation_0",
             "@type": [
               "reportSchema:ValidationResultNode",
               "shacl:ValidationResult"
             ],
             "focusNode": "amf://id#2",
             "location": {
-              "@id": "warning_0_location",
+              "@id": "violation_0_location",
               "@type": [
                 "lexicalSchema:LocationNode",
                 "lexical:Location"
               ],
               "range": {
-                "@id": "warning_0_location_range",
+                "@id": "violation_0_location_range",
                 "@type": [
                   "lexicalSchema:RangeNode",
                   "lexical:Range"
                 ],
                 "end": {
-                  "@id": "warning_0_location_range_end",
+                  "@id": "violation_0_location_range_end",
                   "@type": [
                     "lexicalSchema:PositionNode",
                     "lexical:Position"
@@ -128,7 +128,7 @@
                   "line": 54
                 },
                 "start": {
-                  "@id": "warning_0_location_range_start",
+                  "@id": "violation_0_location_range_start",
                   "@type": [
                     "lexicalSchema:PositionNode",
                     "lexical:Position"
@@ -140,30 +140,30 @@
               "uri": "file://./test/data/production/spectral/negative14.yaml"
             },
             "resultMessage": "Operation tags should be defined in global tags.",
-            "resultSeverity": "http://www.w3.org/ns/shacl#Warning",
+            "resultSeverity": "http://www.w3.org/ns/shacl#Violation",
             "sourceShapeName": "operation-tag-defined",
             "trace": [
               {
-                "@id": "warning_0_0",
+                "@id": "violation_0_0",
                 "@type": [
                   "reportSchema:TraceMessageNode",
                   "validation:TraceMessage"
                 ],
                 "component": "rego",
                 "location": {
-                  "@id": "warning_0_0_location",
+                  "@id": "violation_0_0_location",
                   "@type": [
                     "lexicalSchema:LocationNode",
                     "lexical:Location"
                   ],
                   "range": {
-                    "@id": "warning_0_0_location_range",
+                    "@id": "violation_0_0_location_range",
                     "@type": [
                       "lexicalSchema:RangeNode",
                       "lexical:Range"
                     ],
                     "end": {
-                      "@id": "warning_0_0_location_range_end",
+                      "@id": "violation_0_0_location_range_end",
                       "@type": [
                         "lexicalSchema:PositionNode",
                         "lexical:Position"
@@ -172,7 +172,7 @@
                       "line": 32
                     },
                     "start": {
-                      "@id": "warning_0_0_location_range_start",
+                      "@id": "violation_0_0_location_range_start",
                       "@type": [
                         "lexicalSchema:PositionNode",
                         "lexical:Position"
@@ -185,7 +185,7 @@
                 },
                 "resultPath": "",
                 "traceValue": {
-                  "@id": "warning_0_0_traceValue",
+                  "@id": "violation_0_0_traceValue",
                   "@type": [
                     "reportSchema:TraceValueNode",
                     "validation:TraceValue"
@@ -196,26 +196,26 @@
             ]
           },
           {
-            "@id": "warning_1",
+            "@id": "violation_1",
             "@type": [
               "reportSchema:ValidationResultNode",
               "shacl:ValidationResult"
             ],
             "focusNode": "amf://id#2",
             "location": {
-              "@id": "warning_1_location",
+              "@id": "violation_1_location",
               "@type": [
                 "lexicalSchema:LocationNode",
                 "lexical:Location"
               ],
               "range": {
-                "@id": "warning_1_location_range",
+                "@id": "violation_1_location_range",
                 "@type": [
                   "lexicalSchema:RangeNode",
                   "lexical:Range"
                 ],
                 "end": {
-                  "@id": "warning_1_location_range_end",
+                  "@id": "violation_1_location_range_end",
                   "@type": [
                     "lexicalSchema:PositionNode",
                     "lexical:Position"
@@ -224,7 +224,7 @@
                   "line": 54
                 },
                 "start": {
-                  "@id": "warning_1_location_range_start",
+                  "@id": "violation_1_location_range_start",
                   "@type": [
                     "lexicalSchema:PositionNode",
                     "lexical:Position"
@@ -236,30 +236,30 @@
               "uri": "file://./test/data/production/spectral/negative14.yaml"
             },
             "resultMessage": "Operation tags should be defined in global tags.",
-            "resultSeverity": "http://www.w3.org/ns/shacl#Warning",
+            "resultSeverity": "http://www.w3.org/ns/shacl#Violation",
             "sourceShapeName": "operation-tag-defined",
             "trace": [
               {
-                "@id": "warning_1_0",
+                "@id": "violation_1_0",
                 "@type": [
                   "reportSchema:TraceMessageNode",
                   "validation:TraceMessage"
                 ],
                 "component": "rego",
                 "location": {
-                  "@id": "warning_1_0_location",
+                  "@id": "violation_1_0_location",
                   "@type": [
                     "lexicalSchema:LocationNode",
                     "lexical:Location"
                   ],
                   "range": {
-                    "@id": "warning_1_0_location_range",
+                    "@id": "violation_1_0_location_range",
                     "@type": [
                       "lexicalSchema:RangeNode",
                       "lexical:Range"
                     ],
                     "end": {
-                      "@id": "warning_1_0_location_range_end",
+                      "@id": "violation_1_0_location_range_end",
                       "@type": [
                         "lexicalSchema:PositionNode",
                         "lexical:Position"
@@ -268,7 +268,7 @@
                       "line": 51
                     },
                     "start": {
-                      "@id": "warning_1_0_location_range_start",
+                      "@id": "violation_1_0_location_range_start",
                       "@type": [
                         "lexicalSchema:PositionNode",
                         "lexical:Position"
@@ -281,7 +281,7 @@
                 },
                 "resultPath": "",
                 "traceValue": {
-                  "@id": "warning_1_0_traceValue",
+                  "@id": "violation_1_0_traceValue",
                   "@type": [
                     "reportSchema:TraceValueNode",
                     "validation:TraceValue"
@@ -292,26 +292,26 @@
             ]
           },
           {
-            "@id": "warning_2",
+            "@id": "violation_2",
             "@type": [
               "reportSchema:ValidationResultNode",
               "shacl:ValidationResult"
             ],
             "focusNode": "amf://id#7",
             "location": {
-              "@id": "warning_2_location",
+              "@id": "violation_2_location",
               "@type": [
                 "lexicalSchema:LocationNode",
                 "lexical:Location"
               ],
               "range": {
-                "@id": "warning_2_location_range",
+                "@id": "violation_2_location_range",
                 "@type": [
                   "lexicalSchema:RangeNode",
                   "lexical:Range"
                 ],
                 "end": {
-                  "@id": "warning_2_location_range_end",
+                  "@id": "violation_2_location_range_end",
                   "@type": [
                     "lexicalSchema:PositionNode",
                     "lexical:Position"
@@ -320,7 +320,7 @@
                   "line": 30
                 },
                 "start": {
-                  "@id": "warning_2_location_range_start",
+                  "@id": "violation_2_location_range_start",
                   "@type": [
                     "lexicalSchema:PositionNode",
                     "lexical:Position"
@@ -332,30 +332,30 @@
               "uri": "file://./test/data/production/spectral/negative14.yaml"
             },
             "resultMessage": "Operation should have non-empty tags array.",
-            "resultSeverity": "http://www.w3.org/ns/shacl#Warning",
+            "resultSeverity": "http://www.w3.org/ns/shacl#Violation",
             "sourceShapeName": "operation-tags",
             "trace": [
               {
-                "@id": "warning_2_0",
+                "@id": "violation_2_0",
                 "@type": [
                   "reportSchema:TraceMessageNode",
                   "validation:TraceMessage"
                 ],
                 "component": "minCount",
                 "location": {
-                  "@id": "warning_2_0_location",
+                  "@id": "violation_2_0_location",
                   "@type": [
                     "lexicalSchema:LocationNode",
                     "lexical:Location"
                   ],
                   "range": {
-                    "@id": "warning_2_0_location_range",
+                    "@id": "violation_2_0_location_range",
                     "@type": [
                       "lexicalSchema:RangeNode",
                       "lexical:Range"
                     ],
                     "end": {
-                      "@id": "warning_2_0_location_range_end",
+                      "@id": "violation_2_0_location_range_end",
                       "@type": [
                         "lexicalSchema:PositionNode",
                         "lexical:Position"
@@ -364,7 +364,7 @@
                       "line": 30
                     },
                     "start": {
-                      "@id": "warning_2_0_location_range_start",
+                      "@id": "violation_2_0_location_range_start",
                       "@type": [
                         "lexicalSchema:PositionNode",
                         "lexical:Position"
@@ -377,7 +377,7 @@
                 },
                 "resultPath": "http://a.ml/vocabularies/apiContract#tag",
                 "traceValue": {
-                  "@id": "warning_2_0_traceValue",
+                  "@id": "violation_2_0_traceValue",
                   "@type": [
                     "reportSchema:TraceValueNode",
                     "validation:TraceValue"

--- a/test/data/production/spectral/negative15.yaml.jsonld
+++ b/test/data/production/spectral/negative15.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -200,6 +200,7 @@
       "@id": "amf://id#7",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -242,6 +243,7 @@
       "@id": "amf://id#14",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -366,6 +368,7 @@
       "@id": "amf://id#10",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -379,6 +382,7 @@
       "@id": "amf://id#9",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -439,6 +443,7 @@
       "@id": "amf://id#17",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -452,6 +457,7 @@
       "@id": "amf://id#16",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -527,6 +533,7 @@
       "@id": "amf://id#11",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "",
@@ -607,6 +614,7 @@
       "@id": "amf://id#18",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",

--- a/test/data/production/spectral/negative16.yaml.jsonld
+++ b/test/data/production/spectral/negative16.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -179,6 +179,7 @@
       "@id": "amf://id#7",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -303,6 +304,7 @@
       "@id": "amf://id#10",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -316,6 +318,7 @@
       "@id": "amf://id#9",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -391,6 +394,7 @@
       "@id": "amf://id#11",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",

--- a/test/data/production/spectral/negative17.yaml.jsonld
+++ b/test/data/production/spectral/negative17.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -179,6 +179,7 @@
       "@id": "amf://id#7",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -303,6 +304,7 @@
       "@id": "amf://id#10",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -321,6 +323,7 @@
       "@id": "amf://id#9",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -396,6 +399,7 @@
       "@id": "amf://id#11",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "test",
@@ -419,6 +423,7 @@
       "@id": "amf://id#13",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",

--- a/test/data/production/spectral/negative18.yaml.jsonld
+++ b/test/data/production/spectral/negative18.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -179,6 +179,7 @@
       "@id": "amf://id#14",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -303,6 +304,7 @@
       "@id": "amf://id#17",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -316,6 +318,7 @@
       "@id": "amf://id#16",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -391,6 +394,7 @@
       "@id": "amf://id#18",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",

--- a/test/data/production/spectral/negative2.yaml.jsonld
+++ b/test/data/production/spectral/negative2.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -179,6 +179,7 @@
       "@id": "amf://id#7",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",

--- a/test/data/production/spectral/negative3.yaml.jsonld
+++ b/test/data/production/spectral/negative3.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -124,6 +124,7 @@
       "@id": "amf://id#5",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "patch",
@@ -150,6 +151,7 @@
       "@id": "amf://id#8",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "put",
@@ -182,6 +184,7 @@
       "@id": "amf://id#11",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "patch",
@@ -208,6 +211,7 @@
       "@id": "amf://id#14",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "put",
@@ -282,6 +286,7 @@
       "@id": "amf://id#7",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -337,6 +342,7 @@
       "@id": "amf://id#9",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -381,6 +387,7 @@
       "@id": "amf://id#13",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -436,6 +443,7 @@
       "@id": "amf://id#16",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],

--- a/test/data/production/spectral/negative3.yaml.report.jsonld
+++ b/test/data/production/spectral/negative3.yaml.report.jsonld
@@ -96,30 +96,30 @@
           "reportSchema:ReportNode",
           "shacl:ValidationReport"
         ],
-        "conforms": true,
+        "conforms": false,
         "profileName": "Spectral Base",
         "result": [
           {
-            "@id": "warning_0",
+            "@id": "violation_0",
             "@type": [
               "reportSchema:ValidationResultNode",
               "shacl:ValidationResult"
             ],
             "focusNode": "amf://id#2",
             "location": {
-              "@id": "warning_0_location",
+              "@id": "violation_0_location",
               "@type": [
                 "lexicalSchema:LocationNode",
                 "lexical:Location"
               ],
               "range": {
-                "@id": "warning_0_location_range",
+                "@id": "violation_0_location_range",
                 "@type": [
                   "lexicalSchema:RangeNode",
                   "lexical:Range"
                 ],
                 "end": {
-                  "@id": "warning_0_location_range_end",
+                  "@id": "violation_0_location_range_end",
                   "@type": [
                     "lexicalSchema:PositionNode",
                     "lexical:Position"
@@ -128,7 +128,7 @@
                   "line": 42
                 },
                 "start": {
-                  "@id": "warning_0_location_range_start",
+                  "@id": "violation_0_location_range_start",
                   "@type": [
                     "lexicalSchema:PositionNode",
                     "lexical:Position"
@@ -140,30 +140,30 @@
               "uri": "file://./test/data/production/spectral/negative3.yaml"
             },
             "resultMessage": "Info object should contain contact object.\n\nHopefully your API description document is so good that nobody ever needs to contact you with questions, but that\nis rarely the case. The contact object has a few different options for contact details.\n",
-            "resultSeverity": "http://www.w3.org/ns/shacl#Warning",
+            "resultSeverity": "http://www.w3.org/ns/shacl#Violation",
             "sourceShapeName": "info-contact",
             "trace": [
               {
-                "@id": "warning_0_0",
+                "@id": "violation_0_0",
                 "@type": [
                   "reportSchema:TraceMessageNode",
                   "validation:TraceMessage"
                 ],
                 "component": "minCount",
                 "location": {
-                  "@id": "warning_0_0_location",
+                  "@id": "violation_0_0_location",
                   "@type": [
                     "lexicalSchema:LocationNode",
                     "lexical:Location"
                   ],
                   "range": {
-                    "@id": "warning_0_0_location_range",
+                    "@id": "violation_0_0_location_range",
                     "@type": [
                       "lexicalSchema:RangeNode",
                       "lexical:Range"
                     ],
                     "end": {
-                      "@id": "warning_0_0_location_range_end",
+                      "@id": "violation_0_0_location_range_end",
                       "@type": [
                         "lexicalSchema:PositionNode",
                         "lexical:Position"
@@ -172,7 +172,7 @@
                       "line": 42
                     },
                     "start": {
-                      "@id": "warning_0_0_location_range_start",
+                      "@id": "violation_0_0_location_range_start",
                       "@type": [
                         "lexicalSchema:PositionNode",
                         "lexical:Position"
@@ -185,7 +185,7 @@
                 },
                 "resultPath": "http://a.ml/vocabularies/core#provider",
                 "traceValue": {
-                  "@id": "warning_0_0_traceValue",
+                  "@id": "violation_0_0_traceValue",
                   "@type": [
                     "reportSchema:TraceValueNode",
                     "validation:TraceValue"
@@ -199,26 +199,26 @@
             ]
           },
           {
-            "@id": "warning_1",
+            "@id": "violation_1",
             "@type": [
               "reportSchema:ValidationResultNode",
               "shacl:ValidationResult"
             ],
             "focusNode": "amf://id#2",
             "location": {
-              "@id": "warning_1_location",
+              "@id": "violation_1_location",
               "@type": [
                 "lexicalSchema:LocationNode",
                 "lexical:Location"
               ],
               "range": {
-                "@id": "warning_1_location_range",
+                "@id": "violation_1_location_range",
                 "@type": [
                   "lexicalSchema:RangeNode",
                   "lexical:Range"
                 ],
                 "end": {
-                  "@id": "warning_1_location_range_end",
+                  "@id": "violation_1_location_range_end",
                   "@type": [
                     "lexicalSchema:PositionNode",
                     "lexical:Position"
@@ -227,7 +227,7 @@
                   "line": 42
                 },
                 "start": {
-                  "@id": "warning_1_location_range_start",
+                  "@id": "violation_1_location_range_start",
                   "@type": [
                     "lexicalSchema:PositionNode",
                     "lexical:Position"
@@ -239,30 +239,30 @@
               "uri": "file://./test/data/production/spectral/negative3.yaml"
             },
             "resultMessage": "OpenAPI object info description must be present and non-empty string.\nExamples can contain Markdown so you can really go to town with them, implementing getting started information\nlike where to find authentication keys, and how to use them.\n",
-            "resultSeverity": "http://www.w3.org/ns/shacl#Warning",
+            "resultSeverity": "http://www.w3.org/ns/shacl#Violation",
             "sourceShapeName": "info-description",
             "trace": [
               {
-                "@id": "warning_1_0",
+                "@id": "violation_1_0",
                 "@type": [
                   "reportSchema:TraceMessageNode",
                   "validation:TraceMessage"
                 ],
                 "component": "minCount",
                 "location": {
-                  "@id": "warning_1_0_location",
+                  "@id": "violation_1_0_location",
                   "@type": [
                     "lexicalSchema:LocationNode",
                     "lexical:Location"
                   ],
                   "range": {
-                    "@id": "warning_1_0_location_range",
+                    "@id": "violation_1_0_location_range",
                     "@type": [
                       "lexicalSchema:RangeNode",
                       "lexical:Range"
                     ],
                     "end": {
-                      "@id": "warning_1_0_location_range_end",
+                      "@id": "violation_1_0_location_range_end",
                       "@type": [
                         "lexicalSchema:PositionNode",
                         "lexical:Position"
@@ -271,7 +271,7 @@
                       "line": 42
                     },
                     "start": {
-                      "@id": "warning_1_0_location_range_start",
+                      "@id": "violation_1_0_location_range_start",
                       "@type": [
                         "lexicalSchema:PositionNode",
                         "lexical:Position"
@@ -284,7 +284,7 @@
                 },
                 "resultPath": "http://a.ml/vocabularies/core#description",
                 "traceValue": {
-                  "@id": "warning_1_0_traceValue",
+                  "@id": "violation_1_0_traceValue",
                   "@type": [
                     "reportSchema:TraceValueNode",
                     "validation:TraceValue"
@@ -298,26 +298,26 @@
             ]
           },
           {
-            "@id": "warning_2",
+            "@id": "violation_2",
             "@type": [
               "reportSchema:ValidationResultNode",
               "shacl:ValidationResult"
             ],
             "focusNode": "amf://id#2",
             "location": {
-              "@id": "warning_2_location",
+              "@id": "violation_2_location",
               "@type": [
                 "lexicalSchema:LocationNode",
                 "lexical:Location"
               ],
               "range": {
-                "@id": "warning_2_location_range",
+                "@id": "violation_2_location_range",
                 "@type": [
                   "lexicalSchema:RangeNode",
                   "lexical:Range"
                 ],
                 "end": {
-                  "@id": "warning_2_location_range_end",
+                  "@id": "violation_2_location_range_end",
                   "@type": [
                     "lexicalSchema:PositionNode",
                     "lexical:Position"
@@ -326,7 +326,7 @@
                   "line": 42
                 },
                 "start": {
-                  "@id": "warning_2_location_range_start",
+                  "@id": "violation_2_location_range_start",
                   "@type": [
                     "lexicalSchema:PositionNode",
                     "lexical:Position"
@@ -338,30 +338,30 @@
               "uri": "file://./test/data/production/spectral/negative3.yaml"
             },
             "resultMessage": "The info object should have a license key.\nIt can be hard to pick a license, so if you don't have a lawyer around you can use TLDRLegal and Choose a License\nto help give you an idea.\nHow useful this is in court is not entirely known, but having a license is better than not having a license.\n",
-            "resultSeverity": "http://www.w3.org/ns/shacl#Warning",
+            "resultSeverity": "http://www.w3.org/ns/shacl#Violation",
             "sourceShapeName": "info-license",
             "trace": [
               {
-                "@id": "warning_2_0",
+                "@id": "violation_2_0",
                 "@type": [
                   "reportSchema:TraceMessageNode",
                   "validation:TraceMessage"
                 ],
                 "component": "minCount",
                 "location": {
-                  "@id": "warning_2_0_location",
+                  "@id": "violation_2_0_location",
                   "@type": [
                     "lexicalSchema:LocationNode",
                     "lexical:Location"
                   ],
                   "range": {
-                    "@id": "warning_2_0_location_range",
+                    "@id": "violation_2_0_location_range",
                     "@type": [
                       "lexicalSchema:RangeNode",
                       "lexical:Range"
                     ],
                     "end": {
-                      "@id": "warning_2_0_location_range_end",
+                      "@id": "violation_2_0_location_range_end",
                       "@type": [
                         "lexicalSchema:PositionNode",
                         "lexical:Position"
@@ -370,7 +370,7 @@
                       "line": 42
                     },
                     "start": {
-                      "@id": "warning_2_0_location_range_start",
+                      "@id": "violation_2_0_location_range_start",
                       "@type": [
                         "lexicalSchema:PositionNode",
                         "lexical:Position"
@@ -383,7 +383,7 @@
                 },
                 "resultPath": "http://a.ml/vocabularies/core#license",
                 "traceValue": {
-                  "@id": "warning_2_0_traceValue",
+                  "@id": "violation_2_0_traceValue",
                   "@type": [
                     "reportSchema:TraceValueNode",
                     "validation:TraceValue"
@@ -397,26 +397,26 @@
             ]
           },
           {
-            "@id": "warning_3",
+            "@id": "violation_3",
             "@type": [
               "reportSchema:ValidationResultNode",
               "shacl:ValidationResult"
             ],
             "focusNode": "amf://id#8",
             "location": {
-              "@id": "warning_3_location",
+              "@id": "violation_3_location",
               "@type": [
                 "lexicalSchema:LocationNode",
                 "lexical:Location"
               ],
               "range": {
-                "@id": "warning_3_location_range",
+                "@id": "violation_3_location_range",
                 "@type": [
                   "lexicalSchema:RangeNode",
                   "lexical:Range"
                 ],
                 "end": {
-                  "@id": "warning_3_location_range_end",
+                  "@id": "violation_3_location_range_end",
                   "@type": [
                     "lexicalSchema:PositionNode",
                     "lexical:Position"
@@ -425,7 +425,7 @@
                   "line": 26
                 },
                 "start": {
-                  "@id": "warning_3_location_range_start",
+                  "@id": "violation_3_location_range_start",
                   "@type": [
                     "lexicalSchema:PositionNode",
                     "lexical:Position"
@@ -437,30 +437,30 @@
               "uri": "file://./test/data/production/spectral/negative3.yaml"
             },
             "resultMessage": "Operation should have non-empty tags array.",
-            "resultSeverity": "http://www.w3.org/ns/shacl#Warning",
+            "resultSeverity": "http://www.w3.org/ns/shacl#Violation",
             "sourceShapeName": "operation-tags",
             "trace": [
               {
-                "@id": "warning_3_0",
+                "@id": "violation_3_0",
                 "@type": [
                   "reportSchema:TraceMessageNode",
                   "validation:TraceMessage"
                 ],
                 "component": "minCount",
                 "location": {
-                  "@id": "warning_3_0_location",
+                  "@id": "violation_3_0_location",
                   "@type": [
                     "lexicalSchema:LocationNode",
                     "lexical:Location"
                   ],
                   "range": {
-                    "@id": "warning_3_0_location_range",
+                    "@id": "violation_3_0_location_range",
                     "@type": [
                       "lexicalSchema:RangeNode",
                       "lexical:Range"
                     ],
                     "end": {
-                      "@id": "warning_3_0_location_range_end",
+                      "@id": "violation_3_0_location_range_end",
                       "@type": [
                         "lexicalSchema:PositionNode",
                         "lexical:Position"
@@ -469,7 +469,7 @@
                       "line": 26
                     },
                     "start": {
-                      "@id": "warning_3_0_location_range_start",
+                      "@id": "violation_3_0_location_range_start",
                       "@type": [
                         "lexicalSchema:PositionNode",
                         "lexical:Position"
@@ -482,7 +482,7 @@
                 },
                 "resultPath": "http://a.ml/vocabularies/apiContract#tag",
                 "traceValue": {
-                  "@id": "warning_3_0_traceValue",
+                  "@id": "violation_3_0_traceValue",
                   "@type": [
                     "reportSchema:TraceValueNode",
                     "validation:TraceValue"

--- a/test/data/production/spectral/negative4.yaml.jsonld
+++ b/test/data/production/spectral/negative4.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -155,6 +155,7 @@
       "@id": "amf://id#6",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -197,6 +198,7 @@
       "@id": "amf://id#17",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -296,6 +298,7 @@
       "@id": "amf://id#13",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -309,6 +312,7 @@
       "@id": "amf://id#8",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -374,6 +378,7 @@
       "@id": "amf://id#24",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -387,6 +392,7 @@
       "@id": "amf://id#19",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -467,6 +473,7 @@
       "@id": "amf://id#14",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -489,6 +496,7 @@
       "@id": "amf://id#9",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -566,6 +574,7 @@
       "@id": "amf://id#25",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "other",
@@ -590,6 +599,7 @@
       "@id": "amf://id#20",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/spectral/negative4.yaml.report.jsonld
+++ b/test/data/production/spectral/negative4.yaml.report.jsonld
@@ -96,30 +96,30 @@
           "reportSchema:ReportNode",
           "shacl:ValidationReport"
         ],
-        "conforms": true,
+        "conforms": false,
         "profileName": "Spectral Base",
         "result": [
           {
-            "@id": "warning_0",
+            "@id": "violation_0",
             "@type": [
               "reportSchema:ValidationResultNode",
               "shacl:ValidationResult"
             ],
             "focusNode": "amf://id#2",
             "location": {
-              "@id": "warning_0_location",
+              "@id": "violation_0_location",
               "@type": [
                 "lexicalSchema:LocationNode",
                 "lexical:Location"
               ],
               "range": {
-                "@id": "warning_0_location_range",
+                "@id": "violation_0_location_range",
                 "@type": [
                   "lexicalSchema:RangeNode",
                   "lexical:Range"
                 ],
                 "end": {
-                  "@id": "warning_0_location_range_end",
+                  "@id": "violation_0_location_range_end",
                   "@type": [
                     "lexicalSchema:PositionNode",
                     "lexical:Position"
@@ -128,7 +128,7 @@
                   "line": 74
                 },
                 "start": {
-                  "@id": "warning_0_location_range_start",
+                  "@id": "violation_0_location_range_start",
                   "@type": [
                     "lexicalSchema:PositionNode",
                     "lexical:Position"
@@ -140,30 +140,30 @@
               "uri": "file://./test/data/production/spectral/negative4.yaml"
             },
             "resultMessage": "OpenAPI object info description must be present and non-empty string.\nExamples can contain Markdown so you can really go to town with them, implementing getting started information\nlike where to find authentication keys, and how to use them.\n",
-            "resultSeverity": "http://www.w3.org/ns/shacl#Warning",
+            "resultSeverity": "http://www.w3.org/ns/shacl#Violation",
             "sourceShapeName": "info-description",
             "trace": [
               {
-                "@id": "warning_0_0",
+                "@id": "violation_0_0",
                 "@type": [
                   "reportSchema:TraceMessageNode",
                   "validation:TraceMessage"
                 ],
                 "component": "minCount",
                 "location": {
-                  "@id": "warning_0_0_location",
+                  "@id": "violation_0_0_location",
                   "@type": [
                     "lexicalSchema:LocationNode",
                     "lexical:Location"
                   ],
                   "range": {
-                    "@id": "warning_0_0_location_range",
+                    "@id": "violation_0_0_location_range",
                     "@type": [
                       "lexicalSchema:RangeNode",
                       "lexical:Range"
                     ],
                     "end": {
-                      "@id": "warning_0_0_location_range_end",
+                      "@id": "violation_0_0_location_range_end",
                       "@type": [
                         "lexicalSchema:PositionNode",
                         "lexical:Position"
@@ -172,7 +172,7 @@
                       "line": 74
                     },
                     "start": {
-                      "@id": "warning_0_0_location_range_start",
+                      "@id": "violation_0_0_location_range_start",
                       "@type": [
                         "lexicalSchema:PositionNode",
                         "lexical:Position"
@@ -185,7 +185,7 @@
                 },
                 "resultPath": "http://a.ml/vocabularies/core#description",
                 "traceValue": {
-                  "@id": "warning_0_0_traceValue",
+                  "@id": "violation_0_0_traceValue",
                   "@type": [
                     "reportSchema:TraceValueNode",
                     "validation:TraceValue"
@@ -199,26 +199,26 @@
             ]
           },
           {
-            "@id": "warning_1",
+            "@id": "violation_1",
             "@type": [
               "reportSchema:ValidationResultNode",
               "shacl:ValidationResult"
             ],
             "focusNode": "amf://id#2",
             "location": {
-              "@id": "warning_1_location",
+              "@id": "violation_1_location",
               "@type": [
                 "lexicalSchema:LocationNode",
                 "lexical:Location"
               ],
               "range": {
-                "@id": "warning_1_location_range",
+                "@id": "violation_1_location_range",
                 "@type": [
                   "lexicalSchema:RangeNode",
                   "lexical:Range"
                 ],
                 "end": {
-                  "@id": "warning_1_location_range_end",
+                  "@id": "violation_1_location_range_end",
                   "@type": [
                     "lexicalSchema:PositionNode",
                     "lexical:Position"
@@ -227,7 +227,7 @@
                   "line": 74
                 },
                 "start": {
-                  "@id": "warning_1_location_range_start",
+                  "@id": "violation_1_location_range_start",
                   "@type": [
                     "lexicalSchema:PositionNode",
                     "lexical:Position"
@@ -239,30 +239,30 @@
               "uri": "file://./test/data/production/spectral/negative4.yaml"
             },
             "resultMessage": "The info object should have a license key.\nIt can be hard to pick a license, so if you don't have a lawyer around you can use TLDRLegal and Choose a License\nto help give you an idea.\nHow useful this is in court is not entirely known, but having a license is better than not having a license.\n",
-            "resultSeverity": "http://www.w3.org/ns/shacl#Warning",
+            "resultSeverity": "http://www.w3.org/ns/shacl#Violation",
             "sourceShapeName": "info-license",
             "trace": [
               {
-                "@id": "warning_1_0",
+                "@id": "violation_1_0",
                 "@type": [
                   "reportSchema:TraceMessageNode",
                   "validation:TraceMessage"
                 ],
                 "component": "minCount",
                 "location": {
-                  "@id": "warning_1_0_location",
+                  "@id": "violation_1_0_location",
                   "@type": [
                     "lexicalSchema:LocationNode",
                     "lexical:Location"
                   ],
                   "range": {
-                    "@id": "warning_1_0_location_range",
+                    "@id": "violation_1_0_location_range",
                     "@type": [
                       "lexicalSchema:RangeNode",
                       "lexical:Range"
                     ],
                     "end": {
-                      "@id": "warning_1_0_location_range_end",
+                      "@id": "violation_1_0_location_range_end",
                       "@type": [
                         "lexicalSchema:PositionNode",
                         "lexical:Position"
@@ -271,7 +271,7 @@
                       "line": 74
                     },
                     "start": {
-                      "@id": "warning_1_0_location_range_start",
+                      "@id": "violation_1_0_location_range_start",
                       "@type": [
                         "lexicalSchema:PositionNode",
                         "lexical:Position"
@@ -284,7 +284,7 @@
                 },
                 "resultPath": "http://a.ml/vocabularies/core#license",
                 "traceValue": {
-                  "@id": "warning_1_0_traceValue",
+                  "@id": "violation_1_0_traceValue",
                   "@type": [
                     "reportSchema:TraceValueNode",
                     "validation:TraceValue"

--- a/test/data/production/spectral/negative5.yaml.jsonld
+++ b/test/data/production/spectral/negative5.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -226,6 +226,7 @@
       "@id": "amf://id#9",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -252,6 +253,7 @@
       "@id": "amf://id#7",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -288,6 +290,7 @@
       "@id": "amf://id#17",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -325,6 +328,7 @@
       "@id": "amf://id#25",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -449,6 +453,7 @@
       "@id": "amf://id#11",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -577,6 +582,7 @@
       "@id": "amf://id#19",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -642,6 +648,7 @@
       "@id": "amf://id#32",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -655,6 +662,7 @@
       "@id": "amf://id#27",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -735,6 +743,7 @@
       "@id": "amf://id#12",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -884,6 +893,7 @@
       "@id": "amf://id#20",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -961,6 +971,7 @@
       "@id": "amf://id#33",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -983,6 +994,7 @@
       "@id": "amf://id#28",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/spectral/negative6.yaml.jsonld
+++ b/test/data/production/spectral/negative6.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },

--- a/test/data/production/spectral/negative6.yaml.report.jsonld
+++ b/test/data/production/spectral/negative6.yaml.report.jsonld
@@ -96,30 +96,30 @@
           "reportSchema:ReportNode",
           "shacl:ValidationReport"
         ],
-        "conforms": true,
+        "conforms": false,
         "profileName": "Spectral Base",
         "result": [
           {
-            "@id": "warning_0",
+            "@id": "violation_0",
             "@type": [
               "reportSchema:ValidationResultNode",
               "shacl:ValidationResult"
             ],
             "focusNode": "amf://id#2",
             "location": {
-              "@id": "warning_0_location",
+              "@id": "violation_0_location",
               "@type": [
                 "lexicalSchema:LocationNode",
                 "lexical:Location"
               ],
               "range": {
-                "@id": "warning_0_location_range",
+                "@id": "violation_0_location_range",
                 "@type": [
                   "lexicalSchema:RangeNode",
                   "lexical:Range"
                 ],
                 "end": {
-                  "@id": "warning_0_location_range_end",
+                  "@id": "violation_0_location_range_end",
                   "@type": [
                     "lexicalSchema:PositionNode",
                     "lexical:Position"
@@ -128,7 +128,7 @@
                   "line": 13
                 },
                 "start": {
-                  "@id": "warning_0_location_range_start",
+                  "@id": "violation_0_location_range_start",
                   "@type": [
                     "lexicalSchema:PositionNode",
                     "lexical:Position"
@@ -140,30 +140,30 @@
               "uri": "file://./test/data/production/spectral/negative6.yaml"
             },
             "resultMessage": "Info object should contain contact object.\n\nHopefully your API description document is so good that nobody ever needs to contact you with questions, but that\nis rarely the case. The contact object has a few different options for contact details.\n",
-            "resultSeverity": "http://www.w3.org/ns/shacl#Warning",
+            "resultSeverity": "http://www.w3.org/ns/shacl#Violation",
             "sourceShapeName": "info-contact",
             "trace": [
               {
-                "@id": "warning_0_0",
+                "@id": "violation_0_0",
                 "@type": [
                   "reportSchema:TraceMessageNode",
                   "validation:TraceMessage"
                 ],
                 "component": "minCount",
                 "location": {
-                  "@id": "warning_0_0_location",
+                  "@id": "violation_0_0_location",
                   "@type": [
                     "lexicalSchema:LocationNode",
                     "lexical:Location"
                   ],
                   "range": {
-                    "@id": "warning_0_0_location_range",
+                    "@id": "violation_0_0_location_range",
                     "@type": [
                       "lexicalSchema:RangeNode",
                       "lexical:Range"
                     ],
                     "end": {
-                      "@id": "warning_0_0_location_range_end",
+                      "@id": "violation_0_0_location_range_end",
                       "@type": [
                         "lexicalSchema:PositionNode",
                         "lexical:Position"
@@ -172,7 +172,7 @@
                       "line": 13
                     },
                     "start": {
-                      "@id": "warning_0_0_location_range_start",
+                      "@id": "violation_0_0_location_range_start",
                       "@type": [
                         "lexicalSchema:PositionNode",
                         "lexical:Position"
@@ -185,7 +185,7 @@
                 },
                 "resultPath": "http://a.ml/vocabularies/core#provider",
                 "traceValue": {
-                  "@id": "warning_0_0_traceValue",
+                  "@id": "violation_0_0_traceValue",
                   "@type": [
                     "reportSchema:TraceValueNode",
                     "validation:TraceValue"

--- a/test/data/production/spectral/negative7.yaml.jsonld
+++ b/test/data/production/spectral/negative7.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },

--- a/test/data/production/spectral/negative7.yaml.report.jsonld
+++ b/test/data/production/spectral/negative7.yaml.report.jsonld
@@ -96,30 +96,30 @@
           "reportSchema:ReportNode",
           "shacl:ValidationReport"
         ],
-        "conforms": true,
+        "conforms": false,
         "profileName": "Spectral Base",
         "result": [
           {
-            "@id": "warning_0",
+            "@id": "violation_0",
             "@type": [
               "reportSchema:ValidationResultNode",
               "shacl:ValidationResult"
             ],
             "focusNode": "amf://id#2",
             "location": {
-              "@id": "warning_0_location",
+              "@id": "violation_0_location",
               "@type": [
                 "lexicalSchema:LocationNode",
                 "lexical:Location"
               ],
               "range": {
-                "@id": "warning_0_location_range",
+                "@id": "violation_0_location_range",
                 "@type": [
                   "lexicalSchema:RangeNode",
                   "lexical:Range"
                 ],
                 "end": {
-                  "@id": "warning_0_location_range_end",
+                  "@id": "violation_0_location_range_end",
                   "@type": [
                     "lexicalSchema:PositionNode",
                     "lexical:Position"
@@ -128,7 +128,7 @@
                   "line": 12
                 },
                 "start": {
-                  "@id": "warning_0_location_range_start",
+                  "@id": "violation_0_location_range_start",
                   "@type": [
                     "lexicalSchema:PositionNode",
                     "lexical:Position"
@@ -140,30 +140,30 @@
               "uri": "file://./test/data/production/spectral/negative7.yaml"
             },
             "resultMessage": "The info object should have a license key.\nIt can be hard to pick a license, so if you don't have a lawyer around you can use TLDRLegal and Choose a License\nto help give you an idea.\nHow useful this is in court is not entirely known, but having a license is better than not having a license.\n",
-            "resultSeverity": "http://www.w3.org/ns/shacl#Warning",
+            "resultSeverity": "http://www.w3.org/ns/shacl#Violation",
             "sourceShapeName": "info-license",
             "trace": [
               {
-                "@id": "warning_0_0",
+                "@id": "violation_0_0",
                 "@type": [
                   "reportSchema:TraceMessageNode",
                   "validation:TraceMessage"
                 ],
                 "component": "minCount",
                 "location": {
-                  "@id": "warning_0_0_location",
+                  "@id": "violation_0_0_location",
                   "@type": [
                     "lexicalSchema:LocationNode",
                     "lexical:Location"
                   ],
                   "range": {
-                    "@id": "warning_0_0_location_range",
+                    "@id": "violation_0_0_location_range",
                     "@type": [
                       "lexicalSchema:RangeNode",
                       "lexical:Range"
                     ],
                     "end": {
-                      "@id": "warning_0_0_location_range_end",
+                      "@id": "violation_0_0_location_range_end",
                       "@type": [
                         "lexicalSchema:PositionNode",
                         "lexical:Position"
@@ -172,7 +172,7 @@
                       "line": 12
                     },
                     "start": {
-                      "@id": "warning_0_0_location_range_start",
+                      "@id": "violation_0_0_location_range_start",
                       "@type": [
                         "lexicalSchema:PositionNode",
                         "lexical:Position"
@@ -185,7 +185,7 @@
                 },
                 "resultPath": "http://a.ml/vocabularies/core#license",
                 "traceValue": {
-                  "@id": "warning_0_0_traceValue",
+                  "@id": "violation_0_0_traceValue",
                   "@type": [
                     "reportSchema:TraceValueNode",
                     "validation:TraceValue"

--- a/test/data/production/spectral/negative7b.yaml.jsonld
+++ b/test/data/production/spectral/negative7b.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },

--- a/test/data/production/spectral/negative7b.yaml.report.jsonld
+++ b/test/data/production/spectral/negative7b.yaml.report.jsonld
@@ -96,30 +96,30 @@
           "reportSchema:ReportNode",
           "shacl:ValidationReport"
         ],
-        "conforms": true,
+        "conforms": false,
         "profileName": "Spectral Base",
         "result": [
           {
-            "@id": "warning_0",
+            "@id": "violation_0",
             "@type": [
               "reportSchema:ValidationResultNode",
               "shacl:ValidationResult"
             ],
             "focusNode": "amf://id#4",
             "location": {
-              "@id": "warning_0_location",
+              "@id": "violation_0_location",
               "@type": [
                 "lexicalSchema:LocationNode",
                 "lexical:Location"
               ],
               "range": {
-                "@id": "warning_0_location_range",
+                "@id": "violation_0_location_range",
                 "@type": [
                   "lexicalSchema:RangeNode",
                   "lexical:Range"
                 ],
                 "end": {
-                  "@id": "warning_0_location_range_end",
+                  "@id": "violation_0_location_range_end",
                   "@type": [
                     "lexicalSchema:PositionNode",
                     "lexical:Position"
@@ -128,7 +128,7 @@
                   "line": 7
                 },
                 "start": {
-                  "@id": "warning_0_location_range_start",
+                  "@id": "violation_0_location_range_start",
                   "@type": [
                     "lexicalSchema:PositionNode",
                     "lexical:Position"
@@ -140,30 +140,30 @@
               "uri": "file://./test/data/production/spectral/negative7b.yaml"
             },
             "resultMessage": "Mentioning a license is only useful if people know what the license means, so add a link to the full text for\nthose who need it.\n",
-            "resultSeverity": "http://www.w3.org/ns/shacl#Warning",
+            "resultSeverity": "http://www.w3.org/ns/shacl#Violation",
             "sourceShapeName": "license-url",
             "trace": [
               {
-                "@id": "warning_0_0",
+                "@id": "violation_0_0",
                 "@type": [
                   "reportSchema:TraceMessageNode",
                   "validation:TraceMessage"
                 ],
                 "component": "minCount",
                 "location": {
-                  "@id": "warning_0_0_location",
+                  "@id": "violation_0_0_location",
                   "@type": [
                     "lexicalSchema:LocationNode",
                     "lexical:Location"
                   ],
                   "range": {
-                    "@id": "warning_0_0_location_range",
+                    "@id": "violation_0_0_location_range",
                     "@type": [
                       "lexicalSchema:RangeNode",
                       "lexical:Range"
                     ],
                     "end": {
-                      "@id": "warning_0_0_location_range_end",
+                      "@id": "violation_0_0_location_range_end",
                       "@type": [
                         "lexicalSchema:PositionNode",
                         "lexical:Position"
@@ -172,7 +172,7 @@
                       "line": 7
                     },
                     "start": {
-                      "@id": "warning_0_0_location_range_start",
+                      "@id": "violation_0_0_location_range_start",
                       "@type": [
                         "lexicalSchema:PositionNode",
                         "lexical:Position"
@@ -185,7 +185,7 @@
                 },
                 "resultPath": "http://a.ml/vocabularies/core#url",
                 "traceValue": {
-                  "@id": "warning_0_0_traceValue",
+                  "@id": "violation_0_0_traceValue",
                   "@type": [
                     "reportSchema:TraceValueNode",
                     "validation:TraceValue"

--- a/test/data/production/spectral/negative8.yaml.jsonld
+++ b/test/data/production/spectral/negative8.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },

--- a/test/data/production/spectral/negative9.yaml.jsonld
+++ b/test/data/production/spectral/negative9.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },

--- a/test/data/production/spectral/positive1.yaml.jsonld
+++ b/test/data/production/spectral/positive1.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -179,6 +179,7 @@
       "@id": "amf://id#7",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -298,6 +299,7 @@
       "@id": "amf://id#9",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],

--- a/test/data/production/spectral/positive10.yaml.jsonld
+++ b/test/data/production/spectral/positive10.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -179,6 +179,7 @@
       "@id": "amf://id#7",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -303,6 +304,7 @@
       "@id": "amf://id#10",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -316,6 +318,7 @@
       "@id": "amf://id#9",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -391,6 +394,7 @@
       "@id": "amf://id#11",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",

--- a/test/data/production/spectral/positive11.yaml.jsonld
+++ b/test/data/production/spectral/positive11.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -179,6 +179,7 @@
       "@id": "amf://id#7",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -303,6 +304,7 @@
       "@id": "amf://id#10",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -316,6 +318,7 @@
       "@id": "amf://id#9",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -391,6 +394,7 @@
       "@id": "amf://id#11",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",

--- a/test/data/production/spectral/positive12.yaml.jsonld
+++ b/test/data/production/spectral/positive12.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -179,6 +179,7 @@
       "@id": "amf://id#7",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -303,6 +304,7 @@
       "@id": "amf://id#10",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -316,6 +318,7 @@
       "@id": "amf://id#9",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -391,6 +394,7 @@
       "@id": "amf://id#11",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",

--- a/test/data/production/spectral/positive13.yaml.jsonld
+++ b/test/data/production/spectral/positive13.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -200,6 +200,7 @@
       "@id": "amf://id#7",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -242,6 +243,7 @@
       "@id": "amf://id#14",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -366,6 +368,7 @@
       "@id": "amf://id#10",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -379,6 +382,7 @@
       "@id": "amf://id#9",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -439,6 +443,7 @@
       "@id": "amf://id#17",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -452,6 +457,7 @@
       "@id": "amf://id#16",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -527,6 +533,7 @@
       "@id": "amf://id#11",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -607,6 +614,7 @@
       "@id": "amf://id#18",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",

--- a/test/data/production/spectral/positive14.yaml.jsonld
+++ b/test/data/production/spectral/positive14.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -200,6 +200,7 @@
       "@id": "amf://id#7",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -242,6 +243,7 @@
       "@id": "amf://id#14",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -366,6 +368,7 @@
       "@id": "amf://id#10",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -379,6 +382,7 @@
       "@id": "amf://id#9",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -439,6 +443,7 @@
       "@id": "amf://id#17",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -452,6 +457,7 @@
       "@id": "amf://id#16",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -527,6 +533,7 @@
       "@id": "amf://id#11",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -607,6 +614,7 @@
       "@id": "amf://id#18",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",

--- a/test/data/production/spectral/positive15.yaml
+++ b/test/data/production/spectral/positive15.yaml
@@ -22,6 +22,12 @@ paths:
         schema:
           type: string
     get:
+      parameters:
+        - name: Accept
+          in: header
+          required: true
+          schema:
+            type: string
       description: op-description
       operationId: opid
       tags:

--- a/test/data/production/spectral/positive15.yaml.jsonld
+++ b/test/data/production/spectral/positive15.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -179,6 +179,7 @@
       "@id": "amf://id#7",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -237,7 +238,7 @@
     {
       "@id": "amf://id#2/source-map/lexical/element_6",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#endpoint",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(15,0)-(31,29)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(15,0)-(37,29)]"
     },
     {
       "@id": "amf://id#2/source-map/lexical/element_4",
@@ -262,7 +263,7 @@
     {
       "@id": "amf://id#2/source-map/lexical/element_3",
       "http://a.ml/vocabularies/document-source-maps#element": "amf://id#2",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(1,0)-(31,29)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(1,0)-(37,29)]"
     },
     {
       "@id": "amf://id#2/source-map/lexical/element_5",
@@ -303,10 +304,16 @@
       "@id": "amf://id#10",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#uriParameter": [
+        {
+          "@id": "amf://id#13"
+        }
+      ],
+      "http://a.ml/vocabularies/apiContract#header": [
         {
           "@id": "amf://id#11"
         }
@@ -316,6 +323,7 @@
       "@id": "amf://id#9",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -370,7 +378,7 @@
     {
       "@id": "amf://id#6/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "amf://id#6",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(16,2)-(31,29)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(16,2)-(37,29)]"
     },
     {
       "@id": "amf://id#5/source-map/lexical/element_2",
@@ -388,9 +396,10 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(12,4)-(15,0)]"
     },
     {
-      "@id": "amf://id#11",
+      "@id": "amf://id#13",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -400,6 +409,28 @@
       "http://a.ml/vocabularies/apiContract#style": "simple",
       "http://a.ml/vocabularies/apiContract#explode": false,
       "http://a.ml/vocabularies/apiContract#binding": "path",
+      "http://a.ml/vocabularies/shapes#schema": {
+        "@id": "amf://id#14"
+      },
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "amf://id#13/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "amf://id#11",
+      "@type": [
+        "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/core#name": "Accept",
+      "http://a.ml/vocabularies/apiContract#paramName": "Accept",
+      "http://a.ml/vocabularies/apiContract#required": true,
+      "http://a.ml/vocabularies/apiContract#style": "simple",
+      "http://a.ml/vocabularies/apiContract#explode": false,
+      "http://a.ml/vocabularies/apiContract#binding": "header",
       "http://a.ml/vocabularies/shapes#schema": {
         "@id": "amf://id#12"
       },
@@ -440,32 +471,90 @@
     {
       "@id": "amf://id#7/source-map/lexical/element_5",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#tag",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(27,6)-(29,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(33,6)-(35,0)]"
     },
     {
       "@id": "amf://id#7/source-map/lexical/element_3",
       "http://a.ml/vocabularies/document-source-maps#element": "amf://id#7",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(24,4)-(31,29)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(24,4)-(37,29)]"
     },
     {
       "@id": "amf://id#7/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#returns",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(29,6)-(31,29)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(35,6)-(37,29)]"
     },
     {
       "@id": "amf://id#7/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#operationId",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(26,6)-(27,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(32,6)-(33,0)]"
     },
     {
       "@id": "amf://id#7/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(26,6)-(27,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(32,6)-(33,0)]"
     },
     {
       "@id": "amf://id#7/source-map/lexical/element_4",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(25,6)-(26,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(31,6)-(32,0)]"
+    },
+    {
+      "@id": "amf://id#14",
+      "@type": [
+        "http://a.ml/vocabularies/shapes#ScalarShape",
+        "http://a.ml/vocabularies/shapes#AnyShape",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/shapes#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "http://www.w3.org/ns/shacl#name": "id",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "amf://id#14/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "amf://id#13/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+        {
+          "@id": "amf://id#13/source-map/synthesized-field/element_1"
+        },
+        {
+          "@id": "amf://id#13/source-map/synthesized-field/element_0"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "amf://id#13/source-map/lexical/element_6"
+        },
+        {
+          "@id": "amf://id#13/source-map/lexical/element_4"
+        },
+        {
+          "@id": "amf://id#13/source-map/lexical/element_2"
+        },
+        {
+          "@id": "amf://id#13/source-map/lexical/element_0"
+        },
+        {
+          "@id": "amf://id#13/source-map/lexical/element_1"
+        },
+        {
+          "@id": "amf://id#13/source-map/lexical/element_3"
+        },
+        {
+          "@id": "amf://id#13/source-map/lexical/element_5"
+        }
+      ]
     },
     {
       "@id": "amf://id#12",
@@ -481,7 +570,7 @@
           "@id": "http://www.w3.org/2001/XMLSchema#string"
         }
       ],
-      "http://www.w3.org/ns/shacl#name": "id",
+      "http://www.w3.org/ns/shacl#name": "Accept",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
           "@id": "amf://id#12/source-map"
@@ -503,47 +592,116 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#11/source-map/lexical/element_6"
-        },
-        {
-          "@id": "amf://id#11/source-map/lexical/element_4"
-        },
-        {
-          "@id": "amf://id#11/source-map/lexical/element_2"
-        },
-        {
-          "@id": "amf://id#11/source-map/lexical/element_0"
-        },
-        {
-          "@id": "amf://id#11/source-map/lexical/element_1"
+          "@id": "amf://id#11/source-map/lexical/element_5"
         },
         {
           "@id": "amf://id#11/source-map/lexical/element_3"
         },
         {
-          "@id": "amf://id#11/source-map/lexical/element_5"
+          "@id": "amf://id#11/source-map/lexical/element_1"
+        },
+        {
+          "@id": "amf://id#11/source-map/lexical/element_0"
+        },
+        {
+          "@id": "amf://id#11/source-map/lexical/element_2"
+        },
+        {
+          "@id": "amf://id#11/source-map/lexical/element_4"
         }
       ]
     },
     {
       "@id": "amf://id#9/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(30,8)-(30,13)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(36,8)-(36,13)]"
     },
     {
       "@id": "amf://id#9/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(31,10)-(31,29)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(37,10)-(37,29)]"
     },
     {
       "@id": "amf://id#9/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "amf://id#9",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(30,8)-(31,29)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(36,8)-(37,29)]"
     },
     {
       "@id": "amf://id#8/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "amf://id#8",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(28,10)-(28,23)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(34,10)-(34,23)]"
+    },
+    {
+      "@id": "amf://id#14/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#auto-generated-name": [
+        {
+          "@id": "amf://id#14/source-map/auto-generated-name/element_0"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "amf://id#14/source-map/lexical/element_2"
+        },
+        {
+          "@id": "amf://id#14/source-map/lexical/element_0"
+        },
+        {
+          "@id": "amf://id#14/source-map/lexical/element_1"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
+        {
+          "@id": "amf://id#14/source-map/type-property-lexical-info/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "amf://id#13/source-map/synthesized-field/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#style",
+      "http://a.ml/vocabularies/document-source-maps#value": "true"
+    },
+    {
+      "@id": "amf://id#13/source-map/synthesized-field/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#explode",
+      "http://a.ml/vocabularies/document-source-maps#value": "true"
+    },
+    {
+      "@id": "amf://id#13/source-map/lexical/element_6",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#binding",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(19,8)-(20,0)]"
+    },
+    {
+      "@id": "amf://id#13/source-map/lexical/element_4",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(18,8)-(19,0)]"
+    },
+    {
+      "@id": "amf://id#13/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#paramName",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(18,8)-(19,0)]"
+    },
+    {
+      "@id": "amf://id#13/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/shapes#schema",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(22,8)-(24,0)]"
+    },
+    {
+      "@id": "amf://id#13/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#required",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(20,8)-(21,0)]"
+    },
+    {
+      "@id": "amf://id#13/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#13",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(18,8)-(24,0)]"
+    },
+    {
+      "@id": "amf://id#13/source-map/lexical/element_5",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(21,8)-(22,0)]"
     },
     {
       "@id": "amf://id#12/source-map",
@@ -583,39 +741,59 @@
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#11/source-map/lexical/element_6",
+      "@id": "amf://id#11/source-map/lexical/element_5",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#binding",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(19,8)-(20,0)]"
-    },
-    {
-      "@id": "amf://id#11/source-map/lexical/element_4",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(18,8)-(19,0)]"
-    },
-    {
-      "@id": "amf://id#11/source-map/lexical/element_2",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#paramName",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(18,8)-(19,0)]"
-    },
-    {
-      "@id": "amf://id#11/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/shapes#schema",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(22,8)-(24,0)]"
-    },
-    {
-      "@id": "amf://id#11/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#required",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(20,8)-(21,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(27,10)-(28,0)]"
     },
     {
       "@id": "amf://id#11/source-map/lexical/element_3",
       "http://a.ml/vocabularies/document-source-maps#element": "amf://id#11",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(18,8)-(24,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(26,10)-(31,0)]"
     },
     {
-      "@id": "amf://id#11/source-map/lexical/element_5",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(21,8)-(22,0)]"
+      "@id": "amf://id#11/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#required",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(28,10)-(29,0)]"
+    },
+    {
+      "@id": "amf://id#11/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/shapes#schema",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(29,10)-(31,0)]"
+    },
+    {
+      "@id": "amf://id#11/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(26,10)-(27,0)]"
+    },
+    {
+      "@id": "amf://id#11/source-map/lexical/element_4",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#paramName",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(26,10)-(27,0)]"
+    },
+    {
+      "@id": "amf://id#14/source-map/auto-generated-name/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#14",
+      "http://a.ml/vocabularies/document-source-maps#value": ""
+    },
+    {
+      "@id": "amf://id#14/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(23,10)-(24,0)]"
+    },
+    {
+      "@id": "amf://id#14/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(18,8)-(19,0)]"
+    },
+    {
+      "@id": "amf://id#14/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#14",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(22,8)-(24,0)]"
+    },
+    {
+      "@id": "amf://id#14/source-map/type-property-lexical-info/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#14",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(23,10)-(23,14)]"
     },
     {
       "@id": "amf://id#12/source-map/auto-generated-name/element_0",
@@ -625,22 +803,22 @@
     {
       "@id": "amf://id#12/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(23,10)-(24,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(30,12)-(31,0)]"
     },
     {
       "@id": "amf://id#12/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#name",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(18,8)-(19,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(26,10)-(27,0)]"
     },
     {
       "@id": "amf://id#12/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "amf://id#12",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(22,8)-(24,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(29,10)-(31,0)]"
     },
     {
       "@id": "amf://id#12/source-map/type-property-lexical-info/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "amf://id#12",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(23,10)-(23,14)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(30,12)-(30,16)]"
     },
     {
       "@id": "amf://id",

--- a/test/data/production/spectral/positive16.yaml.jsonld
+++ b/test/data/production/spectral/positive16.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -179,6 +179,7 @@
       "@id": "amf://id#7",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -303,6 +304,7 @@
       "@id": "amf://id#10",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -316,6 +318,7 @@
       "@id": "amf://id#9",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -391,6 +394,7 @@
       "@id": "amf://id#11",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",

--- a/test/data/production/spectral/positive17.yaml.jsonld
+++ b/test/data/production/spectral/positive17.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -179,6 +179,7 @@
       "@id": "amf://id#7",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -303,6 +304,7 @@
       "@id": "amf://id#10",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -316,6 +318,7 @@
       "@id": "amf://id#9",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -391,6 +394,7 @@
       "@id": "amf://id#11",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",

--- a/test/data/production/spectral/positive18.yaml.jsonld
+++ b/test/data/production/spectral/positive18.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -179,6 +179,7 @@
       "@id": "amf://id#14",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -303,6 +304,7 @@
       "@id": "amf://id#17",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -316,6 +318,7 @@
       "@id": "amf://id#16",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -391,6 +394,7 @@
       "@id": "amf://id#18",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",

--- a/test/data/production/spectral/positive2.yaml.jsonld
+++ b/test/data/production/spectral/positive2.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -179,6 +179,7 @@
       "@id": "amf://id#7",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "post",
@@ -298,6 +299,7 @@
       "@id": "amf://id#9",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],

--- a/test/data/production/spectral/positive4.yaml.jsonld
+++ b/test/data/production/spectral/positive4.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -179,6 +179,7 @@
       "@id": "amf://id#7",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -303,6 +304,7 @@
       "@id": "amf://id#14",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -321,6 +323,7 @@
       "@id": "amf://id#9",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -401,6 +404,7 @@
       "@id": "amf://id#17",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -423,6 +427,7 @@
       "@id": "amf://id#15",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -445,6 +450,7 @@
       "@id": "amf://id#10",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/spectral/positive5.yaml.jsonld
+++ b/test/data/production/spectral/positive5.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -221,6 +221,7 @@
       "@id": "amf://id#7",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -258,6 +259,7 @@
       "@id": "amf://id#15",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -300,6 +302,7 @@
       "@id": "amf://id#26",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -424,6 +427,7 @@
       "@id": "amf://id#9",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -489,6 +493,7 @@
       "@id": "amf://id#22",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -502,6 +507,7 @@
       "@id": "amf://id#17",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -567,6 +573,7 @@
       "@id": "amf://id#33",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -583,6 +590,7 @@
       "@id": "amf://id#28",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -663,6 +671,7 @@
       "@id": "amf://id#10",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -740,6 +749,7 @@
       "@id": "amf://id#23",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -762,6 +772,7 @@
       "@id": "amf://id#18",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",
@@ -839,6 +850,7 @@
       "@id": "amf://id#34",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "id",
@@ -861,6 +873,7 @@
       "@id": "amf://id#36",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "other",
@@ -883,6 +896,7 @@
       "@id": "amf://id#29",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/spectral/positive6.yaml.jsonld
+++ b/test/data/production/spectral/positive6.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },

--- a/test/data/production/spectral/positive7.yaml.jsonld
+++ b/test/data/production/spectral/positive7.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },

--- a/test/data/production/spectral/positive8.yaml.jsonld
+++ b/test/data/production/spectral/positive8.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },

--- a/test/data/production/spectral/positive9.yaml.jsonld
+++ b/test/data/production/spectral/positive9.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },

--- a/test/data/production/spectral/profile.yaml
+++ b/test/data/production/spectral/profile.yaml
@@ -3,28 +3,28 @@
 profile: Spectral Base
 
 violation:
-  - operation-2xx-response
+#  - operation-2xx-response
   - path-params
-  - no-eval-in-markdown
-  - no-script-tags-in-markdown
-  - operation-default-response
-  - operation-operationId
-  - path-declarations-must-exist
-  - path-keys-no-trailing-slash
-  - path-not-include-query
-  - duplicated-entry-in-enum
+#  - no-eval-in-markdown
+#  - no-script-tags-in-markdown
+#  - operation-default-response
+#  - operation-operationId
+#  - path-declarations-must-exist
+#  - path-keys-no-trailing-slash
+#  - path-not-include-query
+#  - duplicated-entry-in-enum
 
 warning:
-  - operation-singular-tag
-  - tag-description
-  - info-contact
-  - info-description
-  - info-license
-  - license-url
-  - openapi-tags
-  - operation-description
-  - operation-tags
-  - operation-tag-defined
+#  - operation-singular-tag
+#  - tag-description
+#  - info-contact
+#  - info-description
+#  - info-license
+#  - license-url
+#  - openapi-tags
+#  - operation-description
+#  - operation-tags
+#  - operation-tag-defined
 
 validations:
 
@@ -54,22 +54,28 @@ validations:
     rego: |
       path = $node["http://a.ml/vocabularies/apiContract#path"]
       pathVariables = {v | ms = regex.find_all_string_submatch_n("{([a-z0-9_]+)}", path, -1); m = ms[_]; v = m[1] }
-
-      nested_nodes[operations] with data.nodes as $node["http://a.ml/vocabularies/apiContract#supportedOperation"]
-      operation = operations[_]
-
-      nested_nodes[requests] with data.nodes as object.get(operation, "http://a.ml/vocabularies/apiContract#expects", [])
-      request = requests[_]
-
-      nested_nodes[parameters] with data.nodes as object.get(request, "http://a.ml/vocabularies/apiContract#uriParameter", [])
-
-      declaredPathVariables = { desc |
-        parameter = parameters[_]
+      nested_nodes[endpointParameters] with data.nodes as object.get($node, "http://a.ml/vocabularies/apiContract#parameter", [])
+      
+      endpointParameterNames = { desc |
+        parameter = endpointParameters[_]
         name = parameter["http://a.ml/vocabularies/core#name"]
         parameter["http://a.ml/vocabularies/apiContract#binding"] = "path"
         desc = name
       }
-      $result = (pathVariables == declaredPathVariables)
+      
+      nested_nodes[operations] with data.nodes as object.get($node, "http://a.ml/vocabularies/apiContract#supportedOperation", [])
+      operation = operations[_]
+      nested_nodes[requests] with data.nodes as object.get(operation, "http://a.ml/vocabularies/apiContract#expects", [])
+      request = requests[_]
+      nested_nodes[operationParameters] with data.nodes as object.get(request, "http://a.ml/vocabularies/apiContract#uriParameter", [])
+      operationParameterNames = { desc |
+        parameter = operationParameters[_]
+        name = parameter["http://a.ml/vocabularies/core#name"]
+        parameter["http://a.ml/vocabularies/apiContract#binding"] = "path"
+        desc = name
+      }
+      parameterNames := endpointParameterNames | operationParameterNames
+      $result = (pathVariables == parameterNames)
 
 
   info-contact:

--- a/test/data/production/spectral/profile.yaml
+++ b/test/data/production/spectral/profile.yaml
@@ -3,28 +3,26 @@
 profile: Spectral Base
 
 violation:
-#  - operation-2xx-response
+  - operation-2xx-response
   - path-params
-#  - no-eval-in-markdown
-#  - no-script-tags-in-markdown
-#  - operation-default-response
-#  - operation-operationId
-#  - path-declarations-must-exist
-#  - path-keys-no-trailing-slash
-#  - path-not-include-query
-#  - duplicated-entry-in-enum
-
-warning:
-#  - operation-singular-tag
-#  - tag-description
-#  - info-contact
-#  - info-description
-#  - info-license
-#  - license-url
-#  - openapi-tags
-#  - operation-description
-#  - operation-tags
-#  - operation-tag-defined
+  - no-eval-in-markdown
+  - no-script-tags-in-markdown
+  - operation-default-response
+  - operation-operationId
+  - path-declarations-must-exist
+  - path-keys-no-trailing-slash
+  - path-not-include-query
+  - duplicated-entry-in-enum
+  - operation-singular-tag
+  - tag-description
+  - info-contact
+  - info-description
+  - info-license
+  - license-url
+  - openapi-tags
+  - operation-description
+  - operation-tags
+  - operation-tag-defined
 
 validations:
 

--- a/test/data/production/spectral/profile.yaml
+++ b/test/data/production/spectral/profile.yaml
@@ -13,8 +13,6 @@ violation:
   - path-keys-no-trailing-slash
   - path-not-include-query
   - duplicated-entry-in-enum
-
-warning:
   - operation-singular-tag
   - tag-description
   - info-contact
@@ -54,22 +52,28 @@ validations:
     rego: |
       path = $node["http://a.ml/vocabularies/apiContract#path"]
       pathVariables = {v | ms = regex.find_all_string_submatch_n("{([a-z0-9_]+)}", path, -1); m = ms[_]; v = m[1] }
-
-      nested_nodes[operations] with data.nodes as $node["http://a.ml/vocabularies/apiContract#supportedOperation"]
-      operation = operations[_]
-
-      nested_nodes[requests] with data.nodes as object.get(operation, "http://a.ml/vocabularies/apiContract#expects", [])
-      request = requests[_]
-
-      nested_nodes[parameters] with data.nodes as object.get(request, "http://a.ml/vocabularies/apiContract#uriParameter", [])
-
-      declaredPathVariables = { desc |
-        parameter = parameters[_]
+      nested_nodes[endpointParameters] with data.nodes as object.get($node, "http://a.ml/vocabularies/apiContract#parameter", [])
+      
+      endpointParameterNames = { desc |
+        parameter = endpointParameters[_]
         name = parameter["http://a.ml/vocabularies/core#name"]
         parameter["http://a.ml/vocabularies/apiContract#binding"] = "path"
         desc = name
       }
-      $result = (pathVariables == declaredPathVariables)
+      
+      nested_nodes[operations] with data.nodes as object.get($node, "http://a.ml/vocabularies/apiContract#supportedOperation", [])
+      operation = operations[_]
+      nested_nodes[requests] with data.nodes as object.get(operation, "http://a.ml/vocabularies/apiContract#expects", [])
+      request = requests[_]
+      nested_nodes[operationParameters] with data.nodes as object.get(request, "http://a.ml/vocabularies/apiContract#uriParameter", [])
+      operationParameterNames = { desc |
+        parameter = operationParameters[_]
+        name = parameter["http://a.ml/vocabularies/core#name"]
+        parameter["http://a.ml/vocabularies/apiContract#binding"] = "path"
+        desc = name
+      }
+      parameterNames := endpointParameterNames | operationParameterNames
+      $result = (pathVariables == parameterNames)
 
 
   info-contact:

--- a/test/data/production/zalando/negative1.yaml.jsonld
+++ b/test/data/production/zalando/negative1.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },

--- a/test/data/production/zalando/negative2.yaml.jsonld
+++ b/test/data/production/zalando/negative2.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -169,6 +169,7 @@
       "@id": "amf://id#6",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "Link",

--- a/test/data/production/zalando/negative3.yaml.jsonld
+++ b/test/data/production/zalando/negative3.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -169,6 +169,7 @@
       "@id": "amf://id#6",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -281,6 +282,7 @@
       "@id": "amf://id#17",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -294,6 +296,7 @@
       "@id": "amf://id#8",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -359,6 +362,7 @@
       "@id": "amf://id#18",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "invoice_id",
@@ -381,6 +385,7 @@
       "@id": "amf://id#9",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/production/zalando/positive1.yaml.jsonld
+++ b/test/data/production/zalando/positive1.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },

--- a/test/data/production/zalando/positive2.yaml.jsonld
+++ b/test/data/production/zalando/positive2.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },

--- a/test/data/production/zalando/positive3.yaml.jsonld
+++ b/test/data/production/zalando/positive3.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -169,6 +169,7 @@
       "@id": "amf://id#6",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -281,6 +282,7 @@
       "@id": "amf://id#17",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/core#Request",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -294,6 +296,7 @@
       "@id": "amf://id#8",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
@@ -359,6 +362,7 @@
       "@id": "amf://id#18",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/core#Parameter",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "invoice_id",
@@ -381,6 +385,7 @@
       "@id": "amf://id#9",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#mediaType": "application/json",

--- a/test/data/semex/semantic-extension-pagination/api.async.yaml.jsonld
+++ b/test/data/semex/semantic-extension-pagination/api.async.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "ASYNC 2.0"
     },
@@ -79,6 +79,7 @@
       "@id": "amf://id#4",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "subscribe",
@@ -132,6 +133,7 @@
       "@id": "amf://id#5",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],

--- a/test/data/semex/semantic-extension-pagination/api.oas20.yaml.jsonld
+++ b/test/data/semex/semantic-extension-pagination/api.oas20.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },
@@ -79,6 +79,7 @@
       "@id": "amf://id#4",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -128,6 +129,7 @@
       "@id": "amf://id#5",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],

--- a/test/data/semex/semantic-extension-pagination/api.oas30.yaml.jsonld
+++ b/test/data/semex/semantic-extension-pagination/api.oas30.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
@@ -79,6 +79,7 @@
       "@id": "amf://id#4",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -128,6 +129,7 @@
       "@id": "amf://id#5",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],

--- a/test/data/semex/semantic-extension-pagination/api.raml.jsonld
+++ b/test/data/semex/semantic-extension-pagination/api.raml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.2.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.5.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
@@ -72,6 +72,7 @@
       "@id": "amf://id#4",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#method": "get",
@@ -114,6 +115,7 @@
       "@id": "amf://id#5",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
         "http://a.ml/vocabularies/apiContract#Message",
         "http://a.ml/vocabularies/document#DomainElement"
       ],

--- a/test/fixtures.go
+++ b/test/fixtures.go
@@ -125,6 +125,24 @@ func (f ProductionExample) Reportfile() string {
 	return strings.ReplaceAll(string(f.File), ".jsonld", ".report.jsonld")
 }
 
+func (f ProductionExample) Regofile() string {
+	parts := strings.Split(f.File, string(os.PathSeparator))
+	parts = parts[:len(parts)-1]
+	parts = append(parts, "profile.rego")
+	return strings.Join(parts, string(os.PathSeparator))
+}
+
+func (f ProductionExample) Folfile() string {
+	parts := strings.Split(f.File, string(os.PathSeparator))
+	parts = parts[:len(parts)-1]
+	parts = append(parts, "profile.fol")
+	return strings.Join(parts, string(os.PathSeparator))
+}
+
+func (f ProductionExample) Normalizedinputfile() string {
+	return strings.ReplaceAll(string(f.File), ".jsonld", ".normalized")
+}
+
 func (f ProductionFixture) Examples() []ProductionExample {
 	var acc []ProductionExample
 	filepath.Walk(string(f), func(path string, info os.FileInfo, err error) error {

--- a/wrappers/js-web/package-lock.json
+++ b/wrappers/js-web/package-lock.json
@@ -1,8 +1,9017 @@
 {
   "name": "@aml-org/amf-custom-validator-web",
-  "version": "1.2.0-SNAPSHOT",
-  "lockfileVersion": 1,
+  "version": "1.2.1-SNAPSHOT",
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "@aml-org/amf-custom-validator-web",
+      "version": "1.2.0-SNAPSHOT",
+      "license": "ISC",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "crypto-browserify": "^3.12.0",
+        "os-browserify": "^0.3.0",
+        "pako": "^2.0.4",
+        "stream-browserify": "^3.0.0",
+        "util": "^0.12.4"
+      },
+      "devDependencies": {
+        "cypress": "^9.1.0",
+        "express": "^4.17.1",
+        "forever": "^4.0.1",
+        "mocha": "^8.4.0",
+        "nodemon": "^2.0.15",
+        "npm-run-all": "^4.1.5",
+        "webpack": "^5.53.0",
+        "webpack-cli": "^4.8.0"
+      }
+    },
+    "node_modules/@cypress/request": {
+      "version": "2.88.9",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.9.tgz",
+      "integrity": "sha512-6md3dtAd3DXfTEXFb2Yde3TSaqpYsSBw3a1VFwAC9Fscu2B0DtY2Venu35csZyJj09XNkPMGRoE4ZXUdtkI+zg==",
+      "dev": true,
+      "dependencies": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.3.6",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@cypress/xvfb": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@cypress/xvfb/-/xvfb-1.2.4.tgz",
+      "integrity": "sha512-skbBzPggOVYCbnGgV+0dmBdW/s77ZkAOXIC1knS8NagwDjBrNC1LuXtQJeiN6l+m7lzmHtaoUw/ctJKdqkG57Q==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^3.1.0",
+        "lodash.once": "^4.1.1"
+      }
+    },
+    "node_modules/@cypress/xvfb/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/@discoveryjs/json-ext": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.5.tgz",
+      "integrity": "sha512-6nFkfkmSeV/rqSaS4oWHgmpnYw194f6hmWF5is6b0J1naJZoiD0NTc9AiUwPHvWsowkjuHErCZT1wa0jg+BLIA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
+      "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@szmarczak/http-timer": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
+      "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
+      "dev": true,
+      "dependencies": {
+        "defer-to-connect": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@types/eslint": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.28.0.tgz",
+      "integrity": "sha512-07XlgzX0YJUn4iG1ocY4IX9DzKSmMGUs6ESKlxWhZRaa0fatIWaHWUVapcuGa8r5HFnTqzj+4OCjd5f7EZ/i/A==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "node_modules/@types/eslint-scope": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.1.tgz",
+      "integrity": "sha512-SCFeogqiptms4Fg29WpOTk5nHIzfpKCemSN63ksBQYKTcXoJEmJagV+DhVmbapZzY4/5YaOV1nZwrsU79fFm1g==",
+      "dev": true,
+      "dependencies": {
+        "@types/eslint": "*",
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "0.0.50",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
+      "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==",
+      "dev": true
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.9",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
+      "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "16.9.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.4.tgz",
+      "integrity": "sha512-KDazLNYAGIuJugdbULwFZULF9qQ13yNWEBFnfVpqlpgAAo6H/qnM9RjBgh0A0kmHf3XxAKLdN5mTIng9iUvVLA==",
+      "dev": true
+    },
+    "node_modules/@types/sinonjs__fake-timers": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.4.tgz",
+      "integrity": "sha512-IFQTJARgMUBF+xVd2b+hIgXWrZEjND3vJtRCvIelcFB5SIXfjV4bOHbHJ0eXKh+0COrBRc8MqteKAz/j88rE0A==",
+      "dev": true
+    },
+    "node_modules/@types/sizzle": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
+      "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==",
+      "dev": true
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.2.tgz",
+      "integrity": "sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@ungap/promise-all-settled": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
+      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
+      "dev": true
+    },
+    "node_modules/@webassemblyjs/ast": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
+      "integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
+      "dev": true,
+      "dependencies": {
+        "@webassemblyjs/helper-numbers": "1.11.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.1"
+      }
+    },
+    "node_modules/@webassemblyjs/floating-point-hex-parser": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
+      "integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==",
+      "dev": true
+    },
+    "node_modules/@webassemblyjs/helper-api-error": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
+      "integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==",
+      "dev": true
+    },
+    "node_modules/@webassemblyjs/helper-buffer": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
+      "integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==",
+      "dev": true
+    },
+    "node_modules/@webassemblyjs/helper-numbers": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
+      "integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
+      "dev": true,
+      "dependencies": {
+        "@webassemblyjs/floating-point-hex-parser": "1.11.1",
+        "@webassemblyjs/helper-api-error": "1.11.1",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@webassemblyjs/helper-wasm-bytecode": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
+      "integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==",
+      "dev": true
+    },
+    "node_modules/@webassemblyjs/helper-wasm-section": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
+      "integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
+      "dev": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.11.1",
+        "@webassemblyjs/helper-buffer": "1.11.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+        "@webassemblyjs/wasm-gen": "1.11.1"
+      }
+    },
+    "node_modules/@webassemblyjs/ieee754": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
+      "integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
+      "dev": true,
+      "dependencies": {
+        "@xtuc/ieee754": "^1.2.0"
+      }
+    },
+    "node_modules/@webassemblyjs/leb128": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
+      "integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
+      "dev": true,
+      "dependencies": {
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@webassemblyjs/utf8": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
+      "integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==",
+      "dev": true
+    },
+    "node_modules/@webassemblyjs/wasm-edit": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
+      "integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
+      "dev": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.11.1",
+        "@webassemblyjs/helper-buffer": "1.11.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+        "@webassemblyjs/helper-wasm-section": "1.11.1",
+        "@webassemblyjs/wasm-gen": "1.11.1",
+        "@webassemblyjs/wasm-opt": "1.11.1",
+        "@webassemblyjs/wasm-parser": "1.11.1",
+        "@webassemblyjs/wast-printer": "1.11.1"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-gen": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
+      "integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
+      "dev": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.11.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+        "@webassemblyjs/ieee754": "1.11.1",
+        "@webassemblyjs/leb128": "1.11.1",
+        "@webassemblyjs/utf8": "1.11.1"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-opt": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
+      "integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
+      "dev": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.11.1",
+        "@webassemblyjs/helper-buffer": "1.11.1",
+        "@webassemblyjs/wasm-gen": "1.11.1",
+        "@webassemblyjs/wasm-parser": "1.11.1"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-parser": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
+      "integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
+      "dev": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.11.1",
+        "@webassemblyjs/helper-api-error": "1.11.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+        "@webassemblyjs/ieee754": "1.11.1",
+        "@webassemblyjs/leb128": "1.11.1",
+        "@webassemblyjs/utf8": "1.11.1"
+      }
+    },
+    "node_modules/@webassemblyjs/wast-printer": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
+      "integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
+      "dev": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.11.1",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@webpack-cli/configtest": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.0.4.tgz",
+      "integrity": "sha512-cs3XLy+UcxiP6bj0A6u7MLLuwdXJ1c3Dtc0RkKg+wiI1g/Ti1om8+/2hc2A2B60NbBNAbMgyBMHvyymWm/j4wQ==",
+      "dev": true,
+      "peerDependencies": {
+        "webpack": "4.x.x || 5.x.x",
+        "webpack-cli": "4.x.x"
+      }
+    },
+    "node_modules/@webpack-cli/info": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.3.0.tgz",
+      "integrity": "sha512-ASiVB3t9LOKHs5DyVUcxpraBXDOKubYu/ihHhU+t1UPpxsivg6Od2E2qU4gJCekfEddzRBzHhzA/Acyw/mlK/w==",
+      "dev": true,
+      "dependencies": {
+        "envinfo": "^7.7.3"
+      },
+      "peerDependencies": {
+        "webpack-cli": "4.x.x"
+      }
+    },
+    "node_modules/@webpack-cli/serve": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.5.2.tgz",
+      "integrity": "sha512-vgJ5OLWadI8aKjDlOH3rb+dYyPd2GTZuQC/Tihjct6F9GpXGZINo3Y/IVuZVTM1eDQB+/AOsjPUWH/WySDaXvw==",
+      "dev": true,
+      "peerDependencies": {
+        "webpack-cli": "4.x.x"
+      },
+      "peerDependenciesMeta": {
+        "webpack-dev-server": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@xtuc/ieee754": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+      "dev": true
+    },
+    "node_modules/@xtuc/long": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+      "dev": true
+    },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true
+    },
+    "node_modules/accepts": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+      "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+      "dev": true,
+      "dependencies": {
+        "mime-types": "~2.1.24",
+        "negotiator": "0.6.2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
+      "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-assertions": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.7.6.tgz",
+      "integrity": "sha512-FlVvVFA1TX6l3lp8VjDnYYq7R1nyW6x3svAt4nDgrWQ9SBaSh9CnbwgSUTasgfNfOG5HlM1ehugCvM+hjo56LA==",
+      "dev": true,
+      "peerDependencies": {
+        "acorn": "^8"
+      }
+    },
+    "node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dev": true,
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-keywords": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "dev": true,
+      "peerDependencies": {
+        "ajv": "^6.9.1"
+      }
+    },
+    "node_modules/ansi-align": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.1.0"
+      }
+    },
+    "node_modules/ansi-align/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-align/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-align/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-align/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-colors": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "dev": true,
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/arch": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
+      "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/arr-diff": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+      "dev": true
+    },
+    "node_modules/array-unique": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "dev": true,
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "node_modules/asn1.js/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+    },
+    "node_modules/assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/async": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.2.tgz",
+      "integrity": "sha512-H0E+qZaDEfx/FY4t7iLRv1W2fFI6+pyCeTw1uN20AQPiwqwM6ojPxHxdLv4z8hi2DtnW9BOckSspLucW7pIE5g==",
+      "dev": true
+    },
+    "node_modules/async-each": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
+      "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
+      "dev": true
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "node_modules/at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "dev": true,
+      "bin": {
+        "atob": "bin/atob.js"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws4": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
+      "dev": true
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/base": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "dev": true,
+      "dependencies": {
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/base/node_modules/define-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+      "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+      "dev": true,
+      "dependencies": {
+        "is-descriptor": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/base/node_modules/is-accessor-descriptor": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+      "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/base/node_modules/is-data-descriptor": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+      "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/base/node_modules/is-descriptor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+      "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+      "dev": true,
+      "dependencies": {
+        "is-accessor-descriptor": "^1.0.0",
+        "is-data-descriptor": "^1.0.0",
+        "kind-of": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/blob-util": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/blob-util/-/blob-util-2.0.2.tgz",
+      "integrity": "sha512-T7JQa+zsXXEa6/8ZhHcQEW1UFfVM49Ts65uBkFL6fz2QmrElqmbajIDJvuA0tEhRe5eIjpV9ZF+0RfZR9voJFQ==",
+      "dev": true
+    },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true
+    },
+    "node_modules/bn.js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+      "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
+    },
+    "node_modules/body-parser": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+      "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
+      "dev": true,
+      "dependencies": {
+        "bytes": "3.1.0",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "on-finished": "~2.3.0",
+        "qs": "6.7.0",
+        "raw-body": "2.4.0",
+        "type-is": "~1.6.17"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/body-parser/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/body-parser/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "node_modules/body-parser/node_modules/qs": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+      "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/boxen": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.2.tgz",
+      "integrity": "sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-align": "^3.0.0",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.1.0",
+        "cli-boxes": "^2.2.1",
+        "string-width": "^4.2.2",
+        "type-fest": "^0.20.2",
+        "widest-line": "^3.1.0",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/boxen/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/boxen/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/boxen/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/boxen/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/broadway": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/broadway/-/broadway-0.3.6.tgz",
+      "integrity": "sha1-fb7waLlUt5B5Jf1USWO1eKkCuno=",
+      "dev": true,
+      "dependencies": {
+        "cliff": "0.1.9",
+        "eventemitter2": "0.4.14",
+        "nconf": "0.6.9",
+        "utile": "0.2.1",
+        "winston": "0.8.0"
+      },
+      "engines": {
+        "node": ">= 0.6.4"
+      }
+    },
+    "node_modules/broadway/node_modules/async": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+      "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+      "dev": true
+    },
+    "node_modules/broadway/node_modules/cliff": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/cliff/-/cliff-0.1.9.tgz",
+      "integrity": "sha1-ohHgnGo947oa8n0EnTASUNGIErw=",
+      "dev": true,
+      "dependencies": {
+        "colors": "0.x.x",
+        "eyes": "0.1.x",
+        "winston": "0.8.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/broadway/node_modules/colors": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+      "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/broadway/node_modules/eventemitter2": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+      "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
+      "dev": true
+    },
+    "node_modules/broadway/node_modules/winston": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-0.8.0.tgz",
+      "integrity": "sha1-YdCDD6aZcGISIGsKK1ymmpMENmg=",
+      "dev": true,
+      "dependencies": {
+        "async": "0.2.x",
+        "colors": "0.6.x",
+        "cycle": "1.0.x",
+        "eyes": "0.1.x",
+        "pkginfo": "0.3.x",
+        "stack-trace": "0.0.x"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+    },
+    "node_modules/browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "node_modules/browserify-aes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+      "dependencies": {
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/browserify-cipher": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+      "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+      "dependencies": {
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
+      }
+    },
+    "node_modules/browserify-des": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/browserify-rsa": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.0.tgz",
+      "integrity": "sha512-AdEER0Hkspgno2aR97SAf6vi0y0k8NuOpGnVH3O99rcA5Q6sh8QxcngtHuJ6uXwnfAXNM4Gn1Gb7/MV1+Ymbog==",
+      "dependencies": {
+        "bn.js": "^5.0.0",
+        "randombytes": "^2.0.1"
+      }
+    },
+    "node_modules/browserify-sign": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.1.tgz",
+      "integrity": "sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==",
+      "dependencies": {
+        "bn.js": "^5.1.1",
+        "browserify-rsa": "^4.0.1",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.5.3",
+        "inherits": "^2.0.4",
+        "parse-asn1": "^5.1.5",
+        "readable-stream": "^3.6.0",
+        "safe-buffer": "^5.2.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.0.tgz",
+      "integrity": "sha512-g2BJ2a0nEYvEFQC208q8mVAhfNwpZ5Mu8BwgtCdZKO3qx98HChmeg448fPdUzld8aFmfLgVh7yymqV+q1lJZ5g==",
+      "dev": true,
+      "dependencies": {
+        "caniuse-lite": "^1.0.30001254",
+        "colorette": "^1.3.0",
+        "electron-to-chromium": "^1.3.830",
+        "escalade": "^3.1.1",
+        "node-releases": "^1.1.75"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
+    },
+    "node_modules/buffer-xor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
+    },
+    "node_modules/bytes": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cache-base": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "dev": true,
+      "dependencies": {
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cacheable-request": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
+      "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
+      "dev": true,
+      "dependencies": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^3.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^4.1.0",
+        "responselike": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cacheable-request/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cacheable-request/node_modules/lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cachedir": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.3.0.tgz",
+      "integrity": "sha512-A+Fezp4zxnit6FanDmv9EqXNAi3vt9DWp51/71UEhXukb7QUuvtv9344h91dyAxuTLoSYJFU299qzR3tzwPAhw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/caller": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/caller/-/caller-0.0.1.tgz",
+      "integrity": "sha1-83odbqEOgp2UchrimpC7T7Uqt2c=",
+      "dev": true,
+      "dependencies": {
+        "tape": "~2.3.2"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
+      "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001258",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001258.tgz",
+      "integrity": "sha512-RBByOG6xWXUp0CR2/WU2amXz3stjKpSl5J1xU49F1n2OxD//uBZO4wCKUiG+QMGf7CHGfDDcqoKriomoGVxTeA==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
+      }
+    },
+    "node_modules/caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
+    },
+    "node_modules/chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/check-more-types": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
+      "integrity": "sha1-FCD/sQ/URNz8ebQ4kbv//TKoRgA=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
+      "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
+      "dev": true,
+      "dependencies": {
+        "anymatch": "~3.1.1",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.0",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.5.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.1"
+      }
+    },
+    "node_modules/chrome-trace-event": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
+      "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.0.tgz",
+      "integrity": "sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==",
+      "dev": true
+    },
+    "node_modules/cipher-base": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/class-utils": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "dev": true,
+      "dependencies": {
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/class-utils/node_modules/define-property": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+      "dev": true,
+      "dependencies": {
+        "is-descriptor": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cli-boxes": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
+      "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-table3": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.0.tgz",
+      "integrity": "sha512-gnB85c3MGC7Nm9I/FkiasNBOKjOiO1RNuXXarQms37q4QMpWdlbBgD/VnOStA2faG1dpXMv31RFApjX1/QdgWQ==",
+      "dev": true,
+      "dependencies": {
+        "object-assign": "^4.1.0",
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      },
+      "optionalDependencies": {
+        "colors": "^1.1.2"
+      }
+    },
+    "node_modules/cli-table3/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-table3/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-table3/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-table3/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
+      "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
+      "dev": true,
+      "dependencies": {
+        "slice-ansi": "^3.0.0",
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliff": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/cliff/-/cliff-0.1.10.tgz",
+      "integrity": "sha1-U74z6p9ZvshWCe4wCsQgdgPlIBM=",
+      "dev": true,
+      "dependencies": {
+        "colors": "~1.0.3",
+        "eyes": "~0.1.8",
+        "winston": "0.8.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/cliff/node_modules/colors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/clone-deep": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+      "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+      "dev": true,
+      "dependencies": {
+        "is-plain-object": "^2.0.4",
+        "kind-of": "^6.0.2",
+        "shallow-clone": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/clone-response": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+      "dev": true,
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      }
+    },
+    "node_modules/collection-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "dev": true,
+      "dependencies": {
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/colorette": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
+      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
+      "dev": true
+    },
+    "node_modules/colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
+    },
+    "node_modules/common-tags": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
+      "integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+      "dev": true
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "node_modules/configstore": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
+      "integrity": "sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==",
+      "dev": true,
+      "dependencies": {
+        "dot-prop": "^5.2.0",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^3.0.0",
+        "unique-string": "^2.0.0",
+        "write-file-atomic": "^3.0.0",
+        "xdg-basedir": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+      "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-disposition/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "node_modules/content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+      "dev": true
+    },
+    "node_modules/copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "node_modules/create-ecdh": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
+      "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.5.3"
+      }
+    },
+    "node_modules/create-ecdh/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+    },
+    "node_modules/create-hash": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
+      }
+    },
+    "node_modules/create-hmac": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "dependencies": {
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/crypto-browserify": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+      "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+      "dependencies": {
+        "browserify-cipher": "^1.0.0",
+        "browserify-sign": "^4.0.0",
+        "create-ecdh": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^5.0.0",
+        "inherits": "^2.0.1",
+        "pbkdf2": "^3.0.3",
+        "public-encrypt": "^4.0.0",
+        "randombytes": "^2.0.0",
+        "randomfill": "^1.0.3"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/crypto-random-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
+      "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cycle": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/cypress": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.1.0.tgz",
+      "integrity": "sha512-fyXcCN51vixkPrz/vO/Qy6WL3hKYJzCQFeWofOpGOFewVVXrGfmfSOGFntXpzWBXsIwPn3wzW0HOFw51jZajNQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@cypress/request": "^2.88.7",
+        "@cypress/xvfb": "^1.2.4",
+        "@types/node": "^14.14.31",
+        "@types/sinonjs__fake-timers": "^6.0.2",
+        "@types/sizzle": "^2.3.2",
+        "arch": "^2.2.0",
+        "blob-util": "^2.0.2",
+        "bluebird": "3.7.2",
+        "cachedir": "^2.3.0",
+        "chalk": "^4.1.0",
+        "check-more-types": "^2.24.0",
+        "cli-cursor": "^3.1.0",
+        "cli-table3": "~0.6.0",
+        "commander": "^5.1.0",
+        "common-tags": "^1.8.0",
+        "dayjs": "^1.10.4",
+        "debug": "^4.3.2",
+        "enquirer": "^2.3.6",
+        "eventemitter2": "^6.4.3",
+        "execa": "4.1.0",
+        "executable": "^4.1.1",
+        "extract-zip": "2.0.1",
+        "figures": "^3.2.0",
+        "fs-extra": "^9.1.0",
+        "getos": "^3.2.1",
+        "is-ci": "^3.0.0",
+        "is-installed-globally": "~0.4.0",
+        "lazy-ass": "^1.6.0",
+        "listr2": "^3.8.3",
+        "lodash": "^4.17.21",
+        "log-symbols": "^4.0.0",
+        "minimist": "^1.2.5",
+        "ospath": "^1.2.2",
+        "pretty-bytes": "^5.6.0",
+        "proxy-from-env": "1.0.0",
+        "request-progress": "^3.0.0",
+        "supports-color": "^8.1.1",
+        "tmp": "~0.2.1",
+        "untildify": "^4.0.0",
+        "url": "^0.11.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "cypress": "bin/cypress"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/cypress/node_modules/@types/node": {
+      "version": "14.17.34",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.34.tgz",
+      "integrity": "sha512-USUftMYpmuMzeWobskoPfzDi+vkpe0dvcOBRNOscFrGxVp4jomnRxWuVohgqBow2xyIPC0S3gjxV/5079jhmDg==",
+      "dev": true
+    },
+    "node_modules/cypress/node_modules/commander": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/cypress/node_modules/debug": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cypress/node_modules/execa": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+      "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "get-stream": "^5.0.0",
+        "human-signals": "^1.1.1",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.0",
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/cypress/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cypress/node_modules/human-signals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.12.0"
+      }
+    },
+    "node_modules/cypress/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.7.tgz",
+      "integrity": "sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig==",
+      "dev": true
+    },
+    "node_modules/debug": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/debug/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "dev": true,
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/deep-equal": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.0.5.tgz",
+      "integrity": "sha512-nPiRgmbAtm1a3JsnLCf6/SLfXcjyN5v8L1TXzdCmHrXJ4hx+gW/w1YCcn7z8gJtSiDArZCgYtbao3QqLm/N1Sw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "es-get-iterator": "^1.1.1",
+        "get-intrinsic": "^1.0.1",
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.2",
+        "is-regex": "^1.1.1",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.4",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.2",
+        "regexp.prototype.flags": "^1.3.0",
+        "side-channel": "^1.0.3",
+        "which-boxed-primitive": "^1.0.1",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/defer-to-connect": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
+      "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
+      "dev": true
+    },
+    "node_modules/define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dependencies": {
+        "object-keys": "^1.0.12"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/define-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "dev": true,
+      "dependencies": {
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/define-property/node_modules/is-accessor-descriptor": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+      "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/define-property/node_modules/is-data-descriptor": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+      "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/define-property/node_modules/is-descriptor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+      "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+      "dev": true,
+      "dependencies": {
+        "is-accessor-descriptor": "^1.0.0",
+        "is-data-descriptor": "^1.0.0",
+        "kind-of": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/defined": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
+      "integrity": "sha1-817qfXBekzuvE7LwOz+D2SFAOz4=",
+      "dev": true
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/des.js": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
+      "integrity": "sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+      "dev": true
+    },
+    "node_modules/diff": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/diffie-hellman": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
+      }
+    },
+    "node_modules/diffie-hellman/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+    },
+    "node_modules/director": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/director/-/director-1.2.7.tgz",
+      "integrity": "sha1-v9N0EHX9f7GlsuE2WMX0vsd3NvM=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/dot-prop": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+      "dev": true,
+      "dependencies": {
+        "is-obj": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true
+    },
+    "node_modules/duplexer3": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+      "dev": true
+    },
+    "node_modules/ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
+      "dependencies": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+      "dev": true
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.3.843",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.843.tgz",
+      "integrity": "sha512-OWEwAbzaVd1Lk9MohVw8LxMXFlnYd9oYTYxfX8KS++kLLjDfbovLOcEEXwRhG612dqGQ6+44SZvim0GXuBRiKg==",
+      "dev": true
+    },
+    "node_modules/elliptic": {
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "node_modules/elliptic/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.3.tgz",
+      "integrity": "sha512-EGAbGvH7j7Xt2nc0E7D99La1OiEs8LnyimkRgwExpUMScN6O+3x9tIWs7PLQZVNx4YD+00skHXPXi1yQHpAmZA==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/enquirer": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-colors": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/envinfo": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.8.1.tgz",
+      "integrity": "sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==",
+      "dev": true,
+      "bin": {
+        "envinfo": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-abstract": {
+      "version": "1.18.6",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.6.tgz",
+      "integrity": "sha512-kAeIT4cku5eNLNuUKhlmtuk1/TRZvQoYccn6TO0cSVdf1kzB0T7+dYuVK9MWM7l+/53W2Q8M7N2c6MQvhXFcUQ==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.1.1",
+        "get-symbol-description": "^1.0.0",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.2",
+        "internal-slot": "^1.0.3",
+        "is-callable": "^1.2.4",
+        "is-negative-zero": "^2.0.1",
+        "is-regex": "^1.1.4",
+        "is-string": "^1.0.7",
+        "object-inspect": "^1.11.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.2",
+        "string.prototype.trimend": "^1.0.4",
+        "string.prototype.trimstart": "^1.0.4",
+        "unbox-primitive": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-get-iterator": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.2.tgz",
+      "integrity": "sha512-+DTO8GYwbMCwbywjimwZMHp8AuYXOS2JZFWoi2AlPOS3ebnII9w/NLpNZtA7A0YLaVDw+O7KFCeoIV7OPvM7hQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.0",
+        "has-symbols": "^1.0.1",
+        "is-arguments": "^1.1.0",
+        "is-map": "^2.0.2",
+        "is-set": "^2.0.2",
+        "is-string": "^1.0.5",
+        "isarray": "^2.0.5"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.7.1.tgz",
+      "integrity": "sha512-MgtWFl5No+4S3TmhDmCz2ObFGm6lEpTnzbQi+Dd+pw4mlTIZTmM2iAs5gRlmx5zS9luzobCSBSI90JM/1/JgOw==",
+      "dev": true
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dependencies": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-goat": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-2.1.1.tgz",
+      "integrity": "sha512-8/uIhbG12Csjy2JEW7D9pHbreaVaS/OpN3ycnyvElTdwM5n6GY6W6e2IPemfvGZeUMqZ9A/3GqIZMgKnBhAw/Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+      "dev": true
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dev": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esrecurse/node_modules/estraverse": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+      "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/event-stream": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+      "dev": true,
+      "dependencies": {
+        "duplexer": "~0.1.1",
+        "from": "~0",
+        "map-stream": "~0.1.0",
+        "pause-stream": "0.0.11",
+        "split": "0.3",
+        "stream-combiner": "~0.0.4",
+        "through": "~2.3.1"
+      }
+    },
+    "node_modules/eventemitter2": {
+      "version": "6.4.5",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.5.tgz",
+      "integrity": "sha512-bXE7Dyc1i6oQElDG0jMRZJrRAn9QR2xyyFGmBdZleNmyQX0FqGYmhZIrIrpPfm/w//LTo4tVQGOGQcGCb5q9uw==",
+      "dev": true
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/evp_bytestokey": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "dependencies": {
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/executable": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/executable/-/executable-4.1.1.tgz",
+      "integrity": "sha512-8iA79xD3uAch729dUG8xaaBBFGaEa0wdD2VkYLFHwlqosEj/jT66AzcreRDSgV7ehnNLBW2WR5jIXwGKjVdTLg==",
+      "dev": true,
+      "dependencies": {
+        "pify": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/expand-brackets": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+      "dev": true,
+      "dependencies": {
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expand-brackets/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/expand-brackets/node_modules/define-property": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+      "dev": true,
+      "dependencies": {
+        "is-descriptor": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expand-brackets/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "dev": true,
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expand-brackets/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "node_modules/express": {
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+      "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
+      "dev": true,
+      "dependencies": {
+        "accepts": "~1.3.7",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.19.0",
+        "content-disposition": "0.5.3",
+        "content-type": "~1.0.4",
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.1.2",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.5",
+        "qs": "6.7.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.1.2",
+        "send": "0.17.1",
+        "serve-static": "1.14.1",
+        "setprototypeof": "1.1.1",
+        "statuses": "~1.5.0",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/express/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/express/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "node_modules/express/node_modules/qs": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+      "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/express/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
+    },
+    "node_modules/extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "dev": true,
+      "dependencies": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/extend-shallow/node_modules/is-extendable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+      "dev": true,
+      "dependencies": {
+        "is-plain-object": "^2.0.4"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/extglob": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+      "dev": true,
+      "dependencies": {
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/extglob/node_modules/define-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+      "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+      "dev": true,
+      "dependencies": {
+        "is-descriptor": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/extglob/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "dev": true,
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/extglob/node_modules/is-accessor-descriptor": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+      "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/extglob/node_modules/is-data-descriptor": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+      "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/extglob/node_modules/is-descriptor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+      "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+      "dev": true,
+      "dependencies": {
+        "is-accessor-descriptor": "^1.0.0",
+        "is-data-descriptor": "^1.0.0",
+        "kind-of": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/extract-zip/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true,
+      "engines": [
+        "node >=0.6.0"
+      ]
+    },
+    "node_modules/eyes": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
+      "dev": true,
+      "engines": {
+        "node": "> 0.1.90"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
+    "node_modules/fastest-levenshtein": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
+      "integrity": "sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==",
+      "dev": true
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+      "dev": true,
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/figures": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/figures/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+      "dev": true,
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "statuses": "~1.5.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/finalhandler/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/finalhandler/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true,
+      "bin": {
+        "flat": "cli.js"
+      }
+    },
+    "node_modules/flatiron": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/flatiron/-/flatiron-0.4.3.tgz",
+      "integrity": "sha1-JIz3mj2n19w3nioRySonGcu1QPY=",
+      "dev": true,
+      "dependencies": {
+        "broadway": "~0.3.2",
+        "director": "1.2.7",
+        "optimist": "0.6.0",
+        "prompt": "0.2.14"
+      },
+      "bin": {
+        "flatiron": "bin/flatiron"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+    },
+    "node_modules/forever": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/forever/-/forever-4.0.1.tgz",
+      "integrity": "sha512-NRY5hvmjqfsWXpdGZONsfQg0GpzTHOP3xWTnOc1U3bY92m6TJr2mWDsXzv+3bMk2LftSne72keaMcX891JL2pQ==",
+      "dev": true,
+      "dependencies": {
+        "async": "^1.5.2",
+        "cliff": "^0.1.10",
+        "clone": "^2.1.2",
+        "colors": "^0.6.2",
+        "configstore": "4.0.0",
+        "eventemitter2": "6.4.4",
+        "flatiron": "~0.4.3",
+        "forever-monitor": "^3.0.3",
+        "mkdirp": "^0.5.5",
+        "nssocket": "^0.6.0",
+        "object-assign": "^4.1.1",
+        "prettyjson": "^1.2.1",
+        "shush": "^1.0.0",
+        "winston": "~0.8.1"
+      },
+      "bin": {
+        "forever": "bin/forever"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/forever-monitor": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/forever-monitor/-/forever-monitor-3.0.3.tgz",
+      "integrity": "sha512-7YGDo0UlbMy++6G3lzncWISDaT5CVp+yPVAkZ7FDFF0ec+0HKgBOWOhPGKpMF0hjcm3Ps/HbtrETrQLYREZ7YQ==",
+      "dev": true,
+      "dependencies": {
+        "async": "^1.5.2",
+        "chokidar": "^2.1.8",
+        "eventemitter2": "^6.4.3",
+        "minimatch": "^3.0.4",
+        "ps-tree": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/forever-monitor/node_modules/anymatch": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+      "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+      "dev": true,
+      "dependencies": {
+        "micromatch": "^3.1.4",
+        "normalize-path": "^2.1.1"
+      }
+    },
+    "node_modules/forever-monitor/node_modules/anymatch/node_modules/normalize-path": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "dev": true,
+      "dependencies": {
+        "remove-trailing-separator": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/forever-monitor/node_modules/async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+      "dev": true
+    },
+    "node_modules/forever-monitor/node_modules/binary-extensions": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+      "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/forever-monitor/node_modules/braces": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+      "dev": true,
+      "dependencies": {
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/forever-monitor/node_modules/chokidar": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
+      "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+      "deprecated": "Chokidar 2 does not receive security updates since 2019. Upgrade to chokidar 3 with 15x fewer dependencies",
+      "dev": true,
+      "dependencies": {
+        "anymatch": "^2.0.0",
+        "async-each": "^1.0.1",
+        "braces": "^2.3.2",
+        "glob-parent": "^3.1.0",
+        "inherits": "^2.0.3",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^4.0.0",
+        "normalize-path": "^3.0.0",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.2.1",
+        "upath": "^1.1.1"
+      },
+      "optionalDependencies": {
+        "fsevents": "^1.2.7"
+      }
+    },
+    "node_modules/forever-monitor/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "dev": true,
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/forever-monitor/node_modules/fill-range": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+      "dev": true,
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/forever-monitor/node_modules/fsevents": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+      "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+      "deprecated": "fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "nan": "^2.12.1"
+      },
+      "engines": {
+        "node": ">= 4.0"
+      }
+    },
+    "node_modules/forever-monitor/node_modules/glob-parent": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^3.1.0",
+        "path-dirname": "^1.0.0"
+      }
+    },
+    "node_modules/forever-monitor/node_modules/glob-parent/node_modules/is-glob": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+      "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/forever-monitor/node_modules/is-binary-path": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+      "dev": true,
+      "dependencies": {
+        "binary-extensions": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/forever-monitor/node_modules/is-number": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/forever-monitor/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "node_modules/forever-monitor/node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/forever-monitor/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/forever-monitor/node_modules/readdirp": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+      "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.11",
+        "micromatch": "^3.1.10",
+        "readable-stream": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/forever-monitor/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "node_modules/forever-monitor/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/forever-monitor/node_modules/to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/forever/node_modules/async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+      "dev": true
+    },
+    "node_modules/forever/node_modules/colors": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+      "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/forever/node_modules/configstore": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-4.0.0.tgz",
+      "integrity": "sha512-CmquAXFBocrzaSM8mtGPMM/HiWmyIpr4CcJl/rgY2uCObZ/S7cKU0silxslqJejl+t/T9HS8E0PUNQD81JGUEQ==",
+      "dev": true,
+      "dependencies": {
+        "dot-prop": "^4.1.0",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^1.0.0",
+        "unique-string": "^1.0.0",
+        "write-file-atomic": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/forever/node_modules/crypto-random-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/forever/node_modules/dot-prop": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
+      "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
+      "dev": true,
+      "dependencies": {
+        "is-obj": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/forever/node_modules/eventemitter2": {
+      "version": "6.4.4",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.4.tgz",
+      "integrity": "sha512-HLU3NDY6wARrLCEwyGKRBvuWYyvW6mHYv72SJJAH3iJN3a6eVUvkjFkcxah1bcTgGVBBrFdIopBJPhCQFMLyXw==",
+      "dev": true
+    },
+    "node_modules/forever/node_modules/is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/forever/node_modules/make-dir": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+      "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+      "dev": true,
+      "dependencies": {
+        "pify": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/forever/node_modules/pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/forever/node_modules/unique-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+      "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+      "dev": true,
+      "dependencies": {
+        "crypto-random-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/forever/node_modules/write-file-atomic": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+      "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/forever/node_modules/xdg-basedir": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+      "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "dev": true,
+      "dependencies": {
+        "map-cache": "^0.2.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
+      "dev": true
+    },
+    "node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+      "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/getos": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/getos/-/getos-3.2.1.tgz",
+      "integrity": "sha512-U56CfOK17OKgTVqozZjUKNdkfEv6jk5WISBJ8SHoagjE6L69zOwl3Z+O8myjY9MEW3i2HPWQBt/LTbCgcC973Q==",
+      "dev": true,
+      "dependencies": {
+        "async": "^3.2.0"
+      }
+    },
+    "node_modules/getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "dev": true
+    },
+    "node_modules/global-dirs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.0.tgz",
+      "integrity": "sha512-v8ho2DS5RiCjftj1nD9NmnfaOzTdud7RRnVd9kFNOjqZbISlx5DQ+OrTkywgd0dIt7oFCvKetZSHoHcP3sDdiA==",
+      "dev": true,
+      "dependencies": {
+        "ini": "2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/got": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
+      "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+      "dev": true,
+      "dependencies": {
+        "@sindresorhus/is": "^0.14.0",
+        "@szmarczak/http-timer": "^1.1.2",
+        "cacheable-request": "^6.0.0",
+        "decompress-response": "^3.3.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^4.1.0",
+        "lowercase-keys": "^1.0.1",
+        "mimic-response": "^1.0.1",
+        "p-cancelable": "^1.0.0",
+        "to-readable-stream": "^1.0.0",
+        "url-parse-lax": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/got/node_modules/get-stream": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "dev": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
+      "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
+      "dev": true
+    },
+    "node_modules/growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.x"
+      }
+    },
+    "node_modules/har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/har-validator": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "deprecated": "this library is no longer supported",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-bigints": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
+      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "dependencies": {
+        "has-symbols": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "dev": true,
+      "dependencies": {
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-values/node_modules/is-number": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-values/node_modules/is-number/node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-values/node_modules/kind-of": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+      "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+      "dev": true,
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-yarn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
+      "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hash-base": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
+      "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.6.0",
+        "safe-buffer": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+      "dependencies": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "dev": true
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+      "dev": true
+    },
+    "node_modules/http-errors": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+      "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+      "dev": true,
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.1",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-errors/node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "node_modules/http-signature": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.3.6.tgz",
+      "integrity": "sha512-3adrsD6zqo4GsTqtO7FyrejHNv+NgiIfAfv68+jVlFmSr9OGy7zrxONceFRLKvnnZA5jbxQBX1u9PpB6Wi32Gw==",
+      "dev": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^2.0.2",
+        "sshpk": "^1.14.1"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/i": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/i/-/i-0.3.7.tgz",
+      "integrity": "sha512-FYz4wlXgkQwIPqhzC5TdNMLSE5+GS1IIDJZY/1ZiEPCT2S3COUVZeT5OW4BmW4r5LHLQuOosSwsvnroG9GR59Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/ignore-by-default": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
+      "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
+      "dev": true
+    },
+    "node_modules/import-lazy": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+      "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/import-local": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
+      "integrity": "sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==",
+      "dev": true,
+      "dependencies": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/ini": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
+      "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/internal-slot": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
+      "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+      "dependencies": {
+        "get-intrinsic": "^1.1.0",
+        "has": "^1.0.3",
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/interpret": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
+      "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-accessor-descriptor/node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-arguments": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "node_modules/is-bigint": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+      "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+      "dependencies": {
+        "has-bigints": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+      "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+      "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-ci": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
+      "integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
+      "dev": true,
+      "dependencies": {
+        "ci-info": "^3.2.0"
+      },
+      "bin": {
+        "is-ci": "bin.js"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.6.0.tgz",
+      "integrity": "sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==",
+      "dev": true,
+      "dependencies": {
+        "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-data-descriptor/node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+      "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "dev": true,
+      "dependencies": {
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-descriptor/node_modules/kind-of": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+      "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-installed-globally": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.4.0.tgz",
+      "integrity": "sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==",
+      "dev": true,
+      "dependencies": {
+        "global-dirs": "^3.0.0",
+        "is-path-inside": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-map": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
+      "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+      "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-npm": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-5.0.0.tgz",
+      "integrity": "sha512-WW/rQLOazUq+ST/bCAVBp/2oMERWLsR7OrKyt052dNDk4DHcDE0/7QSXITlmi+VBcV13DfIbysG3tZJm5RfdBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.6.tgz",
+      "integrity": "sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==",
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
+      "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
+      "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+      "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+      "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+      "dependencies": {
+        "has-symbols": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.8.tgz",
+      "integrity": "sha512-HqH41TNZq2fgtGT8WHVFVJhBVGuY3AnP3Q36K8JKXUxSxRgk/d+7NjmwG2vo2mYmXK8UYZKu0qH8bVP5gEisjA==",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "es-abstract": "^1.18.5",
+        "foreach": "^2.0.5",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
+      "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.1.tgz",
+      "integrity": "sha512-b2jKc2pQZjaeFYWEf7ScFj+Be1I+PXmlu572Q8coTXZ+LD/QQZ7ShPMst8h16riVgyXTQwUsFEl74mDvc/3MHQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.1.tgz",
+      "integrity": "sha512-pi4vhbhVHGLxohUw7PhGsueT4vRGFoXhP7+RGN0jKIv9+8PWYCQTqtADngrxOm2g46hoH0+g8uZZBzMrvVGDmw==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-yarn-global": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
+      "integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==",
+      "dev": true
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
+    },
+    "node_modules/jest-worker": {
+      "version": "27.2.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.2.0.tgz",
+      "integrity": "sha512-laB0ZVIBz+voh/QQy9dmUuuDsadixeerrKqyVpgPz+CCWiOYjOBabUXHIXZhsdvkWbLqSHbgkAHWl5cg24Q6RA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
+      "integrity": "sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
+      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
+      "dev": true
+    },
+    "node_modules/json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "dev": true
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/jsprim": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-2.0.2.tgz",
+      "integrity": "sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==",
+      "dev": true,
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "dependencies": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.4.0",
+        "verror": "1.10.0"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
+      "integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
+      "dev": true,
+      "dependencies": {
+        "json-buffer": "3.0.0"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/latest-version": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
+      "integrity": "sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==",
+      "dev": true,
+      "dependencies": {
+        "package-json": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lazy": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/lazy/-/lazy-1.0.11.tgz",
+      "integrity": "sha1-2qBoIGKCVCwIgojpdcKXwa53tpA=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.2.0"
+      }
+    },
+    "node_modules/lazy-ass": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
+      "integrity": "sha1-eZllXoZGwX8In90YfRUNMyTVRRM=",
+      "dev": true,
+      "engines": {
+        "node": "> 0.8"
+      }
+    },
+    "node_modules/listr2": {
+      "version": "3.13.5",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-3.13.5.tgz",
+      "integrity": "sha512-3n8heFQDSk+NcwBn3CgxEibZGaRzx+pC64n3YjpMD1qguV4nWus3Al+Oo3KooqFKTQEJ1v7MmnbnyyNspgx3NA==",
+      "dev": true,
+      "dependencies": {
+        "cli-truncate": "^2.1.0",
+        "colorette": "^2.0.16",
+        "log-update": "^4.0.0",
+        "p-map": "^4.0.0",
+        "rfdc": "^1.3.0",
+        "rxjs": "^7.4.0",
+        "through": "^2.3.8",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "enquirer": ">= 2.3.0 < 3"
+      },
+      "peerDependenciesMeta": {
+        "enquirer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/listr2/node_modules/colorette": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
+      "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
+      "dev": true
+    },
+    "node_modules/load-json-file": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^4.0.0",
+        "pify": "^3.0.0",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/load-json-file/node_modules/pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/loader-runner": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz",
+      "integrity": "sha512-92+huvxMvYlMzMt0iIOukcwYBFpkYJdpl2xsZ7LrlayO7E8SOv+JJUEK17B/dJIHAOLMfh2dZZ/Y18WgmGtYNw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.11.5"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
+      "dev": true
+    },
+    "node_modules/log-symbols": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
+      "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/log-update": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
+      "integrity": "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-escapes": "^4.3.0",
+        "cli-cursor": "^3.1.0",
+        "slice-ansi": "^4.0.0",
+        "wrap-ansi": "^6.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/log-update/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/log-update/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/log-update/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lowercase-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/map-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+      "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
+      "dev": true
+    },
+    "node_modules/map-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "dev": true,
+      "dependencies": {
+        "object-visit": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/md5.js": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "dependencies": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/memorystream": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+      "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+      "dev": true
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+      "dev": true,
+      "dependencies": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/micromatch/node_modules/braces": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+      "dev": true,
+      "dependencies": {
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/micromatch/node_modules/braces/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "dev": true,
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/micromatch/node_modules/fill-range": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+      "dev": true,
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/micromatch/node_modules/fill-range/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "dev": true,
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/micromatch/node_modules/is-number": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/micromatch/node_modules/is-number/node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/micromatch/node_modules/to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/miller-rabin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
+      },
+      "bin": {
+        "miller-rabin": "bin/miller-rabin"
+      }
+    },
+    "node_modules/miller-rabin/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.49.0.tgz",
+      "integrity": "sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.32",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.32.tgz",
+      "integrity": "sha512-hJGaVS4G4c9TSMYh2n6SQAGrC4RnfU+daP8G7cSCmaqNjiOoUY0VHCMS42pxnQmVF1GWwFhbHWn3RIxCqTmZ9A==",
+      "dev": true,
+      "dependencies": {
+        "mime-db": "1.49.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+    },
+    "node_modules/minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
+    },
+    "node_modules/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
+    },
+    "node_modules/mixin-deep": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+      "dev": true,
+      "dependencies": {
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/mixin-deep/node_modules/is-extendable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+      "dev": true,
+      "dependencies": {
+        "is-plain-object": "^2.0.4"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/mocha": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.4.0.tgz",
+      "integrity": "sha512-hJaO0mwDXmZS4ghXsvPVriOhsxQ7ofcpQdm8dE+jISUOKopitvnXFQmpRR7jd2K6VBG6E26gU3IAbXXGIbu4sQ==",
+      "dev": true,
+      "dependencies": {
+        "@ungap/promise-all-settled": "1.1.2",
+        "ansi-colors": "4.1.1",
+        "browser-stdout": "1.3.1",
+        "chokidar": "3.5.1",
+        "debug": "4.3.1",
+        "diff": "5.0.0",
+        "escape-string-regexp": "4.0.0",
+        "find-up": "5.0.0",
+        "glob": "7.1.6",
+        "growl": "1.10.5",
+        "he": "1.2.0",
+        "js-yaml": "4.0.0",
+        "log-symbols": "4.0.0",
+        "minimatch": "3.0.4",
+        "ms": "2.1.3",
+        "nanoid": "3.1.20",
+        "serialize-javascript": "5.0.1",
+        "strip-json-comments": "3.1.1",
+        "supports-color": "8.1.1",
+        "which": "2.0.2",
+        "wide-align": "1.1.3",
+        "workerpool": "6.1.0",
+        "yargs": "16.2.0",
+        "yargs-parser": "20.2.4",
+        "yargs-unparser": "2.0.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha"
+      },
+      "engines": {
+        "node": ">= 10.12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mochajs"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true
+    },
+    "node_modules/nan": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.1.20",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
+      "integrity": "sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==",
+      "dev": true,
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/nanomatch": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+      "dev": true,
+      "dependencies": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nconf": {
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/nconf/-/nconf-0.6.9.tgz",
+      "integrity": "sha1-lXDvFe1vmuays8jV5xtm0xk81mE=",
+      "dev": true,
+      "dependencies": {
+        "async": "0.2.9",
+        "ini": "1.x.x",
+        "optimist": "0.6.0"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/nconf/node_modules/async": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.2.9.tgz",
+      "integrity": "sha1-32MGD789Myhqdqr21Vophtn/hhk=",
+      "dev": true
+    },
+    "node_modules/nconf/node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true
+    },
+    "node_modules/ncp": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz",
+      "integrity": "sha1-q8xsvT7C7Spyn/bnwfqPAXhKhXQ=",
+      "dev": true,
+      "bin": {
+        "ncp": "bin/ncp"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true
+    },
+    "node_modules/nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
+    },
+    "node_modules/node-releases": {
+      "version": "1.1.76",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.76.tgz",
+      "integrity": "sha512-9/IECtNr8dXNmPWmFXepT0/7o5eolGesHUa3mtr0KlgnCvnZxwh2qensKL42JJY2vQKC3nIBXetFAqR+PW1CmA==",
+      "dev": true
+    },
+    "node_modules/nodemon": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.15.tgz",
+      "integrity": "sha512-gdHMNx47Gw7b3kWxJV64NI+Q5nfl0y5DgDbiVtShiwa7Z0IZ07Ll4RLFo6AjrhzMtoEZn5PDE3/c2AbVsiCkpA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "chokidar": "^3.5.2",
+        "debug": "^3.2.7",
+        "ignore-by-default": "^1.0.1",
+        "minimatch": "^3.0.4",
+        "pstree.remy": "^1.1.8",
+        "semver": "^5.7.1",
+        "supports-color": "^5.5.0",
+        "touch": "^3.1.0",
+        "undefsafe": "^2.0.5",
+        "update-notifier": "^5.1.0"
+      },
+      "bin": {
+        "nodemon": "bin/nodemon.js"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nodemon"
+      }
+    },
+    "node_modules/nodemon/node_modules/chokidar": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
+      "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+      "dev": true,
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/nodemon/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/nodemon/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/nodemon/node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/nodemon/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/nopt": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+      "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+      "dev": true,
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "dependencies": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/normalize-url": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
+      "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm-run-all": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.5.tgz",
+      "integrity": "sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "chalk": "^2.4.1",
+        "cross-spawn": "^6.0.5",
+        "memorystream": "^0.3.1",
+        "minimatch": "^3.0.4",
+        "pidtree": "^0.3.0",
+        "read-pkg": "^3.0.0",
+        "shell-quote": "^1.6.1",
+        "string.prototype.padend": "^3.0.0"
+      },
+      "bin": {
+        "npm-run-all": "bin/npm-run-all/index.js",
+        "run-p": "bin/run-p/index.js",
+        "run-s": "bin/run-s/index.js"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "node_modules/npm-run-all/node_modules/cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dev": true,
+      "dependencies": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      },
+      "engines": {
+        "node": ">=4.8"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/nssocket": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/nssocket/-/nssocket-0.6.0.tgz",
+      "integrity": "sha1-Wflvb/MhVm8zxw99vu7N/cBxVPo=",
+      "dev": true,
+      "dependencies": {
+        "eventemitter2": "~0.4.14",
+        "lazy": "~1.0.11"
+      },
+      "engines": {
+        "node": ">= 0.10.x"
+      }
+    },
+    "node_modules/nssocket/node_modules/eventemitter2": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+      "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
+      "dev": true
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-copy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "dev": true,
+      "dependencies": {
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-copy/node_modules/define-property": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+      "dev": true,
+      "dependencies": {
+        "is-descriptor": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-copy/node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
+      "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-is": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object-visit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "dev": true,
+      "dependencies": {
+        "isobject": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+      "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "has-symbols": "^1.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "dev": true,
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "dev": true,
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/optimist": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.0.tgz",
+      "integrity": "sha1-aUJIJvNAX3nxQub8PZrljU27kgA=",
+      "dev": true,
+      "dependencies": {
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
+      }
+    },
+    "node_modules/optimist/node_modules/minimist": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+      "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+      "dev": true
+    },
+    "node_modules/os-browserify": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+      "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
+    },
+    "node_modules/ospath": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/ospath/-/ospath-1.2.2.tgz",
+      "integrity": "sha1-EnZjl3Sj+O8lcvf+QoDg6kVQwHs=",
+      "dev": true
+    },
+    "node_modules/p-cancelable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
+      "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "dev": true,
+      "dependencies": {
+        "aggregate-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/package-json": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-6.5.0.tgz",
+      "integrity": "sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==",
+      "dev": true,
+      "dependencies": {
+        "got": "^9.6.0",
+        "registry-auth-token": "^4.0.0",
+        "registry-url": "^5.0.0",
+        "semver": "^6.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/package-json/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg=="
+    },
+    "node_modules/parse-asn1": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.6.tgz",
+      "integrity": "sha512-RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==",
+      "dependencies": {
+        "asn1.js": "^5.2.0",
+        "browserify-aes": "^1.0.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+      "dev": true,
+      "dependencies": {
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/pascalcase": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-dirname": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+      "dev": true
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+      "dev": true
+    },
+    "node_modules/path-type": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+      "dev": true,
+      "dependencies": {
+        "pify": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/path-type/node_modules/pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+      "dev": true,
+      "dependencies": {
+        "through": "~2.3"
+      }
+    },
+    "node_modules/pbkdf2": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
+      "integrity": "sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==",
+      "dependencies": {
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+      "dev": true
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pidtree": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.1.tgz",
+      "integrity": "sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==",
+      "dev": true,
+      "bin": {
+        "pidtree": "bin/pidtree.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkginfo": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
+      "integrity": "sha1-Wyn2qB9wcXFC4J52W76rl7T4HiE=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/prepend-http": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+      "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pretty-bytes": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
+      "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/prettyjson": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prettyjson/-/prettyjson-1.2.1.tgz",
+      "integrity": "sha1-/P+rQdGcq0365eV15kJGYZsS0ok=",
+      "dev": true,
+      "dependencies": {
+        "colors": "^1.1.2",
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "prettyjson": "bin/prettyjson"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
+    },
+    "node_modules/prompt": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/prompt/-/prompt-0.2.14.tgz",
+      "integrity": "sha1-V3VPZPVD/XsIRXB8gY7OYY8F/9w=",
+      "dev": true,
+      "dependencies": {
+        "pkginfo": "0.x.x",
+        "read": "1.0.x",
+        "revalidator": "0.1.x",
+        "utile": "0.2.x",
+        "winston": "0.8.x"
+      },
+      "engines": {
+        "node": ">= 0.6.6"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dev": true,
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
+      "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=",
+      "dev": true
+    },
+    "node_modules/ps-tree": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.2.0.tgz",
+      "integrity": "sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==",
+      "dev": true,
+      "dependencies": {
+        "event-stream": "=3.3.4"
+      },
+      "bin": {
+        "ps-tree": "bin/ps-tree.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/psl": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
+      "dev": true
+    },
+    "node_modules/pstree.remy": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
+      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
+      "dev": true
+    },
+    "node_modules/public-encrypt": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
+      "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/public-encrypt/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+    },
+    "node_modules/pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pupa": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/pupa/-/pupa-2.1.1.tgz",
+      "integrity": "sha512-l1jNAspIBSFqbT+y+5FosojNpVpF94nlI+wDUpqP9enwOTfHx9f0gh5nB96vl+6yTpsJsypeNrwfzPrKuHB41A==",
+      "dev": true,
+      "dependencies": {
+        "escape-goat": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/randomfill": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+      "dependencies": {
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+      "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
+      "dev": true,
+      "dependencies": {
+        "bytes": "3.1.0",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/read": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+      "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+      "dev": true,
+      "dependencies": {
+        "mute-stream": "~0.0.4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/read-pkg": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+      "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+      "dev": true,
+      "dependencies": {
+        "load-json-file": "^4.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+      "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+      "dev": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/rechoir": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
+      "integrity": "sha512-/njmZ8s1wVeR6pjTZ+0nCnv8SpZNRMT2D1RLOJQESlYFDBvwpTA4KWJpZ+sBJ4+vhjILRcK7JIFdGCdxEAAitg==",
+      "dev": true,
+      "dependencies": {
+        "resolve": "^1.9.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/regex-not": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "dev": true,
+      "dependencies": {
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
+      "integrity": "sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/registry-auth-token": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.1.tgz",
+      "integrity": "sha512-6gkSb4U6aWJB4SF2ZvLb76yCBjcvufXBqvvEx1HbmKPkutswjW1xNVRY0+daljIYRbogN7O0etYSlbiaEQyMyw==",
+      "dev": true,
+      "dependencies": {
+        "rc": "^1.2.8"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/registry-url": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-5.1.0.tgz",
+      "integrity": "sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==",
+      "dev": true,
+      "dependencies": {
+        "rc": "^1.2.8"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "dev": true
+    },
+    "node_modules/repeat-element": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.4.tgz",
+      "integrity": "sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/request-progress": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
+      "integrity": "sha1-TKdUCBx/7GP1BeT6qCWqBs1mnb4=",
+      "dev": true,
+      "dependencies": {
+        "throttleit": "^1.0.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.2.0",
+        "path-parse": "^1.0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+      "dev": true,
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "deprecated": "https://github.com/lydell/resolve-url#deprecated",
+      "dev": true
+    },
+    "node_modules/responselike": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+      "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+      "dev": true,
+      "dependencies": {
+        "lowercase-keys": "^1.0.0"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resumer": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
+      "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
+      "dev": true,
+      "dependencies": {
+        "through": "~2.3.4"
+      }
+    },
+    "node_modules/ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/revalidator": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz",
+      "integrity": "sha1-/s5hv6DBtSoga9axgZgYS91SOjs=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/rfdc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
+      "dev": true
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ripemd160": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+      "dependencies": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.4.0.tgz",
+      "integrity": "sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "~2.1.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "dev": true,
+      "dependencies": {
+        "ret": "~0.1.10"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/schema-utils": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
+      "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.8",
+        "ajv": "^6.12.5",
+        "ajv-keywords": "^3.5.2"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/semver-diff": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-3.1.1.tgz",
+      "integrity": "sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semver-diff/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/send": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+      "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.7.2",
+        "mime": "1.6.0",
+        "ms": "2.1.1",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.1",
+        "statuses": "~1.5.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/send/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+      "dev": true
+    },
+    "node_modules/serialize-javascript": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
+      "integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
+      "dev": true,
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
+      "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
+      "dev": true,
+      "dependencies": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.17.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/set-value": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+      "dev": true,
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/set-value/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "dev": true,
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
+      "dev": true
+    },
+    "node_modules/sha.js": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      },
+      "bin": {
+        "sha.js": "bin.js"
+      }
+    },
+    "node_modules/shallow-clone": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+      "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
+      "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
+      "dev": true
+    },
+    "node_modules/shush": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shush/-/shush-1.0.0.tgz",
+      "integrity": "sha1-wnQVqeRY8v7TmyfPjrN8ADeCtDE=",
+      "dev": true,
+      "dependencies": {
+        "caller": "~0.0.1",
+        "strip-json-comments": "~0.1.1"
+      }
+    },
+    "node_modules/shush/node_modules/strip-json-comments": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz",
+      "integrity": "sha1-Fkxk43Coo8wAyeAbU55WmCPw7lQ=",
+      "dev": true,
+      "bin": {
+        "strip-json-comments": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.4.tgz",
+      "integrity": "sha512-rqYhcAnZ6d/vTPGghdrw7iumdcbXpsk1b8IG/rz+VWV51DM0p7XCtMoJ3qhPLIbp3tvyt3pKRbaaEMZYpHto8Q==",
+      "dev": true
+    },
+    "node_modules/slice-ansi": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
+      "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/snapdragon": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "dev": true,
+      "dependencies": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "dev": true,
+      "dependencies": {
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/snapdragon-node/node_modules/define-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+      "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+      "dev": true,
+      "dependencies": {
+        "is-descriptor": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/snapdragon-node/node_modules/is-accessor-descriptor": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+      "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/snapdragon-node/node_modules/is-data-descriptor": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+      "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/snapdragon-node/node_modules/is-descriptor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+      "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+      "dev": true,
+      "dependencies": {
+        "is-accessor-descriptor": "^1.0.0",
+        "is-data-descriptor": "^1.0.0",
+        "kind-of": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/snapdragon-util/node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/snapdragon/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/snapdragon/node_modules/define-property": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+      "dev": true,
+      "dependencies": {
+        "is-descriptor": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/snapdragon/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "dev": true,
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/snapdragon/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "node_modules/snapdragon/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-resolve": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+      "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
+      "deprecated": "See https://github.com/lydell/source-map-resolve#deprecated",
+      "dev": true,
+      "dependencies": {
+        "atob": "^2.1.2",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.20",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.20.tgz",
+      "integrity": "sha512-n1lZZ8Ve4ksRqizaBQgxXDgKwttHDhyfQjA6YZZn8+AroHbsIz+JjwxQDxbp+7y5OYCI8t1Yk7etjD9CRd2hIw==",
+      "dev": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/source-map-url": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
+      "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
+      "deprecated": "See https://github.com/lydell/source-map-url#deprecated",
+      "dev": true
+    },
+    "node_modules/spdx-correct": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+      "dev": true,
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+      "dev": true
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
+      "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
+      "dev": true
+    },
+    "node_modules/split": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+      "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+      "dev": true,
+      "dependencies": {
+        "through": "2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "dev": true,
+      "dependencies": {
+        "extend-shallow": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sshpk": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "dev": true,
+      "dependencies": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/static-extend": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "dev": true,
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/static-extend/node_modules/define-property": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+      "dev": true,
+      "dependencies": {
+        "is-descriptor": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/stream-browserify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
+      "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
+      "dependencies": {
+        "inherits": "~2.0.4",
+        "readable-stream": "^3.5.0"
+      }
+    },
+    "node_modules/stream-combiner": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+      "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+      "dev": true,
+      "dependencies": {
+        "duplexer": "~0.1.1"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "dependencies": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/string.prototype.padend": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.3.tgz",
+      "integrity": "sha512-jNIIeokznm8SD/TZISQsZKYu7RJyheFNt84DUPrh482GC8RVp2MKqm2O5oBRdGxbDQoXrhhWtPIWQOiy20svUg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.padend/node_modules/es-abstract": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
+      "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.1.1",
+        "get-symbol-description": "^1.0.0",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.2",
+        "internal-slot": "^1.0.3",
+        "is-callable": "^1.2.4",
+        "is-negative-zero": "^2.0.1",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.1",
+        "is-string": "^1.0.7",
+        "is-weakref": "^1.0.1",
+        "object-inspect": "^1.11.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.2",
+        "string.prototype.trimend": "^1.0.4",
+        "string.prototype.trimstart": "^1.0.4",
+        "unbox-primitive": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+      "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+      "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tapable": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tape": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-2.3.3.tgz",
+      "integrity": "sha1-Lnzgox3wn41oUWZKcYQuDKUFevc=",
+      "dev": true,
+      "dependencies": {
+        "deep-equal": "~0.1.0",
+        "defined": "~0.0.0",
+        "inherits": "~2.0.1",
+        "jsonify": "~0.0.0",
+        "resumer": "~0.0.0",
+        "through": "~2.3.4"
+      },
+      "bin": {
+        "tape": "bin/tape"
+      }
+    },
+    "node_modules/tape/node_modules/deep-equal": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.1.2.tgz",
+      "integrity": "sha1-skbCuApXCkfBG+HZvRBw7IeLh84=",
+      "dev": true
+    },
+    "node_modules/terser": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.8.0.tgz",
+      "integrity": "sha512-f0JH+6yMpneYcRJN314lZrSwu9eKkUFEHLN/kNy8ceh8gaRiLgFPJqrB9HsXjhEGdv4e/ekjTOFxIlL6xlma8A==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^2.20.0",
+        "source-map": "~0.7.2",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser-webpack-plugin": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.2.4.tgz",
+      "integrity": "sha512-E2CkNMN+1cho04YpdANyRrn8CyN4yMy+WdFKZIySFZrGXZxJwJP6PMNGGc/Mcr6qygQHUUqRxnAPmi0M9f00XA==",
+      "dev": true,
+      "dependencies": {
+        "jest-worker": "^27.0.6",
+        "p-limit": "^3.1.0",
+        "schema-utils": "^3.1.1",
+        "serialize-javascript": "^6.0.0",
+        "source-map": "^0.6.1",
+        "terser": "^5.7.2"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "uglify-js": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/terser-webpack-plugin/node_modules/serialize-javascript": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+      "dev": true,
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/terser/node_modules/source-map": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/throttleit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
+      "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=",
+      "dev": true
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "node_modules/tmp": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+      "dev": true,
+      "dependencies": {
+        "rimraf": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8.17.0"
+      }
+    },
+    "node_modules/to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/to-object-path/node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/to-readable-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
+      "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/to-regex": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "dev": true,
+      "dependencies": {
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/touch": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
+      "integrity": "sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==",
+      "dev": true,
+      "dependencies": {
+        "nopt": "~1.0.10"
+      },
+      "bin": {
+        "nodetouch": "bin/nodetouch.js"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "dev": true,
+      "dependencies": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+      "dev": true
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true
+    },
+    "node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "dev": true,
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "dev": true,
+      "dependencies": {
+        "is-typedarray": "^1.0.0"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
+      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "has-bigints": "^1.0.1",
+        "has-symbols": "^1.0.2",
+        "which-boxed-primitive": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undefsafe": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
+      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+      "dev": true
+    },
+    "node_modules/union-value": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+      "dev": true,
+      "dependencies": {
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/unique-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
+      "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
+      "dev": true,
+      "dependencies": {
+        "crypto-random-string": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/unset-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "dev": true,
+      "dependencies": {
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/unset-value/node_modules/has-value": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+      "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+      "dev": true,
+      "dependencies": {
+        "get-value": "^2.0.3",
+        "has-values": "^0.1.4",
+        "isobject": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/unset-value/node_modules/has-value/node_modules/isobject": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+      "dev": true,
+      "dependencies": {
+        "isarray": "1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/unset-value/node_modules/has-values": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+      "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/unset-value/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "node_modules/untildify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/upath": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
+      "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
+      "dev": true,
+      "engines": {
+        "node": ">=4",
+        "yarn": "*"
+      }
+    },
+    "node_modules/update-notifier": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-5.1.0.tgz",
+      "integrity": "sha512-ItnICHbeMh9GqUy31hFPrD1kcuZ3rpxDZbf4KUDavXwS0bW5m7SLbDQpGX3UYr072cbrF5hFUs3r5tUsPwjfHw==",
+      "dev": true,
+      "dependencies": {
+        "boxen": "^5.0.0",
+        "chalk": "^4.1.0",
+        "configstore": "^5.0.1",
+        "has-yarn": "^2.1.0",
+        "import-lazy": "^2.1.0",
+        "is-ci": "^2.0.0",
+        "is-installed-globally": "^0.4.0",
+        "is-npm": "^5.0.0",
+        "is-yarn-global": "^0.3.0",
+        "latest-version": "^5.1.0",
+        "pupa": "^2.1.1",
+        "semver": "^7.3.4",
+        "semver-diff": "^3.1.1",
+        "xdg-basedir": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/yeoman/update-notifier?sponsor=1"
+      }
+    },
+    "node_modules/update-notifier/node_modules/ci-info": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+      "dev": true
+    },
+    "node_modules/update-notifier/node_modules/is-ci": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+      "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+      "dev": true,
+      "dependencies": {
+        "ci-info": "^2.0.0"
+      },
+      "bin": {
+        "is-ci": "bin.js"
+      }
+    },
+    "node_modules/update-notifier/node_modules/semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "deprecated": "Please see https://github.com/lydell/urix#deprecated",
+      "dev": true
+    },
+    "node_modules/url": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+      "dev": true,
+      "dependencies": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
+    "node_modules/url-parse-lax": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+      "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+      "dev": true,
+      "dependencies": {
+        "prepend-http": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/url/node_modules/punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+      "dev": true
+    },
+    "node_modules/use": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/util": {
+      "version": "0.12.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
+      "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "safe-buffer": "^5.1.2",
+        "which-typed-array": "^1.1.2"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "node_modules/utile": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
+      "integrity": "sha1-kwyI6ZCY1iIINMNWy9mncFItkNc=",
+      "dev": true,
+      "dependencies": {
+        "async": "~0.2.9",
+        "deep-equal": "*",
+        "i": "0.3.x",
+        "mkdirp": "0.x.x",
+        "ncp": "0.4.x",
+        "rimraf": "2.x.x"
+      },
+      "engines": {
+        "node": ">= 0.6.4"
+      }
+    },
+    "node_modules/utile/node_modules/async": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+      "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+      "dev": true
+    },
+    "node_modules/utile/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/v8-compile-cache": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
+      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+      "dev": true
+    },
+    "node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
+    "node_modules/watchpack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.2.0.tgz",
+      "integrity": "sha512-up4YAn/XHgZHIxFBVCdlMiWDj6WaLKpwVeGQk2I5thdYxF/KmF0aaz6TfJZ/hfl1h/XlcDr7k1KH7ThDagpFaA==",
+      "dev": true,
+      "dependencies": {
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/webpack": {
+      "version": "5.53.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.53.0.tgz",
+      "integrity": "sha512-RZ1Z3z3ni44snoWjfWeHFyzvd9HMVYDYC5VXmlYUT6NWgEOWdCNpad5Fve2CzzHoRED7WtsKe+FCyP5Vk4pWiQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/eslint-scope": "^3.7.0",
+        "@types/estree": "^0.0.50",
+        "@webassemblyjs/ast": "1.11.1",
+        "@webassemblyjs/wasm-edit": "1.11.1",
+        "@webassemblyjs/wasm-parser": "1.11.1",
+        "acorn": "^8.4.1",
+        "acorn-import-assertions": "^1.7.6",
+        "browserslist": "^4.14.5",
+        "chrome-trace-event": "^1.0.2",
+        "enhanced-resolve": "^5.8.0",
+        "es-module-lexer": "^0.7.1",
+        "eslint-scope": "5.1.1",
+        "events": "^3.2.0",
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.2.4",
+        "json-parse-better-errors": "^1.0.2",
+        "loader-runner": "^4.2.0",
+        "mime-types": "^2.1.27",
+        "neo-async": "^2.6.2",
+        "schema-utils": "^3.1.0",
+        "tapable": "^2.1.1",
+        "terser-webpack-plugin": "^5.1.3",
+        "watchpack": "^2.2.0",
+        "webpack-sources": "^3.2.0"
+      },
+      "bin": {
+        "webpack": "bin/webpack.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependenciesMeta": {
+        "webpack-cli": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webpack-cli": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.8.0.tgz",
+      "integrity": "sha512-+iBSWsX16uVna5aAYN6/wjhJy1q/GKk4KjKvfg90/6hykCTSgozbfz5iRgDTSJt/LgSbYxdBX3KBHeobIs+ZEw==",
+      "dev": true,
+      "dependencies": {
+        "@discoveryjs/json-ext": "^0.5.0",
+        "@webpack-cli/configtest": "^1.0.4",
+        "@webpack-cli/info": "^1.3.0",
+        "@webpack-cli/serve": "^1.5.2",
+        "colorette": "^1.2.1",
+        "commander": "^7.0.0",
+        "execa": "^5.0.0",
+        "fastest-levenshtein": "^1.0.12",
+        "import-local": "^3.0.2",
+        "interpret": "^2.2.0",
+        "rechoir": "^0.7.0",
+        "v8-compile-cache": "^2.2.0",
+        "webpack-merge": "^5.7.3"
+      },
+      "bin": {
+        "webpack-cli": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "peerDependencies": {
+        "webpack": "4.x.x || 5.x.x"
+      },
+      "peerDependenciesMeta": {
+        "@webpack-cli/generators": {
+          "optional": true
+        },
+        "@webpack-cli/migrate": {
+          "optional": true
+        },
+        "webpack-bundle-analyzer": {
+          "optional": true
+        },
+        "webpack-dev-server": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webpack-cli/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/webpack-merge": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.8.0.tgz",
+      "integrity": "sha512-/SaI7xY0831XwP6kzuwhKWVKDP9t1QY1h65lAFLbZqMPIuYcD9QAW4u9STIbU9kaJbPBB/geU/gLr1wDjOhQ+Q==",
+      "dev": true,
+      "dependencies": {
+        "clone-deep": "^4.0.1",
+        "wildcard": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/webpack-sources": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.1.tgz",
+      "integrity": "sha512-t6BMVLQ0AkjBOoRTZgqrWm7xbXMBzD+XDq2EZ96+vMfn3qKgsvdXZhbPZ4ElUOpdv4u+iiGe+w3+J75iy/bYGA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "dependencies": {
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
+      "integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
+      "dev": true,
+      "dependencies": {
+        "is-map": "^2.0.1",
+        "is-set": "^2.0.1",
+        "is-weakmap": "^2.0.1",
+        "is-weakset": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.7.tgz",
+      "integrity": "sha512-vjxaB4nfDqwKI0ws7wZpxIlde1XrLX5uB0ZjpfshgmapJMD7jJWhZI+yToJTqaFByF0eNBcYxbjmCzoRP7CfEw==",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "es-abstract": "^1.18.5",
+        "foreach": "^2.0.5",
+        "has-tostringtag": "^1.0.0",
+        "is-typed-array": "^1.1.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^1.0.2 || 2"
+      }
+    },
+    "node_modules/widest-line": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
+      "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/widest-line/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/widest-line/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/widest-line/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/widest-line/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wildcard": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
+      "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
+      "dev": true
+    },
+    "node_modules/winston": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-0.8.3.tgz",
+      "integrity": "sha1-ZLar9M0Brcrv1QCTk7HY6L7BnbA=",
+      "dev": true,
+      "dependencies": {
+        "async": "0.2.x",
+        "colors": "0.6.x",
+        "cycle": "1.0.x",
+        "eyes": "0.1.x",
+        "isstream": "0.1.x",
+        "pkginfo": "0.3.x",
+        "stack-trace": "0.0.x"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/winston/node_modules/async": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+      "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+      "dev": true
+    },
+    "node_modules/winston/node_modules/colors": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+      "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/workerpool": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.0.tgz",
+      "integrity": "sha512-toV7q9rWNYha963Pl/qyeZ6wG+3nnsyvolaNUS8+R5Wtw6qJPTxIlOP1ZSvcGhEJw+l3HMMmtiNo9Gl61G4GVg==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "node_modules/write-file-atomic": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+      "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+      "dev": true,
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "is-typedarray": "^1.0.0",
+        "signal-exit": "^3.0.2",
+        "typedarray-to-buffer": "^3.1.5"
+      }
+    },
+    "node_modules/xdg-basedir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
+      "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.4",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+      "dev": true,
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  },
   "dependencies": {
     "@cypress/request": {
       "version": "2.88.9",
@@ -289,7 +9298,8 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.0.4.tgz",
       "integrity": "sha512-cs3XLy+UcxiP6bj0A6u7MLLuwdXJ1c3Dtc0RkKg+wiI1g/Ti1om8+/2hc2A2B60NbBNAbMgyBMHvyymWm/j4wQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@webpack-cli/info": {
       "version": "1.3.0",
@@ -304,7 +9314,8 @@
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.5.2.tgz",
       "integrity": "sha512-vgJ5OLWadI8aKjDlOH3rb+dYyPd2GTZuQC/Tihjct6F9GpXGZINo3Y/IVuZVTM1eDQB+/AOsjPUWH/WySDaXvw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -344,7 +9355,8 @@
       "version": "1.7.6",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.7.6.tgz",
       "integrity": "sha512-FlVvVFA1TX6l3lp8VjDnYYq7R1nyW6x3svAt4nDgrWQ9SBaSh9CnbwgSUTasgfNfOG5HlM1ehugCvM+hjo56LA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "aggregate-error": {
       "version": "3.1.0",
@@ -372,7 +9384,8 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ansi-align": {
       "version": "3.0.1",
@@ -6054,6 +15067,14 @@
         "duplexer": "~0.1.1"
       }
     },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -6121,14 +15142,6 @@
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
-      }
-    },
-    "string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "requires": {
-        "safe-buffer": "~5.2.0"
       }
     },
     "strip-ansi": {

--- a/wrappers/js-web/package-lock.json
+++ b/wrappers/js-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aml-org/amf-custom-validator-web",
-  "version": "1.2.1-SNAPSHOT",
+  "version": "1.3.0-SNAPSHOT",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@aml-org/amf-custom-validator-web",
-      "version": "1.2.0-SNAPSHOT",
+      "version": "1.3.0-SNAPSHOT",
       "license": "ISC",
       "dependencies": {
         "buffer": "^6.0.3",

--- a/wrappers/js-web/package.json
+++ b/wrappers/js-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aml-org/amf-custom-validator-web",
-  "version": "1.2.0-SNAPSHOT",
+  "version": "1.3.0-SNAPSHOT",
   "description": "AMF validator backed by OPA Rego",
   "main": "dist/main.js",
   "scripts": {

--- a/wrappers/js-web/package.json
+++ b/wrappers/js-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aml-org/amf-custom-validator-web",
-  "version": "1.2.1",
+  "version": "1.3.0-SNAPSHOT",
   "description": "AMF validator backed by OPA Rego",
   "main": "dist/main.js",
   "scripts": {

--- a/wrappers/js-web/package.json
+++ b/wrappers/js-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aml-org/amf-custom-validator-web",
-  "version": "1.3.0-SNAPSHOT",
+  "version": "1.2.2",
   "description": "AMF validator backed by OPA Rego",
   "main": "dist/main.js",
   "scripts": {

--- a/wrappers/js/index.js
+++ b/wrappers/js/index.js
@@ -23,6 +23,35 @@ const validateCustomProfile = function(profile, data, debug, cb) {
         cb(undefined,new Error("WASM/GO not initialized"))
     }
 }
+
+const runGenerateRego = function(profile) {
+    const res = __AMF__generateRego(profile);
+    return res;
+}
+
+const generateRego = function(profile, cb) {
+    if (initialized) {
+        let res = runGenerateRego(profile);
+        cb(res,undefined);
+    } else {
+        cb(undefined,new Error("WASM/GO not initialized"))
+    }
+}
+
+const runNormalizeInput = function(data) {
+    const res = __AMF__normalizeInput(data);
+    return res;
+}
+
+const normalizeInput = function(data, cb) {
+    if (initialized) {
+        let res = runNormalizeInput(data);
+        cb(res,undefined);
+    } else {
+        cb(undefined,new Error("WASM/GO not initialized"))
+    }
+}
+
 const initialize = function(cb) {
     if (initialized === true) {
         cb(undefined)
@@ -53,4 +82,6 @@ const exit = function() {
 
 module.exports.initialize = initialize;
 module.exports.validate = validateCustomProfile;
+module.exports.generateRego = generateRego;
+module.exports.normalizeInput = normalizeInput;
 module.exports.exit = exit;

--- a/wrappers/js/lib/wasm_exec.js
+++ b/wrappers/js/lib/wasm_exec.js
@@ -1,8 +1,3 @@
-// wasm_exec.js obtained from https://github.com/golang/go/blob/758ac371ab930734053ed226ac62681e62ab8eea/misc/wasm/wasm_exec.js
-// Log with custom changes (we should keep track if we diverge from original content):
-//  -
-
-// ---------------------------------------------------
 // Copyright 2018 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
@@ -107,13 +102,16 @@
 		}
 	}
 
-	if (!global.crypto) {
+	if (!global.crypto && global.require) {
 		const nodeCrypto = require("crypto");
 		global.crypto = {
 			getRandomValues(b) {
 				nodeCrypto.randomFillSync(b);
 			},
 		};
+	}
+	if (!global.crypto) {
+		throw new Error("global.crypto is not available, polyfill required (getRandomValues only)");
 	}
 
 	if (!global.performance) {
@@ -125,12 +123,18 @@
 		};
 	}
 
-	if (!global.TextEncoder) {
+	if (!global.TextEncoder && global.require) {
 		global.TextEncoder = require("util").TextEncoder;
 	}
+	if (!global.TextEncoder) {
+		throw new Error("global.TextEncoder is not available, polyfill required");
+	}
 
-	if (!global.TextDecoder) {
+	if (!global.TextDecoder && global.require) {
 		global.TextDecoder = require("util").TextDecoder;
+	}
+	if (!global.TextDecoder) {
+		throw new Error("global.TextDecoder is not available, polyfill required");
 	}
 
 	// End of polyfills for common API.
@@ -260,6 +264,7 @@
 
 					// func wasmExit(code int32)
 					"runtime.wasmExit": (sp) => {
+						sp >>>= 0;
 						const code = this.mem.getInt32(sp + 8, true);
 						this.exited = true;
 						delete this._inst;
@@ -272,6 +277,7 @@
 
 					// func wasmWrite(fd uintptr, p unsafe.Pointer, n int32)
 					"runtime.wasmWrite": (sp) => {
+						sp >>>= 0;
 						const fd = getInt64(sp + 8);
 						const p = getInt64(sp + 16);
 						const n = this.mem.getInt32(sp + 24, true);
@@ -280,16 +286,19 @@
 
 					// func resetMemoryDataView()
 					"runtime.resetMemoryDataView": (sp) => {
+						sp >>>= 0;
 						this.mem = new DataView(this._inst.exports.mem.buffer);
 					},
 
 					// func nanotime1() int64
 					"runtime.nanotime1": (sp) => {
+						sp >>>= 0;
 						setInt64(sp + 8, (timeOrigin + performance.now()) * 1000000);
 					},
 
 					// func walltime1() (sec int64, nsec int32)
 					"runtime.walltime1": (sp) => {
+						sp >>>= 0;
 						const msec = (new Date).getTime();
 						setInt64(sp + 8, msec / 1000);
 						this.mem.setInt32(sp + 16, (msec % 1000) * 1000000, true);
@@ -297,6 +306,7 @@
 
 					// func scheduleTimeoutEvent(delay int64) int32
 					"runtime.scheduleTimeoutEvent": (sp) => {
+						sp >>>= 0;
 						const id = this._nextCallbackTimeoutID;
 						this._nextCallbackTimeoutID++;
 						this._scheduledTimeouts.set(id, setTimeout(
@@ -316,6 +326,7 @@
 
 					// func clearTimeoutEvent(id int32)
 					"runtime.clearTimeoutEvent": (sp) => {
+						sp >>>= 0;
 						const id = this.mem.getInt32(sp + 8, true);
 						clearTimeout(this._scheduledTimeouts.get(id));
 						this._scheduledTimeouts.delete(id);
@@ -323,11 +334,13 @@
 
 					// func getRandomData(r []byte)
 					"runtime.getRandomData": (sp) => {
+						sp >>>= 0;
 						crypto.getRandomValues(loadSlice(sp + 8));
 					},
 
 					// func finalizeRef(v ref)
 					"syscall/js.finalizeRef": (sp) => {
+						sp >>>= 0;
 						const id = this.mem.getUint32(sp + 8, true);
 						this._goRefCounts[id]--;
 						if (this._goRefCounts[id] === 0) {
@@ -340,44 +353,51 @@
 
 					// func stringVal(value string) ref
 					"syscall/js.stringVal": (sp) => {
+						sp >>>= 0;
 						storeValue(sp + 24, loadString(sp + 8));
 					},
 
 					// func valueGet(v ref, p string) ref
 					"syscall/js.valueGet": (sp) => {
+						sp >>>= 0;
 						const result = Reflect.get(loadValue(sp + 8), loadString(sp + 16));
-						sp = this._inst.exports.getsp(); // see comment above
+						sp = this._inst.exports.getsp() >>> 0; // see comment above
 						storeValue(sp + 32, result);
 					},
 
 					// func valueSet(v ref, p string, x ref)
 					"syscall/js.valueSet": (sp) => {
+						sp >>>= 0;
 						Reflect.set(loadValue(sp + 8), loadString(sp + 16), loadValue(sp + 32));
 					},
 
 					// func valueDelete(v ref, p string)
 					"syscall/js.valueDelete": (sp) => {
+						sp >>>= 0;
 						Reflect.deleteProperty(loadValue(sp + 8), loadString(sp + 16));
 					},
 
 					// func valueIndex(v ref, i int) ref
 					"syscall/js.valueIndex": (sp) => {
+						sp >>>= 0;
 						storeValue(sp + 24, Reflect.get(loadValue(sp + 8), getInt64(sp + 16)));
 					},
 
 					// valueSetIndex(v ref, i int, x ref)
 					"syscall/js.valueSetIndex": (sp) => {
+						sp >>>= 0;
 						Reflect.set(loadValue(sp + 8), getInt64(sp + 16), loadValue(sp + 24));
 					},
 
 					// func valueCall(v ref, m string, args []ref) (ref, bool)
 					"syscall/js.valueCall": (sp) => {
+						sp >>>= 0;
 						try {
 							const v = loadValue(sp + 8);
 							const m = Reflect.get(v, loadString(sp + 16));
 							const args = loadSliceOfValues(sp + 32);
 							const result = Reflect.apply(m, v, args);
-							sp = this._inst.exports.getsp(); // see comment above
+							sp = this._inst.exports.getsp() >>> 0; // see comment above
 							storeValue(sp + 56, result);
 							this.mem.setUint8(sp + 64, 1);
 						} catch (err) {
@@ -388,11 +408,12 @@
 
 					// func valueInvoke(v ref, args []ref) (ref, bool)
 					"syscall/js.valueInvoke": (sp) => {
+						sp >>>= 0;
 						try {
 							const v = loadValue(sp + 8);
 							const args = loadSliceOfValues(sp + 16);
 							const result = Reflect.apply(v, undefined, args);
-							sp = this._inst.exports.getsp(); // see comment above
+							sp = this._inst.exports.getsp() >>> 0; // see comment above
 							storeValue(sp + 40, result);
 							this.mem.setUint8(sp + 48, 1);
 						} catch (err) {
@@ -403,11 +424,12 @@
 
 					// func valueNew(v ref, args []ref) (ref, bool)
 					"syscall/js.valueNew": (sp) => {
+						sp >>>= 0;
 						try {
 							const v = loadValue(sp + 8);
 							const args = loadSliceOfValues(sp + 16);
 							const result = Reflect.construct(v, args);
-							sp = this._inst.exports.getsp(); // see comment above
+							sp = this._inst.exports.getsp() >>> 0; // see comment above
 							storeValue(sp + 40, result);
 							this.mem.setUint8(sp + 48, 1);
 						} catch (err) {
@@ -418,11 +440,13 @@
 
 					// func valueLength(v ref) int
 					"syscall/js.valueLength": (sp) => {
+						sp >>>= 0;
 						setInt64(sp + 16, parseInt(loadValue(sp + 8).length));
 					},
 
 					// valuePrepareString(v ref) (ref, int)
 					"syscall/js.valuePrepareString": (sp) => {
+						sp >>>= 0;
 						const str = encoder.encode(String(loadValue(sp + 8)));
 						storeValue(sp + 16, str);
 						setInt64(sp + 24, str.length);
@@ -430,17 +454,20 @@
 
 					// valueLoadString(v ref, b []byte)
 					"syscall/js.valueLoadString": (sp) => {
+						sp >>>= 0;
 						const str = loadValue(sp + 8);
 						loadSlice(sp + 16).set(str);
 					},
 
 					// func valueInstanceOf(v ref, t ref) bool
 					"syscall/js.valueInstanceOf": (sp) => {
+						sp >>>= 0;
 						this.mem.setUint8(sp + 24, (loadValue(sp + 8) instanceof loadValue(sp + 16)) ? 1 : 0);
 					},
 
 					// func copyBytesToGo(dst []byte, src ref) (int, bool)
 					"syscall/js.copyBytesToGo": (sp) => {
+						sp >>>= 0;
 						const dst = loadSlice(sp + 8);
 						const src = loadValue(sp + 32);
 						if (!(src instanceof Uint8Array || src instanceof Uint8ClampedArray)) {
@@ -455,6 +482,7 @@
 
 					// func copyBytesToJS(dst ref, src []byte) (int, bool)
 					"syscall/js.copyBytesToJS": (sp) => {
+						sp >>>= 0;
 						const dst = loadValue(sp + 8);
 						const src = loadSlice(sp + 16);
 						if (!(dst instanceof Uint8Array || dst instanceof Uint8ClampedArray)) {
@@ -475,6 +503,9 @@
 		}
 
 		async run(instance) {
+			if (!(instance instanceof WebAssembly.Instance)) {
+				throw new Error("Go.run: WebAssembly.Instance expected");
+			}
 			this._inst = instance;
 			this.mem = new DataView(this._inst.exports.mem.buffer);
 			this._values = [ // JS values that Go currently has references to, indexed by reference id
@@ -532,6 +563,13 @@
 				this.mem.setUint32(offset + 4, 0, true);
 				offset += 8;
 			});
+
+			// The linker guarantees global data starts from at least wasmMinDataAddr.
+			// Keep in sync with cmd/link/internal/ld/data.go:wasmMinDataAddr.
+			const wasmMinDataAddr = 4096 + 8192;
+			if (offset >= wasmMinDataAddr) {
+				throw new Error("total length of command line and environment variables exceeds limit");
+			}
 
 			this._inst.exports.run(argc, argv);
 			if (this.exited) {

--- a/wrappers/js/package-lock.json
+++ b/wrappers/js/package-lock.json
@@ -1,8 +1,1063 @@
 {
   "name": "@aml-org/amf-custom-validator",
-  "version": "1.2.0-SNAPSHOT",
-  "lockfileVersion": 1,
+  "version": "1.3.0-SNAPSHOT",
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "@aml-org/amf-custom-validator",
+      "version": "1.3.0-SNAPSHOT",
+      "license": "ISC",
+      "dependencies": {
+        "pako": "^2.0.4"
+      },
+      "devDependencies": {
+        "mocha": "^8.4.0"
+      }
+    },
+    "node_modules/@ungap/promise-all-settled": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
+      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
+      "dev": true
+    },
+    "node_modules/ansi-colors": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "dev": true,
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "node_modules/camelcase": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
+      "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
+      "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
+      "dev": true,
+      "dependencies": {
+        "anymatch": "~3.1.1",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.0",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.5.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.1"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "node_modules/debug": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/debug/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/diff": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true,
+      "bin": {
+        "flat": "cli.js"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.x"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "node_modules/js-yaml": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
+      "integrity": "sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
+      "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/mocha": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.4.0.tgz",
+      "integrity": "sha512-hJaO0mwDXmZS4ghXsvPVriOhsxQ7ofcpQdm8dE+jISUOKopitvnXFQmpRR7jd2K6VBG6E26gU3IAbXXGIbu4sQ==",
+      "dev": true,
+      "dependencies": {
+        "@ungap/promise-all-settled": "1.1.2",
+        "ansi-colors": "4.1.1",
+        "browser-stdout": "1.3.1",
+        "chokidar": "3.5.1",
+        "debug": "4.3.1",
+        "diff": "5.0.0",
+        "escape-string-regexp": "4.0.0",
+        "find-up": "5.0.0",
+        "glob": "7.1.6",
+        "growl": "1.10.5",
+        "he": "1.2.0",
+        "js-yaml": "4.0.0",
+        "log-symbols": "4.0.0",
+        "minimatch": "3.0.4",
+        "ms": "2.1.3",
+        "nanoid": "3.1.20",
+        "serialize-javascript": "5.0.1",
+        "strip-json-comments": "3.1.1",
+        "supports-color": "8.1.1",
+        "which": "2.0.2",
+        "wide-align": "1.1.3",
+        "workerpool": "6.1.0",
+        "yargs": "16.2.0",
+        "yargs-parser": "20.2.4",
+        "yargs-unparser": "2.0.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha"
+      },
+      "engines": {
+        "node": ">= 10.12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mochajs"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.1.20",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
+      "integrity": "sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==",
+      "dev": true,
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg=="
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+      "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+      "dev": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/serialize-javascript": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
+      "integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
+      "dev": true,
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "dependencies": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^1.0.2 || 2"
+      }
+    },
+    "node_modules/workerpool": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.0.tgz",
+      "integrity": "sha512-toV7q9rWNYha963Pl/qyeZ6wG+3nnsyvolaNUS8+R5Wtw6qJPTxIlOP1ZSvcGhEJw+l3HMMmtiNo9Gl61G4GVg==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.4",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  },
   "dependencies": {
     "@ungap/promise-all-settled": {
       "version": "1.1.2",

--- a/wrappers/js/package.json
+++ b/wrappers/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aml-org/amf-custom-validator",
-  "version": "1.2.1",
+  "version": "1.3.0-SNAPSHOT",
   "description": "AMF validator backed by OPA Rego",
   "main": "index.js",
   "scripts": {

--- a/wrappers/js/package.json
+++ b/wrappers/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aml-org/amf-custom-validator",
-  "version": "1.2.0-SNAPSHOT",
+  "version": "1.3.0-SNAPSHOT",
   "description": "AMF validator backed by OPA Rego",
   "main": "index.js",
   "scripts": {

--- a/wrappers/js/package.json
+++ b/wrappers/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aml-org/amf-custom-validator",
-  "version": "1.3.0-SNAPSHOT",
+  "version": "1.2.2",
   "description": "AMF validator backed by OPA Rego",
   "main": "index.js",
   "scripts": {

--- a/wrappers/js/test/simple.js
+++ b/wrappers/js/test/simple.js
@@ -12,9 +12,7 @@ describe('validator', () => {
         it("should load the WASM code, validate a profile, exit", (done) => {
             const profile = fs.readFileSync(__dirname + "/../../../test/data/integration/profile10/profile.yaml").toString()
             const data = fs.readFileSync(__dirname + "/../../../test/data/integration/profile10/negative.data.jsonld").toString()
-
             const validator = require(__dirname + "/../index")
-
             validator.initialize(() => {
                 validator.validate(profile, data, false, (r, err) => {
                     if (err) {
@@ -36,5 +34,42 @@ describe('validator', () => {
                 });
             })
         });
+
+        it ("should generate the Rego code for a profile and exit", (done) => {
+            const profile = fs.readFileSync(__dirname + "/../../../test/data/integration/profile10/profile.yaml").toString()
+
+            const validator = require(__dirname + "/../index")
+
+            validator.initialize(() => {
+                validator.generateRego(profile, (r, err) => {
+                    if (err) {
+                        done(err);
+                    } else {
+                        assert.ok(r.indexOf("package profile_kiali") > -1)
+                        validator.exit();
+                        done();
+                    }
+                });
+            })
+        })
+
+        it ("should normalize input data", (done) => {
+            const data = fs.readFileSync(__dirname + "/../../../test/data/integration/profile10/negative.data.jsonld").toString()
+
+            const validator = require(__dirname + "/../index")
+
+            validator.initialize(() => {
+                validator.normalizeInput(data, (r, err) => {
+                    if (err) {
+                        done(err);
+                    } else {
+                        assert.ok(r.indexOf("@ids") > -1)
+                        validator.exit();
+                        done();
+                    }
+                });
+            })
+        })
+
     })
 })


### PR DESCRIPTION
- W-11235951 - Back to snapshot
- Adding async-api production profile and tests.
- Refactoring production tests to generate additional debug info and use positive/negative test information again
- Adding support to generate debug output from the JS wrapper
- W-11721688: bump OPA to 0.44.0
- Adding support to navigate custom properties in property constraints
- Adding support for inverse navigation of custom properties
- Updating documentation with custom domain properties
- Added example with nested properties in API extensions
- Publish amf-custom-validator 1.2.2
