### PR TITLE
W-17395811: replace governance URNs with URLs

### DIFF
--- a/internal/validator/base_uri_test.go
+++ b/internal/validator/base_uri_test.go
@@ -1,0 +1,47 @@
+package validator
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNormalizeBaseUri(t *testing.T) {
+	testDataPath := filepath.Join("..", "..", "test", "data", "test-base-uri.jsonld")
+	fileData, err := os.ReadFile(testDataPath)
+	if err != nil {
+		t.Fatalf("Failed to read test data file: %v", err)
+	}
+
+	originalBaseUri := "urn:ms:d2270dec-7e27-4494-806c-23228cf84dce:asset::d2270dec-7e27-4494-806c-23228cf84dce/required-examples-w-17395811/1.0.0"
+
+	// Check if original JSON contains the base URI
+	if !strings.Contains(string(fileData), originalBaseUri) {
+		t.Errorf("Original JSON should contain base URI: %s", originalBaseUri)
+	}
+
+	// Parse the JSON-LD string into a JSON object
+	var jsonData any
+	err = json.Unmarshal(fileData, &jsonData)
+	if err != nil {
+		t.Fatalf("Failed to parse JSON-LD: %v", err)
+	}
+
+	// Now pass the parsed JSON object to Normalize
+	normalizedJson := Normalize(jsonData)
+
+	// Convert normalized JSON to pretty-printed string
+	normalizedBytes, err := json.MarshalIndent(normalizedJson, "", "  ")
+	if err != nil {
+		t.Fatalf("Failed to marshal normalized JSON: %v", err)
+	}
+
+	normalizedStr := string(normalizedBytes)
+
+	// Check if normalized JSON does not contain the base URI
+	if strings.Contains(normalizedStr, originalBaseUri) {
+		t.Errorf("Normalized JSON should not contain base URI: %s", originalBaseUri)
+	}
+}

--- a/test/data/test-base-uri.jsonld
+++ b/test/data/test-base-uri.jsonld
@@ -1,0 +1,40 @@
+{
+  "@graph": [
+    {
+      "@id": "#/declares/scheme/clientIdEnforcement/source-map/declared-element/element_0",
+      "sourcemaps:element": "urn:ms:d2270dec-7e27-4494-806c-23228cf84dce:asset::d2270dec-7e27-4494-806c-23228cf84dce/required-examples-w-17395811/1.0.0#/declares/scheme/clientIdEnforcement",
+      "sourcemaps:value": ""
+    },
+    {
+      "@id": "#/declares/scheme/clientIdEnforcement/header/parameter/header/client_id/scalar/schema/examples/example/default-example/source-map/tracked-element/element_0",
+      "sourcemaps:element": "urn:ms:d2270dec-7e27-4494-806c-23228cf84dce:asset::d2270dec-7e27-4494-806c-23228cf84dce/required-examples-w-17395811/1.0.0#/declares/scheme/clientIdEnforcement/header/parameter/header/client_id/scalar/schema/examples/example/default-example",
+      "sourcemaps:value": "urn:ms:d2270dec-7e27-4494-806c-23228cf84dce:asset::d2270dec-7e27-4494-806c-23228cf84dce/required-examples-w-17395811/1.0.0#/declares/scheme/clientIdEnforcement/header/parameter/header/client_id"
+    },
+    {
+      "@id": "#/declares/scheme/clientIdEnforcement/header/parameter/header/client_secret/scalar/schema/examples/example/default-example/source-map/tracked-element/element_0",
+      "sourcemaps:element": "urn:ms:d2270dec-7e27-4494-806c-23228cf84dce:asset::d2270dec-7e27-4494-806c-23228cf84dce/required-examples-w-17395811/1.0.0#/declares/scheme/clientIdEnforcement/header/parameter/header/client_secret/scalar/schema/examples/example/default-example",
+      "sourcemaps:value": "urn:ms:d2270dec-7e27-4494-806c-23228cf84dce:asset::d2270dec-7e27-4494-806c-23228cf84dce/required-examples-w-17395811/1.0.0#/declares/scheme/clientIdEnforcement/header/parameter/header/client_secret"
+    },
+    {
+      "@id": "#/declares/scheme/clientIdEnforcement/response/resp/401/payload/application%2Fjson/shape/schema/examples/example/default-example/source-map/tracked-element/element_0",
+      "sourcemaps:element": "urn:ms:d2270dec-7e27-4494-806c-23228cf84dce:asset::d2270dec-7e27-4494-806c-23228cf84dce/required-examples-w-17395811/1.0.0#/declares/scheme/clientIdEnforcement/response/resp/401/payload/application%2Fjson/shape/schema/examples/example/default-example",
+      "sourcemaps:value": "urn:ms:d2270dec-7e27-4494-806c-23228cf84dce:asset::d2270dec-7e27-4494-806c-23228cf84dce/required-examples-w-17395811/1.0.0#/declares/scheme/clientIdEnforcement/response/resp/401/payload/application%2Fjson"
+    },
+    {
+      "@id": "#/declares/scheme/clientIdEnforcement/response/resp/401/header/parameter/header/Content-Type/scalar/schema/examples/example/default-example/source-map/tracked-element/element_0",
+      "sourcemaps:element": "urn:ms:d2270dec-7e27-4494-806c-23228cf84dce:asset::d2270dec-7e27-4494-806c-23228cf84dce/required-examples-w-17395811/1.0.0#/declares/scheme/clientIdEnforcement/response/resp/401/header/parameter/header/Content-Type/scalar/schema/examples/example/default-example",
+      "sourcemaps:value": "urn:ms:d2270dec-7e27-4494-806c-23228cf84dce:asset::d2270dec-7e27-4494-806c-23228cf84dce/required-examples-w-17395811/1.0.0#/declares/scheme/clientIdEnforcement/response/resp/401/header/parameter/header/Content-Type"
+    }
+  ],
+  "@context": {
+    "@base": "urn:ms:d2270dec-7e27-4494-806c-23228cf84dce:asset::d2270dec-7e27-4494-806c-23228cf84dce/required-examples-w-17395811/1.0.0",
+    "raml-shapes": "http://a.ml/vocabularies/shapes#",
+    "security": "http://a.ml/vocabularies/security#",
+    "data": "http://a.ml/vocabularies/data#",
+    "doc": "http://a.ml/vocabularies/document#",
+    "apiContract": "http://a.ml/vocabularies/apiContract#",
+    "core": "http://a.ml/vocabularies/core#",
+    "sourcemaps": "http://a.ml/vocabularies/document-source-maps#",
+    "sh": "http://www.w3.org/ns/shacl#"
+  }
+}


### PR DESCRIPTION
- **chore: refactor outdated file reading methods in fixtures.go**
- **W-17395811: replace governance URNs with URLs**
