### PR TITLE
Custom rego

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -121,6 +121,12 @@ func preamble(profile profile.Profile) string {
 }
 
 const preambleRaw = `
+# Import future keywords
+import future.keywords.in
+import future.keywords.every
+import future.keywords.if
+import future.keywords.contains
+
 # Finds a node in the graph, following a link in the flatten JSON-LD node
 find = node {
   id := data.link["@id"]

--- a/internal/parser/parsing_test.go
+++ b/internal/parser/parsing_test.go
@@ -22,7 +22,7 @@ func TestParsed(t *testing.T) {
 		}
 
 		if actual != expected {
-			t.Errorf("%s> Actual did not match expected", fix.Profile)
+			t.Errorf("%s> Actual did not match expected %s", fix.Profile, fix.Parsed)
 		}
 	}
 }

--- a/internal/parser/profile/parser.go
+++ b/internal/parser/profile/parser.go
@@ -20,6 +20,11 @@ func Parse(doc *y.Yaml) (Profile, error) {
 			profile.Description = &description
 		}
 
+		customRego, err := doc.Get("rego_extensions").String()
+		if err == nil {
+			profile.CustomRego = &customRego
+		}
+
 		prefixes := doc.Get("prefixes")
 		if prefixes.IsFound() {
 			context, err := ParsePrefixes(prefixes)

--- a/internal/parser/profile/rule.go
+++ b/internal/parser/profile/rule.go
@@ -43,6 +43,7 @@ type AtomicStatement struct {
 type Profile struct {
 	Name        string
 	Description *string
+	CustomRego  *string
 	Prefixes    ProfileContext
 	Violation   []Rule
 	Warning     []Rule

--- a/test/data/basic/profile1.rego
+++ b/test/data/basic/profile1.rego
@@ -2,6 +2,12 @@ package profile_test_1
 
 report["profile"] = "Test 1"
 
+# Import future keywords
+import future.keywords.in
+import future.keywords.every
+import future.keywords.if
+import future.keywords.contains
+
 # Finds a node in the graph, following a link in the flatten JSON-LD node
 find = node {
   id := data.link["@id"]

--- a/test/data/basic/profile10.rego
+++ b/test/data/basic/profile10.rego
@@ -2,6 +2,12 @@ package profile_test10
 
 report["profile"] = "Test10"
 
+# Import future keywords
+import future.keywords.in
+import future.keywords.every
+import future.keywords.if
+import future.keywords.contains
+
 # Finds a node in the graph, following a link in the flatten JSON-LD node
 find = node {
   id := data.link["@id"]

--- a/test/data/basic/profile11.rego
+++ b/test/data/basic/profile11.rego
@@ -2,6 +2,12 @@ package profile_test11
 
 report["profile"] = "Test11"
 
+# Import future keywords
+import future.keywords.in
+import future.keywords.every
+import future.keywords.if
+import future.keywords.contains
+
 # Finds a node in the graph, following a link in the flatten JSON-LD node
 find = node {
   id := data.link["@id"]

--- a/test/data/basic/profile12.rego
+++ b/test/data/basic/profile12.rego
@@ -2,6 +2,12 @@ package profile_test13
 
 report["profile"] = "Test13"
 
+# Import future keywords
+import future.keywords.in
+import future.keywords.every
+import future.keywords.if
+import future.keywords.contains
+
 # Finds a node in the graph, following a link in the flatten JSON-LD node
 find = node {
   id := data.link["@id"]

--- a/test/data/basic/profile13.rego
+++ b/test/data/basic/profile13.rego
@@ -2,6 +2,12 @@ package profile_test13
 
 report["profile"] = "Test13"
 
+# Import future keywords
+import future.keywords.in
+import future.keywords.every
+import future.keywords.if
+import future.keywords.contains
+
 # Finds a node in the graph, following a link in the flatten JSON-LD node
 find = node {
   id := data.link["@id"]

--- a/test/data/basic/profile14.rego
+++ b/test/data/basic/profile14.rego
@@ -2,6 +2,12 @@ package profile_name_with_3_non_alphanumeric_characters_like_
 
 report["profile"] = "name with 3 non-alphanumeric characters like %, ^ & *"
 
+# Import future keywords
+import future.keywords.in
+import future.keywords.every
+import future.keywords.if
+import future.keywords.contains
+
 # Finds a node in the graph, following a link in the flatten JSON-LD node
 find = node {
   id := data.link["@id"]

--- a/test/data/basic/profile15.rego
+++ b/test/data/basic/profile15.rego
@@ -2,6 +2,12 @@ package profile_test
 
 report["profile"] = "test"
 
+# Import future keywords
+import future.keywords.in
+import future.keywords.every
+import future.keywords.if
+import future.keywords.contains
+
 # Finds a node in the graph, following a link in the flatten JSON-LD node
 find = node {
   id := data.link["@id"]

--- a/test/data/basic/profile16.parsed
+++ b/test/data/basic/profile16.parsed
@@ -1,0 +1,14 @@
+validation1[violation] :=  ∀x[Class(ex.Test)] : 
+  (
+  (
+    minExclusive(x,'ex.errorCount',0)
+  →
+    in(x,'ex.someProp',false)
+  )
+  ∧
+  (
+  ¬  minExclusive(x,'ex.errorCount',0)
+  →
+    in(x,'ex.otherProp',true)
+  )
+  )

--- a/test/data/basic/profile16.rego
+++ b/test/data/basic/profile16.rego
@@ -19,6 +19,12 @@ instances contains instance if {
 }
 
 
+# Import future keywords
+import future.keywords.in
+import future.keywords.every
+import future.keywords.if
+import future.keywords.contains
+
 # Finds a node in the graph, following a link in the flatten JSON-LD node
 find = node {
   id := data.link["@id"]

--- a/test/data/basic/profile16.yaml
+++ b/test/data/basic/profile16.yaml
@@ -1,0 +1,42 @@
+#%Validation Profile 1.0
+profile: test
+
+violation:
+  - validation1
+
+rego_extensions: |
+  import future.keywords.in
+  import future.keywords.every
+  import future.keywords.if
+  import future.keywords.contains
+  sites := []
+  containers := []
+  instances contains instance if {
+    server := sites[_].servers[_]
+    instance := {"address": server.hostname, "name": server.name}
+  }
+  instances contains instance if {
+    container := containers[_]
+    instance := {"address": container.ipaddress, "name": container.name}
+  }
+
+validations:
+
+  validation1:
+    targetClass: ex.Test
+    if:
+      propertyConstraints:
+        ex.errorCount:
+          minExclusive: 0
+    then:
+      propertyConstraints:
+        ex.someProp:
+          in: [false]
+    else:
+      propertyConstraints:
+        ex.otherProp:
+          in: [true]
+
+prefixes:
+  ex: https://github.com/aml-org/amf-custom-validator/test/data/tck/conditionals/if-then-else#
+

--- a/test/data/basic/profile2.rego
+++ b/test/data/basic/profile2.rego
@@ -2,6 +2,12 @@ package profile_test_2
 
 report["profile"] = "Test 2"
 
+# Import future keywords
+import future.keywords.in
+import future.keywords.every
+import future.keywords.if
+import future.keywords.contains
+
 # Finds a node in the graph, following a link in the flatten JSON-LD node
 find = node {
   id := data.link["@id"]

--- a/test/data/basic/profile3.rego
+++ b/test/data/basic/profile3.rego
@@ -2,6 +2,12 @@ package profile_test_3
 
 report["profile"] = "Test 3"
 
+# Import future keywords
+import future.keywords.in
+import future.keywords.every
+import future.keywords.if
+import future.keywords.contains
+
 # Finds a node in the graph, following a link in the flatten JSON-LD node
 find = node {
   id := data.link["@id"]

--- a/test/data/basic/profile4.rego
+++ b/test/data/basic/profile4.rego
@@ -2,6 +2,12 @@ package profile_test_4
 
 report["profile"] = "Test 4"
 
+# Import future keywords
+import future.keywords.in
+import future.keywords.every
+import future.keywords.if
+import future.keywords.contains
+
 # Finds a node in the graph, following a link in the flatten JSON-LD node
 find = node {
   id := data.link["@id"]

--- a/test/data/basic/profile5.rego
+++ b/test/data/basic/profile5.rego
@@ -2,6 +2,12 @@ package profile_test_profile_5
 
 report["profile"] = "Test profile 5"
 
+# Import future keywords
+import future.keywords.in
+import future.keywords.every
+import future.keywords.if
+import future.keywords.contains
+
 # Finds a node in the graph, following a link in the flatten JSON-LD node
 find = node {
   id := data.link["@id"]

--- a/test/data/basic/profile6.rego
+++ b/test/data/basic/profile6.rego
@@ -2,6 +2,12 @@ package profile_test6
 
 report["profile"] = "Test6"
 
+# Import future keywords
+import future.keywords.in
+import future.keywords.every
+import future.keywords.if
+import future.keywords.contains
+
 # Finds a node in the graph, following a link in the flatten JSON-LD node
 find = node {
   id := data.link["@id"]

--- a/test/data/basic/profile6b.rego
+++ b/test/data/basic/profile6b.rego
@@ -2,6 +2,12 @@ package profile_test6
 
 report["profile"] = "Test6"
 
+# Import future keywords
+import future.keywords.in
+import future.keywords.every
+import future.keywords.if
+import future.keywords.contains
+
 # Finds a node in the graph, following a link in the flatten JSON-LD node
 find = node {
   id := data.link["@id"]

--- a/test/data/basic/profile7.rego
+++ b/test/data/basic/profile7.rego
@@ -2,6 +2,12 @@ package profile_test13
 
 report["profile"] = "Test13"
 
+# Import future keywords
+import future.keywords.in
+import future.keywords.every
+import future.keywords.if
+import future.keywords.contains
+
 # Finds a node in the graph, following a link in the flatten JSON-LD node
 find = node {
   id := data.link["@id"]

--- a/test/data/basic/profile8.rego
+++ b/test/data/basic/profile8.rego
@@ -2,6 +2,12 @@ package profile_test_1
 
 report["profile"] = "Test 1"
 
+# Import future keywords
+import future.keywords.in
+import future.keywords.every
+import future.keywords.if
+import future.keywords.contains
+
 # Finds a node in the graph, following a link in the flatten JSON-LD node
 find = node {
   id := data.link["@id"]

--- a/test/data/basic/profile9.rego
+++ b/test/data/basic/profile9.rego
@@ -2,6 +2,12 @@ package profile_test9
 
 report["profile"] = "Test9"
 
+# Import future keywords
+import future.keywords.in
+import future.keywords.every
+import future.keywords.if
+import future.keywords.contains
+
 # Finds a node in the graph, following a link in the flatten JSON-LD node
 find = node {
   id := data.link["@id"]


### PR DESCRIPTION
- Including custom rego code provided by the customer in the top-level `rego_extension` property before our rego prologue in the generated rego translation
- Adding support for the current set of future keywords


See https://github.com/aml-org/amf-validation-profile-dialect/pull/31 for matching changes in the dialect.