### PR TITLE
Report configurations: W-14608348 & W-14688992

### DIFF
--- a/internal/validator/config/report_configuration.go
+++ b/internal/validator/config/report_configuration.go
@@ -2,10 +2,14 @@ package config
 
 type ReportConfiguration struct {
 	IncludeReportCreationTime bool
+	ReportSchemaIri           string
+	LexicalSchemaIri          string
 }
 
 func DefaultReportConfiguration() ReportConfiguration {
 	return ReportConfiguration{
 		IncludeReportCreationTime: true,
+		ReportSchemaIri:           "file:///dialects/validation-report.yaml",
+		LexicalSchemaIri:          "file:///dialects/lexical.yaml",
 	}
 }

--- a/internal/validator/config/report_configuration.go
+++ b/internal/validator/config/report_configuration.go
@@ -1,4 +1,4 @@
-package validator
+package config
 
 type ReportConfiguration struct {
 	IncludeReportCreationTime bool

--- a/internal/validator/config/validation_configuration.go
+++ b/internal/validator/config/validation_configuration.go
@@ -1,4 +1,4 @@
-package validator
+package config
 
 import "time"
 

--- a/internal/validator/contexts/contexts.go
+++ b/internal/validator/contexts/contexts.go
@@ -1,6 +1,10 @@
 package contexts
 
-import "github.com/aml-org/amf-custom-validator/internal/types"
+import (
+	"fmt"
+	"github.com/aml-org/amf-custom-validator/internal/types"
+	"github.com/aml-org/amf-custom-validator/internal/validator/config"
+)
 
 var ApiExtensionUri = "http://a.ml/vocabularies/api-extension#"
 var DefaultAMFContext = types.ObjectMap{
@@ -24,106 +28,111 @@ var DefaultAMFContext = types.ObjectMap{
 	"catalog":     "http://anypoint.com/vocabs/digital-repository#",
 }
 
-var DefaultValidationContext = types.ObjectMap{
-	"actual": types.StringMap{
-		"@id": "http://a.ml/vocabularies/validation#actual",
-	},
-	"condition": types.StringMap{
-		"@id": "http://a.ml/vocabularies/validation#condition",
-	},
-	"expected": types.StringMap{
-		"@id": "http://a.ml/vocabularies/validation#expected",
-	},
-	"negated": types.StringMap{
-		"@id": "http://a.ml/vocabularies/validation#negated",
-	},
-	"argument": types.StringMap{
-		"@id": "http://a.ml/vocabularies/validation#argument",
-	},
-	"focusNode": types.StringMap{
-		"@id": "http://www.w3.org/ns/shacl#focusNode",
-	},
-	"trace": types.StringMap{
-		"@id": "http://a.ml/vocabularies/validation#trace",
-	},
-	"component": types.StringMap{
-		"@id": "http://a.ml/vocabularies/validation#component",
-	},
-	"resultPath": types.StringMap{
-		"@id": "http://www.w3.org/ns/shacl#resultPath",
-	},
-	"traceValue": types.StringMap{
-		"@id": "http://www.w3.org/ns/shacl#traceValue",
-	},
-	"location": types.StringMap{
-		"@id": "http://a.ml/vocabularies/validation#location",
-	},
-	"uri": types.StringMap{
-		"@id": "http://a.ml/vocabularies/lexical#uri",
-	},
-	"start": types.StringMap{
-		"@id": "http://a.ml/vocabularies/lexical#start",
-	},
-	"end": types.StringMap{
-		"@id": "http://a.ml/vocabularies/lexical#end",
-	},
-	"range": types.StringMap{
-		"@id": "http://a.ml/vocabularies/lexical#range",
-	},
-	"line": types.StringMap{
-		"@id": "http://a.ml/vocabularies/lexical#line",
-	},
-	"column": types.StringMap{
-		"@id": "http://a.ml/vocabularies/lexical#column",
-	},
-	"sourceShapeName": types.StringMap{
-		"@id": "http://a.ml/vocabularies/validation#sourceShapeName",
-	},
-	"conforms": types.StringMap{
-		"@id": "http://www.w3.org/ns/shacl#conforms",
-	},
-	"dateCreated": types.StringMap{
-		"@id": "http://a.ml/vocabularies/core#dateCreated",
-	},
-	"profileName": types.StringMap{
-		"@id": "http://a.ml/vocabularies/validation#profileName",
-	},
-	"result": types.StringMap{
-		"@id": "http://www.w3.org/ns/shacl#result",
-	},
-	"subResult": types.StringMap{
-		"@id": "http://a.ml/vocabularies/validation#subResult",
-	},
-	"resultSeverity": types.StringMap{
-		"@id": "http://www.w3.org/ns/shacl#resultSeverity",
-	},
-	"resultMessage": types.StringMap{
-		"@id": "http://www.w3.org/ns/shacl#resultMessage",
-	},
-	"shacl":         "http://www.w3.org/ns/shacl#",
-	"doc":           "http://a.ml/vocabularies/document#",
-	"meta":          "http://a.ml/vocabularies/meta#",
-	"validation":    "http://a.ml/vocabularies/validation#",
-	"lexical":       "http://a.ml/vocabularies/lexical#",
-	"reportSchema":  reportPath,
-	"lexicalSchema": lexicalPath,
+func DefaultValidationContext(reportConfig config.ReportConfiguration) types.ObjectMap {
+	return types.ObjectMap{
+		"actual": types.StringMap{
+			"@id": "http://a.ml/vocabularies/validation#actual",
+		},
+		"condition": types.StringMap{
+			"@id": "http://a.ml/vocabularies/validation#condition",
+		},
+		"expected": types.StringMap{
+			"@id": "http://a.ml/vocabularies/validation#expected",
+		},
+		"negated": types.StringMap{
+			"@id": "http://a.ml/vocabularies/validation#negated",
+		},
+		"argument": types.StringMap{
+			"@id": "http://a.ml/vocabularies/validation#argument",
+		},
+		"focusNode": types.StringMap{
+			"@id": "http://www.w3.org/ns/shacl#focusNode",
+		},
+		"trace": types.StringMap{
+			"@id": "http://a.ml/vocabularies/validation#trace",
+		},
+		"component": types.StringMap{
+			"@id": "http://a.ml/vocabularies/validation#component",
+		},
+		"resultPath": types.StringMap{
+			"@id": "http://www.w3.org/ns/shacl#resultPath",
+		},
+		"traceValue": types.StringMap{
+			"@id": "http://www.w3.org/ns/shacl#traceValue",
+		},
+		"location": types.StringMap{
+			"@id": "http://a.ml/vocabularies/validation#location",
+		},
+		"uri": types.StringMap{
+			"@id": "http://a.ml/vocabularies/lexical#uri",
+		},
+		"start": types.StringMap{
+			"@id": "http://a.ml/vocabularies/lexical#start",
+		},
+		"end": types.StringMap{
+			"@id": "http://a.ml/vocabularies/lexical#end",
+		},
+		"range": types.StringMap{
+			"@id": "http://a.ml/vocabularies/lexical#range",
+		},
+		"line": types.StringMap{
+			"@id": "http://a.ml/vocabularies/lexical#line",
+		},
+		"column": types.StringMap{
+			"@id": "http://a.ml/vocabularies/lexical#column",
+		},
+		"sourceShapeName": types.StringMap{
+			"@id": "http://a.ml/vocabularies/validation#sourceShapeName",
+		},
+		"conforms": types.StringMap{
+			"@id": "http://www.w3.org/ns/shacl#conforms",
+		},
+		"dateCreated": types.StringMap{
+			"@id": "http://a.ml/vocabularies/core#dateCreated",
+		},
+		"profileName": types.StringMap{
+			"@id": "http://a.ml/vocabularies/validation#profileName",
+		},
+		"result": types.StringMap{
+			"@id": "http://www.w3.org/ns/shacl#result",
+		},
+		"subResult": types.StringMap{
+			"@id": "http://a.ml/vocabularies/validation#subResult",
+		},
+		"resultSeverity": types.StringMap{
+			"@id": "http://www.w3.org/ns/shacl#resultSeverity",
+		},
+		"resultMessage": types.StringMap{
+			"@id": "http://www.w3.org/ns/shacl#resultMessage",
+		},
+		"shacl":         "http://www.w3.org/ns/shacl#",
+		"doc":           "http://a.ml/vocabularies/document#",
+		"meta":          "http://a.ml/vocabularies/meta#",
+		"validation":    "http://a.ml/vocabularies/validation#",
+		"lexical":       "http://a.ml/vocabularies/lexical#",
+		"reportSchema":  DeclarationsFrom(reportConfig.ReportSchemaIri),
+		"lexicalSchema": DeclarationsFrom(reportConfig.LexicalSchemaIri),
+	}
 }
 
-var reportPath = "file:///dialects/validation-report.yaml#/declarations/"
-var lexicalPath = "file:///dialects/lexical.yaml#/declarations/"
+func ConformsContext(reportConfig config.ReportConfiguration) types.ObjectMap {
+	return types.ObjectMap{
+		"conforms": types.StringMap{
+			"@id": "http://www.w3.org/ns/shacl#conforms",
+		},
+		"shacl":        "http://www.w3.org/ns/shacl#",
+		"doc":          "http://a.ml/vocabularies/document#",
+		"reportSchema": DeclarationsFrom(reportConfig.ReportSchemaIri),
+		"meta":         "http://a.ml/vocabularies/meta#",
+		"dateCreated": types.StringMap{
+			"@id": "http://a.ml/vocabularies/core#dateCreated",
+		},
+		"profileName": types.StringMap{
+			"@id": "http://a.ml/vocabularies/validation#profileName",
+		},
+	}
+}
 
-var ConformsContext = types.ObjectMap{
-	"conforms": types.StringMap{
-		"@id": "http://www.w3.org/ns/shacl#conforms",
-	},
-	"shacl":        "http://www.w3.org/ns/shacl#",
-	"doc":          "http://a.ml/vocabularies/document#",
-	"reportSchema": reportPath,
-	"meta":         "http://a.ml/vocabularies/meta#",
-	"dateCreated": types.StringMap{
-		"@id": "http://a.ml/vocabularies/core#dateCreated",
-	},
-	"profileName": types.StringMap{
-		"@id": "http://a.ml/vocabularies/validation#profileName",
-	},
+func DeclarationsFrom(schemaIri string) string {
+	return fmt.Sprintf("%s#/declarations/", schemaIri)
 }

--- a/internal/validator/process_result.go
+++ b/internal/validator/process_result.go
@@ -1,11 +1,12 @@
 package validator
 
 import (
+	"github.com/aml-org/amf-custom-validator/internal/validator/config"
 	e "github.com/aml-org/amf-custom-validator/pkg/events"
 	"github.com/open-policy-agent/opa/rego"
 )
 
-func processResult(result *rego.ResultSet, eventChan *chan e.Event, validationConfig ValidationConfiguration, reportConfig ReportConfiguration) (string, error) {
+func processResult(result *rego.ResultSet, eventChan *chan e.Event, validationConfig config.ValidationConfiguration, reportConfig config.ReportConfiguration) (string, error) {
 	dispatchEvent(e.NewEvent(e.BuildReportStart), eventChan)
 	report, err := BuildReport(result, validationConfig, reportConfig)
 	dispatchEvent(e.NewEvent(e.BuildReportDone), eventChan)

--- a/internal/validator/process_result.go
+++ b/internal/validator/process_result.go
@@ -5,9 +5,9 @@ import (
 	"github.com/open-policy-agent/opa/rego"
 )
 
-func processResult(result *rego.ResultSet, eventChan *chan e.Event, configuration ValidationConfiguration) (string, error) {
+func processResult(result *rego.ResultSet, eventChan *chan e.Event, validationConfig ValidationConfiguration) (string, error) {
 	dispatchEvent(e.NewEvent(e.BuildReportStart), eventChan)
-	report, err := BuildReport(result, configuration)
+	report, err := BuildReport(result, validationConfig)
 	dispatchEvent(e.NewEvent(e.BuildReportDone), eventChan)
 	return report, err
 }

--- a/internal/validator/process_result.go
+++ b/internal/validator/process_result.go
@@ -5,9 +5,9 @@ import (
 	"github.com/open-policy-agent/opa/rego"
 )
 
-func processResult(result *rego.ResultSet, eventChan *chan e.Event, validationConfig ValidationConfiguration) (string, error) {
+func processResult(result *rego.ResultSet, eventChan *chan e.Event, validationConfig ValidationConfiguration, reportConfig ReportConfiguration) (string, error) {
 	dispatchEvent(e.NewEvent(e.BuildReportStart), eventChan)
-	report, err := BuildReport(result, validationConfig)
+	report, err := BuildReport(result, validationConfig, reportConfig)
 	dispatchEvent(e.NewEvent(e.BuildReportDone), eventChan)
 	return report, err
 }

--- a/internal/validator/report.go
+++ b/internal/validator/report.go
@@ -28,7 +28,7 @@ func BuildReport(resultPtr *rego.ResultSet, validationConfig config.ValidationCo
 	results := buildResults(violations, warnings, infos)
 	conforms := len(violations) == 0
 
-	context := buildContext(len(results) == 0)
+	context := buildContext(len(results) == 0, reportConfig)
 	reportNode := ValidationReportNode(profileName, results, conforms, validationConfig, reportConfig)
 	instance := DialectInstance(&reportNode, &context)
 	return Encode(instance), nil
@@ -74,11 +74,11 @@ func defineIdRecursively(node *types.ObjectMap, id string) {
 	}
 }
 
-func buildContext(emptyReport bool) types.ObjectMap {
+func buildContext(emptyReport bool, reportConfig config.ReportConfiguration) types.ObjectMap {
 	if emptyReport {
-		return contexts.ConformsContext
+		return contexts.ConformsContext(reportConfig)
 	} else {
-		return contexts.DefaultValidationContext
+		return contexts.DefaultValidationContext(reportConfig)
 	}
 }
 

--- a/internal/validator/report.go
+++ b/internal/validator/report.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 )
 
-func BuildReport(resultPtr *rego.ResultSet, configuration ValidationConfiguration) (string, error) {
+func BuildReport(resultPtr *rego.ResultSet, validationConfig ValidationConfiguration) (string, error) {
 	result := *resultPtr
 	if len(result) == 0 {
 		return "", errors.New("empty result from evaluation")
@@ -26,10 +26,9 @@ func BuildReport(resultPtr *rego.ResultSet, configuration ValidationConfiguratio
 	infos := m["info"].([]any)
 	results := buildResults(violations, warnings, infos)
 	conforms := len(violations) == 0
-	dateCreated := configuration.CurrentTime()
 
 	context := buildContext(len(results) == 0)
-	reportNode := ValidationReportNode(profileName, results, conforms, dateCreated)
+	reportNode := ValidationReportNode(profileName, results, conforms, validationConfig)
 	instance := DialectInstance(&reportNode, &context)
 	return Encode(instance), nil
 }

--- a/internal/validator/report.go
+++ b/internal/validator/report.go
@@ -6,13 +6,14 @@ import (
 	"errors"
 	"fmt"
 	"github.com/aml-org/amf-custom-validator/internal/types"
+	"github.com/aml-org/amf-custom-validator/internal/validator/config"
 	"github.com/aml-org/amf-custom-validator/internal/validator/contexts"
 	"github.com/open-policy-agent/opa/rego"
 	"strconv"
 	"strings"
 )
 
-func BuildReport(resultPtr *rego.ResultSet, validationConfig ValidationConfiguration, reportConfig ReportConfiguration) (string, error) {
+func BuildReport(resultPtr *rego.ResultSet, validationConfig config.ValidationConfiguration, reportConfig config.ReportConfiguration) (string, error) {
 	result := *resultPtr
 	if len(result) == 0 {
 		return "", errors.New("empty result from evaluation")

--- a/internal/validator/report.go
+++ b/internal/validator/report.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 )
 
-func BuildReport(resultPtr *rego.ResultSet, validationConfig ValidationConfiguration) (string, error) {
+func BuildReport(resultPtr *rego.ResultSet, validationConfig ValidationConfiguration, reportConfig ReportConfiguration) (string, error) {
 	result := *resultPtr
 	if len(result) == 0 {
 		return "", errors.New("empty result from evaluation")
@@ -28,7 +28,7 @@ func BuildReport(resultPtr *rego.ResultSet, validationConfig ValidationConfigura
 	conforms := len(violations) == 0
 
 	context := buildContext(len(results) == 0)
-	reportNode := ValidationReportNode(profileName, results, conforms, validationConfig)
+	reportNode := ValidationReportNode(profileName, results, conforms, validationConfig, reportConfig)
 	instance := DialectInstance(&reportNode, &context)
 	return Encode(instance), nil
 }

--- a/internal/validator/report_configuration.go
+++ b/internal/validator/report_configuration.go
@@ -1,0 +1,11 @@
+package validator
+
+type ReportConfiguration struct {
+	IncludeReportCreationTime bool
+}
+
+func DefaultReportConfiguration() ReportConfiguration {
+	return ReportConfiguration{
+		IncludeReportCreationTime: true,
+	}
+}

--- a/internal/validator/report_nodes.go
+++ b/internal/validator/report_nodes.go
@@ -2,6 +2,7 @@ package validator
 
 import (
 	"github.com/aml-org/amf-custom-validator/internal/types"
+	"github.com/aml-org/amf-custom-validator/internal/validator/config"
 	"time"
 )
 
@@ -16,7 +17,7 @@ func DialectInstance(report *types.ObjectMap, context *types.ObjectMap) []types.
 	return []types.ObjectMap{dialectInstance}
 }
 
-func ValidationReportNode(profileName string, results []any, conforms bool, validationConfig ValidationConfiguration, reportConfig ReportConfiguration) types.ObjectMap {
+func ValidationReportNode(profileName string, results []any, conforms bool, validationConfig config.ValidationConfiguration, reportConfig config.ReportConfiguration) types.ObjectMap {
 	reportTypes := []string{"reportSchema:ReportNode", "shacl:ValidationReport"}
 	report := types.ObjectMap{
 		"@id":         "validation-report",

--- a/internal/validator/report_nodes.go
+++ b/internal/validator/report_nodes.go
@@ -16,14 +16,14 @@ func DialectInstance(report *types.ObjectMap, context *types.ObjectMap) []types.
 	return []types.ObjectMap{dialectInstance}
 }
 
-func ValidationReportNode(profileName string, results []any, conforms bool, dateCreated time.Time) types.ObjectMap {
+func ValidationReportNode(profileName string, results []any, conforms bool, validationConfig ValidationConfiguration) types.ObjectMap {
 	reportTypes := []string{"reportSchema:ReportNode", "shacl:ValidationReport"}
 	report := types.ObjectMap{
 		"@id":         "validation-report",
 		"@type":       reportTypes,
 		"profileName": profileName,
 		"conforms":    conforms,
-		"dateCreated": dateCreated.Format(time.RFC3339),
+		"dateCreated": validationConfig.ReportCreationTime().Format(time.RFC3339),
 	}
 	if len(results) != 0 {
 		report["result"] = results

--- a/internal/validator/report_nodes.go
+++ b/internal/validator/report_nodes.go
@@ -16,14 +16,16 @@ func DialectInstance(report *types.ObjectMap, context *types.ObjectMap) []types.
 	return []types.ObjectMap{dialectInstance}
 }
 
-func ValidationReportNode(profileName string, results []any, conforms bool, validationConfig ValidationConfiguration) types.ObjectMap {
+func ValidationReportNode(profileName string, results []any, conforms bool, validationConfig ValidationConfiguration, reportConfig ReportConfiguration) types.ObjectMap {
 	reportTypes := []string{"reportSchema:ReportNode", "shacl:ValidationReport"}
 	report := types.ObjectMap{
 		"@id":         "validation-report",
 		"@type":       reportTypes,
 		"profileName": profileName,
 		"conforms":    conforms,
-		"dateCreated": validationConfig.ReportCreationTime().Format(time.RFC3339),
+	}
+	if reportConfig.IncludeReportCreationTime {
+		report["dateCreated"] = validationConfig.ReportCreationTime().Format(time.RFC3339)
 	}
 	if len(results) != 0 {
 		report["result"] = results

--- a/internal/validator/test_utils.go
+++ b/internal/validator/test_utils.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/aml-org/amf-custom-validator/internal/config"
 	p "github.com/aml-org/amf-custom-validator/internal/parser/profile"
+	config2 "github.com/aml-org/amf-custom-validator/internal/validator/config"
 	"github.com/aml-org/amf-custom-validator/pkg/milestones"
 	"io/ioutil"
 	"strings"
@@ -28,7 +29,7 @@ func validate(profile relativePath, data relativePath) string {
 	p.GenReset()
 	profileText := read(profile)
 	dataText := read(data)
-	report, err := ValidateWithConfiguration(profileText, dataText, config.Debug, nil, TestValidationConfiguration{}, DefaultReportConfiguration())
+	report, err := ValidateWithConfiguration(profileText, dataText, config.Debug, nil, config2.TestValidationConfiguration{}, config2.DefaultReportConfiguration())
 	if err != nil {
 		panic(err)
 	}

--- a/internal/validator/test_utils.go
+++ b/internal/validator/test_utils.go
@@ -28,7 +28,7 @@ func validate(profile relativePath, data relativePath) string {
 	p.GenReset()
 	profileText := read(profile)
 	dataText := read(data)
-	report, err := ValidateWithConfiguration(profileText, dataText, config.Debug, nil, TestConfiguration{})
+	report, err := ValidateWithConfiguration(profileText, dataText, config.Debug, nil, TestValidationConfiguration{})
 	if err != nil {
 		panic(err)
 	}

--- a/internal/validator/test_utils.go
+++ b/internal/validator/test_utils.go
@@ -28,7 +28,7 @@ func validate(profile relativePath, data relativePath) string {
 	p.GenReset()
 	profileText := read(profile)
 	dataText := read(data)
-	report, err := ValidateWithConfiguration(profileText, dataText, config.Debug, nil, TestValidationConfiguration{})
+	report, err := ValidateWithConfiguration(profileText, dataText, config.Debug, nil, TestValidationConfiguration{}, DefaultReportConfiguration())
 	if err != nil {
 		panic(err)
 	}

--- a/internal/validator/validate.go
+++ b/internal/validator/validate.go
@@ -11,14 +11,14 @@ import (
 // directly to `internal.Validate` rather than `pkg.Validate`
 
 func Validate(profileText string, jsonldText string, debug bool, eventChan *chan e.Event) (string, error) {
-	return ValidateWithConfiguration(profileText, jsonldText, debug, eventChan, DefaultConfiguration{})
+	return ValidateWithConfiguration(profileText, jsonldText, debug, eventChan, DefaultValidationConfiguration{})
 }
 
 func ValidateCompiled(compiledRegoPtr *rego.PreparedEvalQuery, jsonldText string, debug bool, eventChan *chan e.Event) (string, error) {
-	return ValidateCompiledWithConfiguration(compiledRegoPtr, jsonldText, debug, eventChan, DefaultConfiguration{})
+	return ValidateCompiledWithConfiguration(compiledRegoPtr, jsonldText, debug, eventChan, DefaultValidationConfiguration{})
 }
 
-func ValidateWithConfiguration(profileText string, jsonldText string, debug bool, eventChan *chan e.Event, configuration ValidationConfiguration) (string, error) {
+func ValidateWithConfiguration(profileText string, jsonldText string, debug bool, eventChan *chan e.Event, validationConfig ValidationConfiguration) (string, error) {
 	// Generate and compile Rego code
 	compiledRego, err := ProcessProfile(profileText, debug, eventChan)
 
@@ -27,10 +27,10 @@ func ValidateWithConfiguration(profileText string, jsonldText string, debug bool
 		return "", err
 	}
 
-	return ValidateCompiledWithConfiguration(compiledRego, jsonldText, debug, eventChan, configuration)
+	return ValidateCompiledWithConfiguration(compiledRego, jsonldText, debug, eventChan, validationConfig)
 }
 
-func ValidateCompiledWithConfiguration(compiledRegoPtr *rego.PreparedEvalQuery, jsonldText string, debug bool, eventChan *chan e.Event, configuration ValidationConfiguration) (string, error) {
+func ValidateCompiledWithConfiguration(compiledRegoPtr *rego.PreparedEvalQuery, jsonldText string, debug bool, eventChan *chan e.Event, validationConfig ValidationConfiguration) (string, error) {
 	compiledRego := *compiledRegoPtr
 
 	// Normalize input
@@ -50,7 +50,7 @@ func ValidateCompiledWithConfiguration(compiledRegoPtr *rego.PreparedEvalQuery, 
 	}
 
 	// Build report
-	report, err := processResult(validationResult, eventChan, configuration)
+	report, err := processResult(validationResult, eventChan, validationConfig)
 
 	if err != nil {
 		CloseEventChan(eventChan)

--- a/internal/validator/validate.go
+++ b/internal/validator/validate.go
@@ -11,14 +11,14 @@ import (
 // directly to `internal.Validate` rather than `pkg.Validate`
 
 func Validate(profileText string, jsonldText string, debug bool, eventChan *chan e.Event) (string, error) {
-	return ValidateWithConfiguration(profileText, jsonldText, debug, eventChan, DefaultValidationConfiguration{})
+	return ValidateWithConfiguration(profileText, jsonldText, debug, eventChan, DefaultValidationConfiguration{}, DefaultReportConfiguration())
 }
 
 func ValidateCompiled(compiledRegoPtr *rego.PreparedEvalQuery, jsonldText string, debug bool, eventChan *chan e.Event) (string, error) {
-	return ValidateCompiledWithConfiguration(compiledRegoPtr, jsonldText, debug, eventChan, DefaultValidationConfiguration{})
+	return ValidateCompiledWithConfiguration(compiledRegoPtr, jsonldText, debug, eventChan, DefaultValidationConfiguration{}, DefaultReportConfiguration())
 }
 
-func ValidateWithConfiguration(profileText string, jsonldText string, debug bool, eventChan *chan e.Event, validationConfig ValidationConfiguration) (string, error) {
+func ValidateWithConfiguration(profileText string, jsonldText string, debug bool, eventChan *chan e.Event, validationConfig ValidationConfiguration, reportConfig ReportConfiguration) (string, error) {
 	// Generate and compile Rego code
 	compiledRego, err := ProcessProfile(profileText, debug, eventChan)
 
@@ -27,10 +27,10 @@ func ValidateWithConfiguration(profileText string, jsonldText string, debug bool
 		return "", err
 	}
 
-	return ValidateCompiledWithConfiguration(compiledRego, jsonldText, debug, eventChan, validationConfig)
+	return ValidateCompiledWithConfiguration(compiledRego, jsonldText, debug, eventChan, validationConfig, reportConfig)
 }
 
-func ValidateCompiledWithConfiguration(compiledRegoPtr *rego.PreparedEvalQuery, jsonldText string, debug bool, eventChan *chan e.Event, validationConfig ValidationConfiguration) (string, error) {
+func ValidateCompiledWithConfiguration(compiledRegoPtr *rego.PreparedEvalQuery, jsonldText string, debug bool, eventChan *chan e.Event, validationConfig ValidationConfiguration, reportConfig ReportConfiguration) (string, error) {
 	compiledRego := *compiledRegoPtr
 
 	// Normalize input
@@ -50,7 +50,7 @@ func ValidateCompiledWithConfiguration(compiledRegoPtr *rego.PreparedEvalQuery, 
 	}
 
 	// Build report
-	report, err := processResult(validationResult, eventChan, validationConfig)
+	report, err := processResult(validationResult, eventChan, validationConfig, reportConfig)
 
 	if err != nil {
 		CloseEventChan(eventChan)

--- a/internal/validator/validate.go
+++ b/internal/validator/validate.go
@@ -2,6 +2,7 @@ package validator
 
 import (
 	"context"
+	"github.com/aml-org/amf-custom-validator/internal/validator/config"
 	e "github.com/aml-org/amf-custom-validator/pkg/events"
 	"github.com/open-policy-agent/opa/rego"
 )
@@ -11,14 +12,14 @@ import (
 // directly to `internal.Validate` rather than `pkg.Validate`
 
 func Validate(profileText string, jsonldText string, debug bool, eventChan *chan e.Event) (string, error) {
-	return ValidateWithConfiguration(profileText, jsonldText, debug, eventChan, DefaultValidationConfiguration{}, DefaultReportConfiguration())
+	return ValidateWithConfiguration(profileText, jsonldText, debug, eventChan, config.DefaultValidationConfiguration{}, config.DefaultReportConfiguration())
 }
 
 func ValidateCompiled(compiledRegoPtr *rego.PreparedEvalQuery, jsonldText string, debug bool, eventChan *chan e.Event) (string, error) {
-	return ValidateCompiledWithConfiguration(compiledRegoPtr, jsonldText, debug, eventChan, DefaultValidationConfiguration{}, DefaultReportConfiguration())
+	return ValidateCompiledWithConfiguration(compiledRegoPtr, jsonldText, debug, eventChan, config.DefaultValidationConfiguration{}, config.DefaultReportConfiguration())
 }
 
-func ValidateWithConfiguration(profileText string, jsonldText string, debug bool, eventChan *chan e.Event, validationConfig ValidationConfiguration, reportConfig ReportConfiguration) (string, error) {
+func ValidateWithConfiguration(profileText string, jsonldText string, debug bool, eventChan *chan e.Event, validationConfig config.ValidationConfiguration, reportConfig config.ReportConfiguration) (string, error) {
 	// Generate and compile Rego code
 	compiledRego, err := ProcessProfile(profileText, debug, eventChan)
 
@@ -30,7 +31,7 @@ func ValidateWithConfiguration(profileText string, jsonldText string, debug bool
 	return ValidateCompiledWithConfiguration(compiledRego, jsonldText, debug, eventChan, validationConfig, reportConfig)
 }
 
-func ValidateCompiledWithConfiguration(compiledRegoPtr *rego.PreparedEvalQuery, jsonldText string, debug bool, eventChan *chan e.Event, validationConfig ValidationConfiguration, reportConfig ReportConfiguration) (string, error) {
+func ValidateCompiledWithConfiguration(compiledRegoPtr *rego.PreparedEvalQuery, jsonldText string, debug bool, eventChan *chan e.Event, validationConfig config.ValidationConfiguration, reportConfig config.ReportConfiguration) (string, error) {
 	compiledRego := *compiledRegoPtr
 
 	// Normalize input

--- a/internal/validator/validate_configuration_test.go
+++ b/internal/validator/validate_configuration_test.go
@@ -3,18 +3,19 @@ package validator
 import (
 	"encoding/json"
 	"github.com/aml-org/amf-custom-validator/internal/config"
+	config2 "github.com/aml-org/amf-custom-validator/internal/validator/config"
 	"testing"
 )
 
 func TestNoDateCreated(t *testing.T) {
-	reportConfig := ReportConfiguration{
+	reportConfig := config2.ReportConfiguration{
 		IncludeReportCreationTime: false,
 	}
 
 	profile := read("../../test/data/integration/profile1/profile.yaml")
 	data := read("../../test/data/integration/profile1/negative.data.jsonld")
 
-	report, err := ValidateWithConfiguration(profile, data, config.Debug, nil, TestValidationConfiguration{}, reportConfig)
+	report, err := ValidateWithConfiguration(profile, data, config.Debug, nil, config2.TestValidationConfiguration{}, reportConfig)
 
 	if err != nil {
 		t.Errorf("Error during validation\n")

--- a/internal/validator/validate_configuration_test.go
+++ b/internal/validator/validate_configuration_test.go
@@ -1,0 +1,37 @@
+package validator
+
+import (
+	"encoding/json"
+	"github.com/aml-org/amf-custom-validator/internal/config"
+	"testing"
+)
+
+func TestNoDateCreated(t *testing.T) {
+	reportConfig := ReportConfiguration{
+		IncludeReportCreationTime: false,
+	}
+
+	profile := read("../../test/data/integration/profile1/profile.yaml")
+	data := read("../../test/data/integration/profile1/negative.data.jsonld")
+
+	report, err := ValidateWithConfiguration(profile, data, config.Debug, nil, TestValidationConfiguration{}, reportConfig)
+
+	if err != nil {
+		t.Errorf("Error during validation\n")
+	}
+
+	var output []any
+	err = json.Unmarshal([]byte(report), &output)
+	if err != nil {
+		t.Errorf("Error during report JSON unmarshling\n")
+	}
+	doc := output[0].(map[string]any)
+	encoded := doc["doc:encodes"].([]any)
+	encodedDoc := encoded[0].(map[string]any)
+
+	_, hasKey := encodedDoc["dateCreated"]
+
+	if hasKey {
+		t.Errorf("Report contains 'dateCreated' despite being disabled\n")
+	}
+}

--- a/internal/validator/validate_integration_test.go
+++ b/internal/validator/validate_integration_test.go
@@ -13,7 +13,7 @@ func TestIntegrationPositiveData(t *testing.T) {
 	for _, fixture := range test.IntegrationFixtures("../../test/data/integration", &filter) {
 		prof := fixture.ReadProfile()
 		profile.GenReset()
-		report, err := ValidateWithConfiguration(prof, fixture.ReadFixturePositiveData(), config.Debug, nil, TestValidationConfiguration{})
+		report, err := ValidateWithConfiguration(prof, fixture.ReadFixturePositiveData(), config.Debug, nil, TestValidationConfiguration{}, DefaultReportConfiguration())
 
 		if err != nil {
 			t.Errorf("%s > Positive case > Failed with error %v", fixture, err)
@@ -35,7 +35,7 @@ func TestIntegrationNegativeData(t *testing.T) {
 	for _, fixture := range test.IntegrationFixtures("../../test/data/integration", &filter) {
 		prof := fixture.ReadProfile()
 		profile.GenReset()
-		report, err := ValidateWithConfiguration(prof, fixture.ReadFixtureNegativeData(), config.Debug, nil, TestValidationConfiguration{})
+		report, err := ValidateWithConfiguration(prof, fixture.ReadFixtureNegativeData(), config.Debug, nil, TestValidationConfiguration{}, DefaultReportConfiguration())
 		if err != nil {
 			t.Errorf("%s > Negative case > Failed with error %v", fixture, err)
 		}
@@ -59,7 +59,7 @@ func TestIntegrationNegativeDataWithLexical(t *testing.T) {
 
 		lexicalFixture, fixtureError := fixture.ReadFixtureNegativeDataWithLexical()
 		if fixtureError == nil {
-			report, err := ValidateWithConfiguration(prof, lexicalFixture, config.Debug, nil, TestValidationConfiguration{})
+			report, err := ValidateWithConfiguration(prof, lexicalFixture, config.Debug, nil, TestValidationConfiguration{}, DefaultReportConfiguration())
 			if err != nil {
 				t.Errorf("%s > Negative case with lexical > Failed with error %v", fixture, err)
 			}

--- a/internal/validator/validate_integration_test.go
+++ b/internal/validator/validate_integration_test.go
@@ -3,6 +3,7 @@ package validator
 import (
 	"github.com/aml-org/amf-custom-validator/internal/config"
 	"github.com/aml-org/amf-custom-validator/internal/parser/profile"
+	config2 "github.com/aml-org/amf-custom-validator/internal/validator/config"
 	"github.com/aml-org/amf-custom-validator/test"
 	"strings"
 	"testing"
@@ -13,7 +14,7 @@ func TestIntegrationPositiveData(t *testing.T) {
 	for _, fixture := range test.IntegrationFixtures("../../test/data/integration", &filter) {
 		prof := fixture.ReadProfile()
 		profile.GenReset()
-		report, err := ValidateWithConfiguration(prof, fixture.ReadFixturePositiveData(), config.Debug, nil, TestValidationConfiguration{}, DefaultReportConfiguration())
+		report, err := ValidateWithConfiguration(prof, fixture.ReadFixturePositiveData(), config.Debug, nil, config2.TestValidationConfiguration{}, config2.DefaultReportConfiguration())
 
 		if err != nil {
 			t.Errorf("%s > Positive case > Failed with error %v", fixture, err)
@@ -35,7 +36,7 @@ func TestIntegrationNegativeData(t *testing.T) {
 	for _, fixture := range test.IntegrationFixtures("../../test/data/integration", &filter) {
 		prof := fixture.ReadProfile()
 		profile.GenReset()
-		report, err := ValidateWithConfiguration(prof, fixture.ReadFixtureNegativeData(), config.Debug, nil, TestValidationConfiguration{}, DefaultReportConfiguration())
+		report, err := ValidateWithConfiguration(prof, fixture.ReadFixtureNegativeData(), config.Debug, nil, config2.TestValidationConfiguration{}, config2.DefaultReportConfiguration())
 		if err != nil {
 			t.Errorf("%s > Negative case > Failed with error %v", fixture, err)
 		}
@@ -59,7 +60,7 @@ func TestIntegrationNegativeDataWithLexical(t *testing.T) {
 
 		lexicalFixture, fixtureError := fixture.ReadFixtureNegativeDataWithLexical()
 		if fixtureError == nil {
-			report, err := ValidateWithConfiguration(prof, lexicalFixture, config.Debug, nil, TestValidationConfiguration{}, DefaultReportConfiguration())
+			report, err := ValidateWithConfiguration(prof, lexicalFixture, config.Debug, nil, config2.TestValidationConfiguration{}, config2.DefaultReportConfiguration())
 			if err != nil {
 				t.Errorf("%s > Negative case with lexical > Failed with error %v", fixture, err)
 			}

--- a/internal/validator/validate_integration_test.go
+++ b/internal/validator/validate_integration_test.go
@@ -13,7 +13,7 @@ func TestIntegrationPositiveData(t *testing.T) {
 	for _, fixture := range test.IntegrationFixtures("../../test/data/integration", &filter) {
 		prof := fixture.ReadProfile()
 		profile.GenReset()
-		report, err := ValidateWithConfiguration(prof, fixture.ReadFixturePositiveData(), config.Debug, nil, TestConfiguration{})
+		report, err := ValidateWithConfiguration(prof, fixture.ReadFixturePositiveData(), config.Debug, nil, TestValidationConfiguration{})
 
 		if err != nil {
 			t.Errorf("%s > Positive case > Failed with error %v", fixture, err)
@@ -35,7 +35,7 @@ func TestIntegrationNegativeData(t *testing.T) {
 	for _, fixture := range test.IntegrationFixtures("../../test/data/integration", &filter) {
 		prof := fixture.ReadProfile()
 		profile.GenReset()
-		report, err := ValidateWithConfiguration(prof, fixture.ReadFixtureNegativeData(), config.Debug, nil, TestConfiguration{})
+		report, err := ValidateWithConfiguration(prof, fixture.ReadFixtureNegativeData(), config.Debug, nil, TestValidationConfiguration{})
 		if err != nil {
 			t.Errorf("%s > Negative case > Failed with error %v", fixture, err)
 		}
@@ -59,7 +59,7 @@ func TestIntegrationNegativeDataWithLexical(t *testing.T) {
 
 		lexicalFixture, fixtureError := fixture.ReadFixtureNegativeDataWithLexical()
 		if fixtureError == nil {
-			report, err := ValidateWithConfiguration(prof, lexicalFixture, config.Debug, nil, TestConfiguration{})
+			report, err := ValidateWithConfiguration(prof, lexicalFixture, config.Debug, nil, TestValidationConfiguration{})
 			if err != nil {
 				t.Errorf("%s > Negative case with lexical > Failed with error %v", fixture, err)
 			}

--- a/internal/validator/validate_production_test.go
+++ b/internal/validator/validate_production_test.go
@@ -18,7 +18,7 @@ func TestProduction(t *testing.T) {
 		for _, example := range fixture.Examples() {
 			filter := "" // put the number of the text to filter here
 			if strings.Index(example.File, filter) > -1 {
-				report, err := ValidateWithConfiguration(profile, example.Text, config.Debug, nil, TestConfiguration{})
+				report, err := ValidateWithConfiguration(profile, example.Text, config.Debug, nil, TestValidationConfiguration{})
 				if config.Debug {
 					generateDebugOutput(profile, example)
 				}

--- a/internal/validator/validate_production_test.go
+++ b/internal/validator/validate_production_test.go
@@ -18,7 +18,7 @@ func TestProduction(t *testing.T) {
 		for _, example := range fixture.Examples() {
 			filter := "" // put the number of the text to filter here
 			if strings.Index(example.File, filter) > -1 {
-				report, err := ValidateWithConfiguration(profile, example.Text, config.Debug, nil, TestValidationConfiguration{})
+				report, err := ValidateWithConfiguration(profile, example.Text, config.Debug, nil, TestValidationConfiguration{}, DefaultReportConfiguration())
 				if config.Debug {
 					generateDebugOutput(profile, example)
 				}

--- a/internal/validator/validate_production_test.go
+++ b/internal/validator/validate_production_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/aml-org/amf-custom-validator/internal/config"
 	"github.com/aml-org/amf-custom-validator/internal/parser"
+	config2 "github.com/aml-org/amf-custom-validator/internal/validator/config"
 	"github.com/aml-org/amf-custom-validator/test"
 	"strings"
 	"testing"
@@ -18,7 +19,7 @@ func TestProduction(t *testing.T) {
 		for _, example := range fixture.Examples() {
 			filter := "" // put the number of the text to filter here
 			if strings.Index(example.File, filter) > -1 {
-				report, err := ValidateWithConfiguration(profile, example.Text, config.Debug, nil, TestValidationConfiguration{}, DefaultReportConfiguration())
+				report, err := ValidateWithConfiguration(profile, example.Text, config.Debug, nil, config2.TestValidationConfiguration{}, config2.DefaultReportConfiguration())
 				if config.Debug {
 					generateDebugOutput(profile, example)
 				}

--- a/internal/validator/validation_configuration.go
+++ b/internal/validator/validation_configuration.go
@@ -3,17 +3,17 @@ package validator
 import "time"
 
 type ValidationConfiguration interface {
-	CurrentTime() time.Time
+	ReportCreationTime() time.Time
 }
 
-type DefaultConfiguration struct{}
+type DefaultValidationConfiguration struct{}
 
-func (d DefaultConfiguration) CurrentTime() time.Time {
+func (d DefaultValidationConfiguration) ReportCreationTime() time.Time {
 	return time.Now()
 }
 
-type TestConfiguration struct{}
+type TestValidationConfiguration struct{}
 
-func (d TestConfiguration) CurrentTime() time.Time {
+func (d TestValidationConfiguration) ReportCreationTime() time.Time {
 	return time.Date(2000, time.November, 28, 0, 0, 0, 0, time.UTC)
 }

--- a/js/validator.go
+++ b/js/validator.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"github.com/aml-org/amf-custom-validator/internal/validator"
+	"github.com/aml-org/amf-custom-validator/internal/validator/config"
 	"syscall/js"
 )
 
@@ -38,7 +39,7 @@ func validateWithConfigurationWrapper() js.Func {
 			return "ValidationConfiguration not yet supported, please set this parameter as 'undefined'. ValidationConfiguration needs to import functions from JS which is not supported by Go 1.19"
 		}
 		reportConfig := buildReportConfiguration(args[4])
-		res, err := validator.ValidateWithConfiguration(profileString, dataString, debug, nil, validator.DefaultValidationConfiguration{}, reportConfig)
+		res, err := validator.ValidateWithConfiguration(profileString, dataString, debug, nil, config.DefaultValidationConfiguration{}, reportConfig)
 		if err != nil {
 			return err.Error()
 		}
@@ -47,9 +48,9 @@ func validateWithConfigurationWrapper() js.Func {
 	return jsonFunc
 }
 
-func buildReportConfiguration(value js.Value) validator.ReportConfiguration {
+func buildReportConfiguration(value js.Value) config.ReportConfiguration {
 	includeReportCreationTime := value.Get("IncludeReportCreationTime").Bool()
-	return validator.ReportConfiguration{
+	return config.ReportConfiguration{
 		IncludeReportCreationTime: includeReportCreationTime,
 	}
 }

--- a/js/validator.go
+++ b/js/validator.go
@@ -50,8 +50,12 @@ func validateWithConfigurationWrapper() js.Func {
 
 func buildReportConfiguration(value js.Value) config.ReportConfiguration {
 	includeReportCreationTime := value.Get("IncludeReportCreationTime").Bool()
+	reportSchemaIri := value.Get("ReportSchemaIri").String()
+	lexicalSchemaIri := value.Get("LexicalSchemaIri").String()
 	return config.ReportConfiguration{
 		IncludeReportCreationTime: includeReportCreationTime,
+		ReportSchemaIri:           reportSchemaIri,
+		LexicalSchemaIri:          lexicalSchemaIri,
 	}
 }
 

--- a/wrappers/js-web/cypress/e2e/withConfiguration.cy.js
+++ b/wrappers/js-web/cypress/e2e/withConfiguration.cy.js
@@ -1,0 +1,8 @@
+/// <reference types="cypress" />
+
+describe('withConfiguration', () => {
+  it('should render report', () => {
+    cy.visit('cypress/html/withConfiguration.html')
+    cy.get('#report').should('have.text', 'does not have date')
+  })
+})

--- a/wrappers/js-web/cypress/e2e/withConfiguration.cy.js
+++ b/wrappers/js-web/cypress/e2e/withConfiguration.cy.js
@@ -3,6 +3,12 @@
 describe('withConfiguration', () => {
   it('should render report', () => {
     cy.visit('cypress/html/withConfiguration.html')
-    cy.get('#report').should('have.text', 'does not have date')
+
+    let dateText = "does not have date"
+    let reportSchema = "http://a.ml/report#/declarations/"
+    let lexicalSchema = "http://a.ml/lexical#/declarations/"
+    let expectedText = `${dateText}, ${reportSchema}, ${lexicalSchema}`
+
+    cy.get('#report').should('have.text', expectedText)
   })
 })

--- a/wrappers/js-web/cypress/html/withConfiguration.html
+++ b/wrappers/js-web/cypress/html/withConfiguration.html
@@ -1,0 +1,12 @@
+<html lang="eng">
+<head>
+    <title>Tests</title>
+</head>
+<body>
+    <pre id="report"></pre>
+    <script src="../../test/out/withConfiguration.js"></script>
+    <script>
+        test.run()
+    </script>
+</body>
+</html>

--- a/wrappers/js-web/index.js
+++ b/wrappers/js-web/index.js
@@ -7,7 +7,7 @@ let initialized = false
 let go = undefined;
 let wasm;
 
-const run = function(profile, data, debug) {
+const validateKernel = function(profile, data, debug) {
     let before = new Date()
     const res = __AMF__validateCustomProfile(profile,data, debug);
     let after = new Date();
@@ -15,12 +15,29 @@ const run = function(profile, data, debug) {
     return res;
 }
 
+const validateWithReportConfigurationKernel = function(profile, data, debug, reportConfig) {
+    let before = new Date()
+    const res = __AMF__validateCustomProfileWithConfiguration(profile,data, debug, undefined, reportConfig);
+    let after = new Date();
+    if (debug) console.log("Elapsed : " + (after - before))
+    return res;
+}
+
 const validateCustomProfile = function(profile, data, debug, cb) {
     if (initialized) {
-        let res = run(profile, data, debug);
+        let res = validateKernel(profile, data, debug);
         cb(res, undefined);
     } else {
         cb(undefined, new Error("WASM/GO not initialized"))
+    }
+}
+
+const validateCustomProfileWithReportConfiguration = function(profile, data, debug, reportConfig, cb) {
+    if (initialized) {
+        let res = validateWithReportConfigurationKernel(profile, data, debug, reportConfig);
+        cb(res,undefined);
+    } else {
+        cb(undefined,new Error("WASM/GO not initialized"))
     }
 }
 
@@ -54,4 +71,5 @@ const exit = function() {
 
 module.exports.initialize = initialize;
 module.exports.validate = validateCustomProfile;
+module.exports.validateWithReportConfiguration = validateCustomProfileWithReportConfiguration;
 module.exports.exit = exit;

--- a/wrappers/js-web/test/src/withConfiguration.js
+++ b/wrappers/js-web/test/src/withConfiguration.js
@@ -1,0 +1,31 @@
+// Imports
+const profile = require("../../../../test/data/integration/profile10/profile.yaml")
+const data = require("../../../../test/data/integration/profile10/negative.data.jsonld")
+const validator = require("../../dist/main")
+
+// Test
+function run() {
+    validator.initialize(() => {
+        const reportConfig = {
+            "IncludeReportCreationTime": false
+        }
+        validator.validateWithReportConfiguration(profile, data.toString(), false, reportConfig, (r, err) => {
+            if (err) {
+                console.log(err);
+            } else {
+                let element = document.getElementById('report');
+                let report = JSON.parse(r)
+                let dateCreated = element.textContent = report[0]['doc:encodes'][0]['dateCreated']
+                if (dateCreated) {
+                    element.textContent = 'has date'
+                } else {
+                    element.textContent = 'does not have date'
+                }
+                element.report = report
+            }
+        });
+    })
+}
+
+module.exports.run = run;
+

--- a/wrappers/js-web/test/src/withConfiguration.js
+++ b/wrappers/js-web/test/src/withConfiguration.js
@@ -7,7 +7,9 @@ const validator = require("../../dist/main")
 function run() {
     validator.initialize(() => {
         const reportConfig = {
-            "IncludeReportCreationTime": false
+            "IncludeReportCreationTime": false,
+            "ReportSchemaIri": "http://a.ml/report",
+            "LexicalSchemaIri": "http://a.ml/lexical"
         }
         validator.validateWithReportConfiguration(profile, data.toString(), false, reportConfig, (r, err) => {
             if (err) {
@@ -16,11 +18,17 @@ function run() {
                 let element = document.getElementById('report');
                 let report = JSON.parse(r)
                 let dateCreated = element.textContent = report[0]['doc:encodes'][0]['dateCreated']
+                let reportSchema = report[0]["@context"]["reportSchema"]
+                let lexicalSchema = report[0]["@context"]["lexicalSchema"]
+
+                let dateText
                 if (dateCreated) {
-                    element.textContent = 'has date'
+                    dateText = 'has date'
                 } else {
-                    element.textContent = 'does not have date'
+                    dateText = 'does not have date'
                 }
+
+                element.textContent = `${dateText}, ${reportSchema}, ${lexicalSchema}`
                 element.report = report
             }
         });

--- a/wrappers/js-web/test/webpack.config.js
+++ b/wrappers/js-web/test/webpack.config.js
@@ -33,6 +33,7 @@ config.module.rules.push(
 config.entry = {
     simple: path.join(__dirname, 'src/simple.js'),
     double: path.join(__dirname, 'src/double.js'),
+    withConfiguration: path.join(__dirname, 'src/withConfiguration.js'),
     messageExpression: path.join(__dirname, 'src/messageExpression.js')
 }
 

--- a/wrappers/js/index.js
+++ b/wrappers/js/index.js
@@ -7,7 +7,7 @@ let wasm
 let initialized = false
 let go = undefined;
 
-const run = function(profile, data, debug) {
+const validateKernel = function(profile, data, debug) {
     let before = new Date()
     const res = __AMF__validateCustomProfile(profile,data, debug);
     let after = new Date();
@@ -15,9 +15,26 @@ const run = function(profile, data, debug) {
     return res;
 }
 
+const validateWithReportConfigurationKernel = function(profile, data, debug, reportConfig) {
+    let before = new Date()
+    const res = __AMF__validateCustomProfileWithConfiguration(profile,data, debug, undefined, reportConfig);
+    let after = new Date();
+    if (debug) console.log("Elapsed : " + (after - before))
+    return res;
+}
+
 const validateCustomProfile = function(profile, data, debug, cb) {
     if (initialized) {
-        let res = run(profile, data, debug);
+        let res = validateKernel(profile, data, debug);
+        cb(res,undefined);
+    } else {
+        cb(undefined,new Error("WASM/GO not initialized"))
+    }
+}
+
+const validateCustomProfileWithReportConfiguration = function(profile, data, debug, reportConfig, cb) {
+    if (initialized) {
+        let res = validateWithReportConfigurationKernel(profile, data, debug, reportConfig);
         cb(res,undefined);
     } else {
         cb(undefined,new Error("WASM/GO not initialized"))
@@ -82,6 +99,7 @@ const exit = function() {
 
 module.exports.initialize = initialize;
 module.exports.validate = validateCustomProfile;
+module.exports.validateWithReportConfiguration = validateCustomProfileWithReportConfiguration;
 module.exports.generateRego = generateRego;
 module.exports.normalizeInput = normalizeInput;
 module.exports.exit = exit;

--- a/wrappers/js/test/simple.js
+++ b/wrappers/js/test/simple.js
@@ -93,4 +93,28 @@ describe('validator', () => {
             })
         });
     })
+
+    describe('validate with configuration', () => {
+
+        it("must match expected report output", (done) => {
+            const profile = fs.readFileSync(__dirname + "/../../../test/data/integration/profile26/profile.yaml").toString()
+            const data = fs.readFileSync(__dirname + "/../../../test/data/integration/profile26/negative.data.jsonld").toString()
+            const validator = require(__dirname + "/../index")
+            validator.initialize(() => {
+                const reportConfig = {
+                    "IncludeReportCreationTime": false
+                }
+                validator.validateWithReportConfiguration(profile, data, false, reportConfig, (r, err) => {
+                    if (err) {
+                        done(err);
+                    } else {
+                        let report = JSON.parse(r)
+                        assert.ok(report[0]["doc:encodes"][0]["dateCreated"] === undefined)
+                        validator.exit();
+                        done();
+                    }
+                });
+            })
+        });
+    })
 })

--- a/wrappers/js/test/simple.js
+++ b/wrappers/js/test/simple.js
@@ -102,7 +102,9 @@ describe('validator', () => {
             const validator = require(__dirname + "/../index")
             validator.initialize(() => {
                 const reportConfig = {
-                    "IncludeReportCreationTime": false
+                    "IncludeReportCreationTime": false,
+                    "ReportSchemaIri": "http://a.ml/report",
+                    "LexicalSchemaIri": "http://a.ml/lexical"
                 }
                 validator.validateWithReportConfiguration(profile, data, false, reportConfig, (r, err) => {
                     if (err) {
@@ -110,6 +112,8 @@ describe('validator', () => {
                     } else {
                         let report = JSON.parse(r)
                         assert.ok(report[0]["doc:encodes"][0]["dateCreated"] === undefined)
+                        assert.strictEqual(report[0]["@context"]["reportSchema"], "http://a.ml/report#/declarations/")
+                        assert.strictEqual(report[0]["@context"]["lexicalSchema"], "http://a.ml/lexical#/declarations/")
                         validator.exit();
                         done();
                     }


### PR DESCRIPTION
- Refactor: small naming & parameters changes ValidationConfiguration related
- W-14608348: added report configuration & make 'dateCreated' configurable
- W-14608348: added validateWithConfig to JS interface
- Refactor: move configurations to new 'config' package
- W-14688992: make schema and lexical IRIs configurable
